### PR TITLE
Add classical essential-matrix two-view VO frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `visloc-rs` will be documented here.
 
 ### Added
 
+- `visloc-vision::two_view` module with `TwoViewCorrespondence`, a Hartley-normalized 8-point `EightPointEssentialMatrixEstimator`, Sampson-distance-scored `EssentialRansac`, 4-fold `recover_relative_pose` cheirality decomposition, and a composing `RelativePoseEstimator` that applies a caller-supplied translation scale.
+- `EssentialMatrixVisualOdometryFrontend` and `EssentialMatrixVisualOdometryConfig` expose the classical-geometry pipeline as a `VisualOdometryFrontend`, returning a full SE3 relative pose plus inlier/Sampson diagnostics and supporting per-pair translation-scale overrides.
+- `two_view_vo_compare` example runs the classical essential-matrix frontend alongside the flow-only `TwoViewMatchVisualOdometryFrontend` on the same synthetic three-frame sequence to make the structural difference visible; with `--out-dir` it writes a per-frame text report.
+- Deep VO / loop-close milestone completion increased to 60% to reflect the classical two-view geometry pipeline and demo.
 - `track_sequence_with_two_view_match_vo_prior` example reads per-pair two-view match text files with `read_two_view_matches_txt`, populates `TwoViewMatchVisualOdometryFrontend`, and feeds the resulting VO priors through `track_frame_with_localization_prior_submap_provider` for a short three-frame sequence; with `--out-dir` it writes the generated input match files plus a per-frame text report.
 - `tests/two_view_vo.rs` now covers the file-backed two-view match VO path across consecutive frame pairs to guard the `read_two_view_matches_txt` → `TwoViewMatchVisualOdometryFrontend` → `VisualOdometryPriorProvider` chain.
 - Documentation now clarifies that `VisualOdometryEstimate::mean_reprojection_error` stores the mean inlier two-view flow residual in pixels when produced by `TwoViewMatchVisualOdometryFrontend`, and recommends labeling the field as `mean_flow_residual_px` in user-facing logs/reports for that case.

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,7 @@ Repository:
 Current milestone completion:
 
 ```text
-Deep VO / Loop Close completion: 55%
+Deep VO / Loop Close completion: 60%
 ```
 
 Report this value at the end of development updates until it changes. Increase
@@ -319,10 +319,10 @@ blocked CI.
 Current score:
 
 ```text
-Deep VO / Loop Close completion: 55%
+Deep VO / Loop Close completion: 60%
 ```
 
-Why 55%:
+Why 60%:
 
 - Tracking and local mapping scaffolds exist.
 - Online SLAM composition exists.
@@ -336,36 +336,57 @@ Why 55%:
   `VisualOdometryPriorProvider`, and `track_frame_with_localization_prior_submap_provider`,
   exercised by the `track_sequence_with_two_view_match_vo_prior` example and a
   matching integration test.
+- A classical essential-matrix two-view geometry pipeline lives in
+  `visloc-vision::two_view`: Hartley-normalized 8-point essential-matrix
+  estimator, Sampson-distance scored RANSAC, and 4-fold cheirality
+  disambiguation. `EssentialMatrixVisualOdometryFrontend` exposes it as a
+  `VisualOdometryFrontend`, returning a full SE3 relative pose with
+  caller-supplied translation scale. The `two_view_vo_compare` example runs the
+  classical and flow-only frontends on the same synthetic three-frame
+  sequence and prints relative-translation estimates against ground truth.
 
 Why not higher:
 
 - No real learned frontend is running in Rust yet.
-- No real classical two-view geometry backend is producing metric VO yet.
-- No public sequence demo shows learned correspondences driving tracking.
-- Loop closure is candidate reporting only.
+- The classical two-view geometry backend exists but is only exercised on a
+  synthetic three-frame demo so far.
+- No public sequence demo shows correspondences driving tracking with the
+  classical or learned frontend over more than a few frames.
+- Loop closure is candidate reporting only; the verifier does not yet feed the
+  classical relative-pose estimator.
 - No pose-graph constraints or global correction exist.
 
-## Next Milestone: 55% to 60%
+## Next Milestone: 60% to 70%
 
-Goal: make the Deep VO path less synthetic while still avoiding mandatory model
-runtimes.
+Goal: turn the existing classical two-view geometry from a synthetic comparison
+demo into something that visibly drives a longer sequence and feeds loop
+closure verification, while keeping mandatory deep-learning runtimes out of the
+default crates.
 
-Recommended next task:
+Completed at 60%:
 
-### 1. File-Backed Two-View VO Sequence Example (Done at 55%)
+- `visloc-vision::two_view` (8-point + RANSAC + cheirality recovery).
+- `EssentialMatrixVisualOdometryFrontend` exposing it through
+  `VisualOdometryFrontend`.
+- `two_view_vo_compare` short-sequence demo that prints classical vs flow-only
+  relative-translation estimates against ground truth.
 
-`examples/track_sequence_with_two_view_match_vo_prior.rs` now exists. It builds
-a small visual map and three synthetic frames, generates per-pair two-view
-match text files for frame pairs `100 -> 101` and `101 -> 102`, reads them back
-with `read_two_view_matches_txt`, populates a
-`TwoViewMatchVisualOdometryFrontend`, and feeds each VO prior through
-`track_frame_with_localization_prior_submap_provider`. The example prints
-per-frame diagnostics (frame id, whether a VO prior was used, match count,
-inlier count, mean flow residual, candidate landmark count, localization
-success, used external prior, and estimated camera center) and writes a text
-report plus the generated input match files when `--out-dir` is supplied.
-`tests/two_view_vo.rs` covers the file-backed read → frontend → prior chain
-across consecutive frame pairs.
+Recommended next tasks (any single one is enough to push toward 70%):
+
+1. Public sequence demo: replace the synthetic three frames in
+   `two_view_vo_compare` with a small public image sequence (e.g., a KITTI
+   subset or a tiny self-contained fixture) so the classical frontend's
+   correspondence quality, pose continuity, and Sampson diagnostics are visible
+   over more than three frames.
+2. Stronger loop-closure candidate verification: feed the candidate pairs from
+   `LoopClosureCandidate` into `EssentialMatrixVisualOdometryFrontend` (or a
+   direct `RelativePoseEstimator` call) plus existing PnP RANSAC to score
+   candidates with inlier count, inlier ratio, and reprojection error before
+   accepting them.
+3. Pose-graph constraint type (no global optimization yet): introduce a
+   `LoopClosureConstraint { from_keyframe_id, to_keyframe_id, relative_pose,
+   inlier_count, score }` type plus a small builder that turns a verified
+   candidate into a constraint, leaving the actual graph solver out.
 
 ### 2. Make the VO Adapter Diagnostics More Explicit
 
@@ -583,7 +604,7 @@ If handing off to another agent, use this:
 You are continuing the Rust project visloc-rs.
 Read PLAN.md, docs/progress.md, docs/roadmap.md, docs/interfaces.md, and src/two_view_vo.rs first.
 Current Deep VO / Loop Close completion is 55%.
-The file-backed two-view VO sequence example already exists as track_sequence_with_two_view_match_vo_prior with covering tests in tests/two_view_vo.rs. Implement the next milestone: a real classical two-view geometry path (essential or fundamental matrix RANSAC, relative-pose recovery, optional scale from priors) under crates/vision/src/two_view/, expose it through VisualOdometryFrontend, drive a short sequence demo that compares it with the existing flow-only adapter, add tests, update README/docs/CHANGELOG, run scripts/check.sh, commit, push, and watch CI.
+The classical two-view geometry pipeline already exists in visloc-vision::two_view (8-point, Sampson RANSAC, cheirality recovery), and EssentialMatrixVisualOdometryFrontend exposes it through VisualOdometryFrontend. The two_view_vo_compare example contrasts it with the flow-only frontend on a synthetic three-frame sequence. Pick one of the recommended 60%-to-70% tasks: a public-data sequence demo, geometric verification of LoopClosureCandidate via the classical frontend, or introducing a LoopClosureConstraint type without a full pose-graph solver. Add tests, update README/docs/CHANGELOG, run scripts/check.sh, commit, push, and watch CI.
 Do not add mandatory deep-learning runtime dependencies and do not claim full SLAM or full loop closure.
 End every status/final message with: Deep VO / Loop Close completion: <percent>.
 ```
@@ -597,5 +618,5 @@ End every status/final message with: Deep VO / Loop Close completion: <percent>.
 - Start with the classical two-view geometry path (essential/fundamental matrix
   RANSAC and relative-pose recovery) once the file-backed two-view VO sequence
   milestone is in.
-- Keep completion at 55% until the next runnable example/test/docs milestone is
+- Keep completion at 60% until the next runnable example/test/docs milestone is
   complete.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/rust-1.82%2B-f46623" alt="Rust 1.82+">
   <img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue" alt="License: MIT OR Apache-2.0">
   <img src="https://img.shields.io/badge/scope-visual%20localization-35d0ba" alt="Scope: visual localization">
-  <img src="https://img.shields.io/badge/deep%20VO%20%2F%20loop%20close-55%25-f59e0b" alt="Deep VO / loop close completion: 55%">
+  <img src="https://img.shields.io/badge/deep%20VO%20%2F%20loop%20close-60%25-f59e0b" alt="Deep VO / loop close completion: 60%">
 </p>
 
 `visloc-rs` is a Rust foundation library for map-based visual localization: load an existing COLMAP/SfM visual map, match query image features to 3D landmarks, and estimate the camera pose with PnP + RANSAC.
@@ -313,6 +313,8 @@ cargo run --example visual_odometry_prior_dummy
 cargo run --example track_sequence_with_visual_odometry_prior
 cargo run --example track_sequence_with_two_view_match_vo_prior
 cargo run --example track_sequence_with_two_view_match_vo_prior -- --out-dir target/visloc_two_view_match_vo_demo
+cargo run --example two_view_vo_compare
+cargo run --example two_view_vo_compare -- --out-dir target/visloc_two_view_vo_compare_demo
 ```
 
 With `--out-dir`, sequence/tracking examples write `tracking.csv`, `tracking_summary.json`, `tracking_report.html` for frame-by-frame state transitions, and `trajectory_report.html` for the estimated pose path. The GNSS-prior demo also writes `tracking_evaluation.json` so success-rate, lost-count, prior-usage, and inlier-quality thresholds can be checked by CI.
@@ -322,6 +324,7 @@ The visual-odometry-prior tracking example uses a two-frame VO prior to narrow m
 The two-view match reader example shows the simple text bridge for external learned matchers without making a model runtime a core dependency.
 The two-view match VO prior example turns externally supplied correspondences into a lightweight translation-only VO prior that can be fed through `VisualOdometryPriorProvider`.
 The file-backed two-view match VO sequence example writes per-pair match text files, reads them back with `read_two_view_matches_txt`, builds a `TwoViewMatchVisualOdometryFrontend`, and feeds the resulting pose priors through `track_frame_with_localization_prior_submap_provider` for a short three-frame sequence. With `--out-dir`, it also writes the per-frame text report and stores the generated input match files alongside it.
+The two-view VO comparison example runs both the flow-only `TwoViewMatchVisualOdometryFrontend` and the classical-geometry `EssentialMatrixVisualOdometryFrontend` on the same synthetic three-frame sequence and prints per-frame relative-translation estimates next to the ground-truth values, so the structural difference between a flow heuristic and an essential-matrix RANSAC + cheirality recovery is visible.
 
 Run a moving-camera GNSS-prior tracking example that narrows the visual map before localization and writes an `index.html` dashboard, `manifest.json`, `tracking.csv`, `trajectory.csv`, KITTI/TUM pose exports, synthetic-reference error reports, JSON summaries, and browser-viewable reports:
 

--- a/crates/vision/src/lib.rs
+++ b/crates/vision/src/lib.rs
@@ -10,3 +10,4 @@ pub mod features;
 pub mod matching;
 pub mod pnp;
 pub mod ransac;
+pub mod two_view;

--- a/crates/vision/src/two_view/mod.rs
+++ b/crates/vision/src/two_view/mod.rs
@@ -1,0 +1,680 @@
+//! Classical two-view geometry building blocks.
+//!
+//! The module exposes a small, testable pipeline:
+//! 1. Normalize pixel correspondences with camera intrinsics.
+//! 2. Estimate the essential matrix with the 8-point algorithm in a
+//!    Sampson-distance scored RANSAC loop (`EssentialRansac`).
+//! 3. Decompose the essential matrix into the four (R, t) candidates and pick
+//!    the one with the most correspondences in front of both cameras
+//!    (`recover_relative_pose`).
+//! 4. Compose the above as a `RelativePoseEstimator`, optionally applying a
+//!    caller-supplied translation scale.
+//!
+//! These components are intentionally independent of `Frame`, `FrameId`, or
+//! the tracking pipeline so they can be used as the geometric core of any
+//! `VisualOdometryFrontend` implementation. The
+//! `EssentialMatrixVisualOdometryFrontend` in the top-level `visloc-rs` crate
+//! wires this module into the existing tracking layer.
+
+use nalgebra::{DMatrix, Matrix3, Matrix3x4, Point2, UnitQuaternion, Vector3};
+use rand::rngs::SmallRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+use visloc_core::geometry::SE3;
+use visloc_core::types::Camera;
+
+/// One pixel-space correspondence between a previous and a current frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TwoViewCorrespondence {
+    pub previous_xy: Point2<f64>,
+    pub current_xy: Point2<f64>,
+}
+
+impl TwoViewCorrespondence {
+    pub fn new(previous_xy: Point2<f64>, current_xy: Point2<f64>) -> Self {
+        Self {
+            previous_xy,
+            current_xy,
+        }
+    }
+}
+
+/// Output of the essential-matrix RANSAC loop.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EssentialRansacReport {
+    pub essential: Matrix3<f64>,
+    pub inliers: Vec<usize>,
+    pub mean_sampson_error: f64,
+}
+
+/// Output of relative-pose recovery: rotation, unit translation direction,
+/// applied scale, the implied `SE3` previous-to-current transform, inlier
+/// indices, and Sampson diagnostics.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelativePose {
+    pub previous_to_current: SE3,
+    pub translation_unit: Vector3<f64>,
+    pub translation_scale: f64,
+    pub inliers: Vec<usize>,
+    pub mean_sampson_error: f64,
+}
+
+/// Estimator for an essential matrix from pixel correspondences plus
+/// intrinsics. Implementors return `None` when the input is degenerate.
+pub trait EssentialMatrixEstimator {
+    fn estimate(
+        &self,
+        correspondences: &[TwoViewCorrespondence],
+        camera: &Camera,
+    ) -> Option<Matrix3<f64>>;
+    fn minimum_correspondences(&self) -> usize;
+}
+
+/// Hartley-normalized 8-point essential-matrix estimator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EightPointEssentialMatrixEstimator {
+    pub min_correspondences: usize,
+}
+
+impl Default for EightPointEssentialMatrixEstimator {
+    fn default() -> Self {
+        Self {
+            min_correspondences: 8,
+        }
+    }
+}
+
+impl EssentialMatrixEstimator for EightPointEssentialMatrixEstimator {
+    fn minimum_correspondences(&self) -> usize {
+        self.min_correspondences
+    }
+
+    fn estimate(
+        &self,
+        correspondences: &[TwoViewCorrespondence],
+        camera: &Camera,
+    ) -> Option<Matrix3<f64>> {
+        if correspondences.len() < self.min_correspondences {
+            return None;
+        }
+
+        let normalized = normalize_pairs(correspondences, camera)?;
+        let (previous_normalization, previous_points) =
+            hartley_normalization(normalized.iter().map(|(p, _)| *p))?;
+        let (current_normalization, current_points) =
+            hartley_normalization(normalized.iter().map(|(_, c)| *c))?;
+
+        let mut a = DMatrix::<f64>::zeros(normalized.len(), 9);
+        for row in 0..normalized.len() {
+            let (x, y) = (previous_points[row].x, previous_points[row].y);
+            let (xp, yp) = (current_points[row].x, current_points[row].y);
+            a[(row, 0)] = xp * x;
+            a[(row, 1)] = xp * y;
+            a[(row, 2)] = xp;
+            a[(row, 3)] = yp * x;
+            a[(row, 4)] = yp * y;
+            a[(row, 5)] = yp;
+            a[(row, 6)] = x;
+            a[(row, 7)] = y;
+            a[(row, 8)] = 1.0;
+        }
+
+        // The 8-point linear system A * f = 0 has 9 unknowns. When there are
+        // fewer than 9 rows the thin SVD that nalgebra computes for non-square
+        // inputs drops the last right singular vector — the very direction we
+        // want. Multiply by A^T A so the SVD always operates on a 9x9 matrix.
+        let ata = a.transpose() * a;
+        let svd = ata.svd(true, true);
+        let v_t = svd.v_t?;
+        let last = v_t.row(v_t.nrows() - 1);
+        let mut essential_normalized = Matrix3::new(
+            last[0], last[1], last[2], last[3], last[4], last[5], last[6], last[7], last[8],
+        );
+
+        // Project E_normalized onto the essential manifold.
+        let essential_norm_svd = essential_normalized.svd(true, true);
+        let u_n = essential_norm_svd.u?;
+        let v_t_n = essential_norm_svd.v_t?;
+        let s_n =
+            (essential_norm_svd.singular_values[0] + essential_norm_svd.singular_values[1]) * 0.5;
+        let constrained_n = Matrix3::from_diagonal(&Vector3::new(s_n, s_n, 0.0));
+        essential_normalized = u_n * constrained_n * v_t_n;
+
+        let essential_calibrated: Matrix3<f64> =
+            current_normalization.transpose() * essential_normalized * previous_normalization;
+        Some(essential_calibrated)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EssentialRansacConfig {
+    pub iterations: usize,
+    /// Sampson distance threshold in normalized image-plane units. A 1-pixel
+    /// reprojection error at focal length `f` corresponds to a normalized
+    /// distance of `1.0 / f`.
+    pub sampson_threshold: f64,
+    pub seed: u64,
+}
+
+impl Default for EssentialRansacConfig {
+    fn default() -> Self {
+        Self {
+            iterations: 256,
+            sampson_threshold: 5.0e-3,
+            seed: 7,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EssentialRansac<E = EightPointEssentialMatrixEstimator> {
+    pub estimator: E,
+    pub config: EssentialRansacConfig,
+}
+
+impl Default for EssentialRansac {
+    fn default() -> Self {
+        Self {
+            estimator: EightPointEssentialMatrixEstimator::default(),
+            config: EssentialRansacConfig::default(),
+        }
+    }
+}
+
+impl<E> EssentialRansac<E>
+where
+    E: EssentialMatrixEstimator,
+{
+    pub fn estimate(
+        &self,
+        correspondences: &[TwoViewCorrespondence],
+        camera: &Camera,
+    ) -> Option<EssentialRansacReport> {
+        let sample_size = self.estimator.minimum_correspondences();
+        if correspondences.len() < sample_size {
+            return None;
+        }
+
+        let mut rng = SmallRng::seed_from_u64(self.config.seed);
+        let mut indices: Vec<usize> = (0..correspondences.len()).collect();
+        let mut best_inliers: Vec<usize> = Vec::new();
+        let mut best_essential: Option<Matrix3<f64>> = None;
+        let threshold_sq = self.config.sampson_threshold * self.config.sampson_threshold;
+
+        for _ in 0..self.config.iterations {
+            indices.shuffle(&mut rng);
+            let sample: Vec<TwoViewCorrespondence> = indices[..sample_size]
+                .iter()
+                .map(|&i| correspondences[i])
+                .collect();
+
+            let Some(candidate) = self.estimator.estimate(&sample, camera) else {
+                continue;
+            };
+
+            let inliers = score_inliers(&candidate, correspondences, camera, threshold_sq);
+            if inliers.len() > best_inliers.len() {
+                best_inliers = inliers;
+                best_essential = Some(candidate);
+            }
+        }
+
+        let essential = best_essential?;
+        if best_inliers.len() < sample_size {
+            return None;
+        }
+
+        let inlier_correspondences: Vec<TwoViewCorrespondence> =
+            best_inliers.iter().map(|&i| correspondences[i]).collect();
+        let refined = self
+            .estimator
+            .estimate(&inlier_correspondences, camera)
+            .unwrap_or(essential);
+        let final_inliers = score_inliers(&refined, correspondences, camera, threshold_sq);
+        let final_inliers = if final_inliers.len() >= best_inliers.len() {
+            final_inliers
+        } else {
+            best_inliers
+        };
+        let mean = mean_sampson_error(&refined, correspondences, camera, &final_inliers);
+
+        Some(EssentialRansacReport {
+            essential: refined,
+            inliers: final_inliers,
+            mean_sampson_error: mean,
+        })
+    }
+}
+
+/// Composes essential-matrix RANSAC with relative-pose recovery, applying a
+/// caller-controlled translation scale.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RelativePoseEstimator<E = EightPointEssentialMatrixEstimator> {
+    pub ransac: EssentialRansac<E>,
+    /// Default translation scale applied when no per-call scale is supplied.
+    /// Stays at 1.0 unless the caller knows the metric scale (e.g., from a
+    /// GNSS displacement, the previous frame's translation, or a configured
+    /// default).
+    pub default_translation_scale: f64,
+}
+
+impl Default for RelativePoseEstimator {
+    fn default() -> Self {
+        Self {
+            ransac: EssentialRansac::default(),
+            default_translation_scale: 1.0,
+        }
+    }
+}
+
+impl<E> RelativePoseEstimator<E>
+where
+    E: EssentialMatrixEstimator,
+{
+    pub fn estimate(
+        &self,
+        correspondences: &[TwoViewCorrespondence],
+        camera: &Camera,
+    ) -> Option<RelativePose> {
+        self.estimate_with_scale(correspondences, camera, self.default_translation_scale)
+    }
+
+    pub fn estimate_with_scale(
+        &self,
+        correspondences: &[TwoViewCorrespondence],
+        camera: &Camera,
+        translation_scale: f64,
+    ) -> Option<RelativePose> {
+        let report = self.ransac.estimate(correspondences, camera)?;
+        let (rotation, translation_unit) =
+            recover_relative_pose(&report.essential, correspondences, camera, &report.inliers)?;
+        let se3 = SE3::new(rotation, translation_unit * translation_scale);
+        Some(RelativePose {
+            previous_to_current: se3,
+            translation_unit,
+            translation_scale,
+            inliers: report.inliers,
+            mean_sampson_error: report.mean_sampson_error,
+        })
+    }
+}
+
+/// Decompose an essential matrix into the (R, t_unit) pair that puts the most
+/// inlier correspondences in front of both cameras.
+pub fn recover_relative_pose(
+    essential: &Matrix3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    camera: &Camera,
+    inliers: &[usize],
+) -> Option<(UnitQuaternion<f64>, Vector3<f64>)> {
+    let svd = essential.svd(true, true);
+    let u = svd.u?;
+    let v_t = svd.v_t?;
+
+    let w = Matrix3::new(0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+    let mut r1 = u * w * v_t;
+    let mut r2 = u * w.transpose() * v_t;
+    if r1.determinant() < 0.0 {
+        r1 = -r1;
+    }
+    if r2.determinant() < 0.0 {
+        r2 = -r2;
+    }
+    let t_unit = u.column(2).into_owned();
+
+    let candidates = [(r1, t_unit), (r1, -t_unit), (r2, t_unit), (r2, -t_unit)];
+    let mut best: Option<(Matrix3<f64>, Vector3<f64>)> = None;
+    let mut best_score: i64 = -1;
+    for (rotation, translation) in candidates {
+        let score = cheirality_score(&rotation, &translation, correspondences, camera, inliers);
+        if score > best_score {
+            best_score = score;
+            best = Some((rotation, translation));
+        }
+    }
+
+    let (rotation, translation) = best?;
+    if best_score <= 0 {
+        return None;
+    }
+    let rotation = UnitQuaternion::from_matrix(&rotation);
+    Some((rotation, translation))
+}
+
+fn cheirality_score(
+    rotation: &Matrix3<f64>,
+    translation: &Vector3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    camera: &Camera,
+    inliers: &[usize],
+) -> i64 {
+    let p_prev = Matrix3x4::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+    let mut p_curr = Matrix3x4::zeros();
+    p_curr.fixed_view_mut::<3, 3>(0, 0).copy_from(rotation);
+    p_curr.fixed_view_mut::<3, 1>(0, 3).copy_from(translation);
+
+    let mut score: i64 = 0;
+    for &index in inliers {
+        let correspondence = &correspondences[index];
+        let Some(prev) = camera.normalize_pixel(&correspondence.previous_xy) else {
+            continue;
+        };
+        let Some(curr) = camera.normalize_pixel(&correspondence.current_xy) else {
+            continue;
+        };
+
+        let mut a = DMatrix::<f64>::zeros(4, 4);
+        for column in 0..4 {
+            a[(0, column)] = prev.x * p_prev[(2, column)] - p_prev[(0, column)];
+            a[(1, column)] = prev.y * p_prev[(2, column)] - p_prev[(1, column)];
+            a[(2, column)] = curr.x * p_curr[(2, column)] - p_curr[(0, column)];
+            a[(3, column)] = curr.y * p_curr[(2, column)] - p_curr[(1, column)];
+        }
+        let svd = a.svd(true, true);
+        let Some(v_t) = svd.v_t else {
+            continue;
+        };
+        let solution = v_t.row(v_t.nrows() - 1);
+        let w = solution[3];
+        if w.abs() < 1e-12 {
+            continue;
+        }
+        let world = Vector3::new(solution[0] / w, solution[1] / w, solution[2] / w);
+        let camera_curr = rotation * world + translation;
+        if world.z > 0.0 && camera_curr.z > 0.0 {
+            score += 1;
+        }
+    }
+    score
+}
+
+/// Hartley normalization for a set of 2D points: translate so the centroid is
+/// at the origin and scale so the average distance to the origin is sqrt(2).
+/// Returns the 3x3 transform `T` (so `T * [x, y, 1]` gives the normalized
+/// point) and the normalized points themselves.
+fn hartley_normalization<I>(points: I) -> Option<(Matrix3<f64>, Vec<Point2<f64>>)>
+where
+    I: IntoIterator<Item = Point2<f64>>,
+{
+    let collected: Vec<Point2<f64>> = points.into_iter().collect();
+    if collected.is_empty() {
+        return None;
+    }
+
+    let mut mean_x = 0.0;
+    let mut mean_y = 0.0;
+    for point in &collected {
+        mean_x += point.x;
+        mean_y += point.y;
+    }
+    let count = collected.len() as f64;
+    mean_x /= count;
+    mean_y /= count;
+
+    let mut mean_distance = 0.0;
+    for point in &collected {
+        let dx = point.x - mean_x;
+        let dy = point.y - mean_y;
+        mean_distance += (dx * dx + dy * dy).sqrt();
+    }
+    mean_distance /= count;
+    if mean_distance < 1.0e-12 {
+        return None;
+    }
+    let scale = std::f64::consts::SQRT_2 / mean_distance;
+    let transform = Matrix3::new(
+        scale,
+        0.0,
+        -scale * mean_x,
+        0.0,
+        scale,
+        -scale * mean_y,
+        0.0,
+        0.0,
+        1.0,
+    );
+
+    let normalized = collected
+        .into_iter()
+        .map(|point| Point2::new(scale * (point.x - mean_x), scale * (point.y - mean_y)))
+        .collect();
+    Some((transform, normalized))
+}
+
+fn normalize_pairs(
+    correspondences: &[TwoViewCorrespondence],
+    camera: &Camera,
+) -> Option<Vec<(Point2<f64>, Point2<f64>)>> {
+    correspondences
+        .iter()
+        .map(|correspondence| {
+            Some((
+                camera.normalize_pixel(&correspondence.previous_xy)?,
+                camera.normalize_pixel(&correspondence.current_xy)?,
+            ))
+        })
+        .collect()
+}
+
+fn score_inliers(
+    essential: &Matrix3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    camera: &Camera,
+    threshold_sq: f64,
+) -> Vec<usize> {
+    let mut inliers = Vec::with_capacity(correspondences.len());
+    for (index, correspondence) in correspondences.iter().enumerate() {
+        let Some(distance_sq) = sampson_distance_squared(essential, correspondence, camera) else {
+            continue;
+        };
+        if distance_sq <= threshold_sq {
+            inliers.push(index);
+        }
+    }
+    inliers
+}
+
+fn mean_sampson_error(
+    essential: &Matrix3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    camera: &Camera,
+    inliers: &[usize],
+) -> f64 {
+    if inliers.is_empty() {
+        return f64::INFINITY;
+    }
+    let mut total = 0.0;
+    let mut count = 0.0;
+    for &index in inliers {
+        if let Some(distance_sq) =
+            sampson_distance_squared(essential, &correspondences[index], camera)
+        {
+            total += distance_sq.sqrt();
+            count += 1.0;
+        }
+    }
+    if count > 0.0 {
+        total / count
+    } else {
+        f64::INFINITY
+    }
+}
+
+fn sampson_distance_squared(
+    essential: &Matrix3<f64>,
+    correspondence: &TwoViewCorrespondence,
+    camera: &Camera,
+) -> Option<f64> {
+    let prev = camera.normalize_pixel(&correspondence.previous_xy)?;
+    let curr = camera.normalize_pixel(&correspondence.current_xy)?;
+    let prev_h = Vector3::new(prev.x, prev.y, 1.0);
+    let curr_h = Vector3::new(curr.x, curr.y, 1.0);
+    let e_prev = essential * prev_h;
+    let et_curr = essential.transpose() * curr_h;
+    let numerator = curr_h.dot(&e_prev).powi(2);
+    let denominator = e_prev.x.powi(2) + e_prev.y.powi(2) + et_curr.x.powi(2) + et_curr.y.powi(2);
+    if denominator < 1e-18 {
+        return None;
+    }
+    Some(numerator / denominator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Point3, UnitQuaternion};
+    use visloc_core::geometry::Pose;
+
+    fn synthetic_camera() -> Camera {
+        Camera::pinhole(1, 640, 480, 500.0, 500.0, 320.0, 240.0)
+    }
+
+    fn project(pose: &Pose, camera: &Camera, point: &Point3<f64>) -> Point2<f64> {
+        camera
+            .project(&pose.transform_world_point(point))
+            .expect("synthetic point must project in front of the camera")
+    }
+
+    fn synthetic_world_points() -> Vec<Point3<f64>> {
+        vec![
+            Point3::new(-1.0, -1.0, 5.0),
+            Point3::new(1.0, -1.0, 5.0),
+            Point3::new(-1.0, 1.0, 5.0),
+            Point3::new(1.0, 1.0, 5.0),
+            Point3::new(0.0, 0.0, 5.0),
+            Point3::new(0.5, -0.25, 6.0),
+            Point3::new(-0.7, 0.4, 4.5),
+            Point3::new(0.6, 0.8, 5.5),
+            Point3::new(-0.3, -0.6, 4.8),
+            Point3::new(0.2, 0.2, 6.5),
+        ]
+    }
+
+    fn correspondences(
+        previous_pose: &Pose,
+        current_pose: &Pose,
+        camera: &Camera,
+        points: &[Point3<f64>],
+    ) -> Vec<TwoViewCorrespondence> {
+        points
+            .iter()
+            .map(|point| TwoViewCorrespondence {
+                previous_xy: project(previous_pose, camera, point),
+                current_xy: project(current_pose, camera, point),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn essential_ransac_recovers_pure_translation() {
+        let camera = synthetic_camera();
+        let previous =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0));
+        let current =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.3, 0.0, 0.0));
+        let correspondences =
+            correspondences(&previous, &current, &camera, &synthetic_world_points());
+
+        let estimator = RelativePoseEstimator::default();
+        let pose = estimator
+            .estimate_with_scale(&correspondences, &camera, 0.3)
+            .expect("relative pose must be recovered");
+
+        let translation = pose.previous_to_current.translation;
+        assert!(
+            (translation - Vector3::new(-0.3, 0.0, 0.0)).norm() < 5.0e-3,
+            "translation drifted: {translation:?}"
+        );
+        let rotation = pose.previous_to_current.rotation.angle();
+        assert!(
+            rotation < 5.0e-3,
+            "rotation should be near zero: {rotation}"
+        );
+        assert!(pose.inliers.len() >= 8);
+        assert!(pose.mean_sampson_error < 5.0e-3);
+    }
+
+    #[test]
+    fn essential_ransac_recovers_translation_with_yaw() {
+        let camera = synthetic_camera();
+        let previous =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0));
+        let yaw = UnitQuaternion::from_axis_angle(&Vector3::y_axis(), 0.05);
+        let current_world_to_camera = SE3::new(yaw, Vector3::new(-0.2, 0.0, -0.05));
+        let current = Pose {
+            world_to_camera: current_world_to_camera.clone(),
+        };
+        let correspondences =
+            correspondences(&previous, &current, &camera, &synthetic_world_points());
+
+        let estimator = RelativePoseEstimator::default();
+        let scale = current_world_to_camera.translation.norm();
+        let pose = estimator
+            .estimate_with_scale(&correspondences, &camera, scale)
+            .expect("relative pose must be recovered");
+
+        assert!(pose.inliers.len() >= 8);
+        let translation_error =
+            (pose.previous_to_current.translation - current_world_to_camera.translation).norm();
+        assert!(
+            translation_error < 5.0e-3,
+            "translation drifted: error={translation_error}"
+        );
+        let rotation_error = pose
+            .previous_to_current
+            .rotation
+            .rotation_to(&current_world_to_camera.rotation)
+            .angle()
+            .abs();
+        assert!(
+            rotation_error < 5.0e-3,
+            "rotation drifted: error_rad={rotation_error}"
+        );
+    }
+
+    #[test]
+    fn essential_ransac_recovers_pure_translation_with_eight_points() {
+        let camera = synthetic_camera();
+        let previous =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0));
+        let current =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.30, 0.0, 0.0));
+        let points = [
+            Point3::new(-1.0, -1.0, 4.5),
+            Point3::new(1.0, -1.0, 4.6),
+            Point3::new(-1.0, 1.0, 5.5),
+            Point3::new(1.0, 1.0, 5.4),
+            Point3::new(0.0, 0.0, 5.0),
+            Point3::new(0.5, -0.25, 6.0),
+            Point3::new(-0.6, 0.4, 4.8),
+            Point3::new(0.4, 0.7, 5.2),
+        ];
+        let correspondences = correspondences(&previous, &current, &camera, &points);
+
+        let estimator = RelativePoseEstimator::default();
+        let pose = estimator
+            .estimate_with_scale(&correspondences, &camera, 0.30)
+            .expect("relative pose must be recovered");
+        let translation = pose.previous_to_current.translation;
+        assert!(
+            (translation - Vector3::new(-0.30, 0.0, 0.0)).norm() < 5.0e-3,
+            "translation drifted: {translation:?}"
+        );
+        assert!(pose.inliers.len() >= 8);
+    }
+
+    #[test]
+    fn essential_ransac_returns_none_for_too_few_points() {
+        let camera = synthetic_camera();
+        let previous =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0));
+        let current =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.2, 0.0, 0.0));
+        let mut points = synthetic_world_points();
+        points.truncate(6);
+        let correspondences = correspondences(&previous, &current, &camera, &points);
+
+        let estimator = RelativePoseEstimator::default();
+        assert!(estimator.estimate(&correspondences, &camera).is_none());
+    }
+}

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -102,6 +102,7 @@ The default `localize(query, map)` path builds a descriptor store from `Landmark
 - `VisualOdometryPosePrior`: bundles the generated pose prior with the VO estimate diagnostics
 - `NoopVisualOdometryFrontend`: default no-estimate implementation for callers that want to wire the interface before adding a real frontend
 - `TwoViewMatchVisualOdometryFrontend`: converts externally supplied two-view correspondences into a lightweight translation-only VO prior without adding a model runtime dependency
+- `EssentialMatrixVisualOdometryFrontend`: classical-geometry VO frontend that runs the `visloc-vision::two_view` essential-matrix RANSAC + cheirality recovery on externally supplied correspondences, returning a full `SE3` relative pose with caller-supplied translation scale
 - `Tracker`: feeds frames through a localization pipeline and updates state from success/failure
 - `ImageTracker`: extracts features from image inputs and feeds generated frames into `Tracker`
 
@@ -188,6 +189,32 @@ Use `visloc_io::descriptors::read_landmark_descriptors_txt` for the first experi
 ```
 
 Use `visloc_io::query_features::read_query_features_txt` for file-based experiments. `examples/localize_from_files.rs` combines this query format with a COLMAP text model and landmark descriptor file.
+
+## Two-View Geometry
+
+`visloc-vision::two_view` ships the classical two-view geometry pieces used by
+`EssentialMatrixVisualOdometryFrontend`:
+
+- `TwoViewCorrespondence`: pixel-space correspondence between the previous and
+  current frame.
+- `EssentialMatrixEstimator` / `EightPointEssentialMatrixEstimator`:
+  Hartley-normalized 8-point essential-matrix estimator. Pixels are first
+  normalized with the camera intrinsics, then Hartley-normalized for
+  conditioning before solving the linear system on `A^T A` so the smallest
+  right singular vector is always available.
+- `EssentialRansac`: Sampson-distance scored RANSAC that returns the best
+  essential matrix, inlier indices, and mean Sampson error.
+- `recover_relative_pose`: SVD-based decomposition of the essential matrix
+  into the four (R, t) candidates, with cheirality scoring to pick the
+  candidate that puts the most inliers in front of both cameras.
+- `RelativePoseEstimator`: composes the RANSAC and recovery steps and applies a
+  caller-supplied translation scale (`default_translation_scale` or per-pair
+  scale through `EssentialMatrixVisualOdometryFrontend::insert_matches_with_scale`)
+  because translation is recovered up to a scalar.
+
+This module deliberately avoids OpenCV / OpenGV dependencies. Heavier or more
+specialized two-view solvers can be added as separate frontends without
+touching this baseline.
 
 ## Two-View Match Text Format
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -4,12 +4,13 @@ This file tracks the project milestone completion used in development updates.
 
 ## Current Development Completion
 
-**Deep VO / Loop Close completion: 55%**
+**Deep VO / Loop Close completion: 60%**
 
-This score means the core extension boundaries exist and the file-backed
-two-view match VO path now drives a short tracking sequence end-to-end, but the
-project has not yet reached a real learned-frontend sequence demo or full
-loop-closure backend.
+This score means the file-backed two-view match VO path drives a short tracking
+sequence end-to-end and a classical essential-matrix RANSAC frontend recovers
+metric relative pose (rotation + translation direction) from the same external
+correspondences, but the project has not yet reached a real learned-frontend
+sequence demo or full loop-closure backend.
 
 Completed pieces:
 
@@ -22,6 +23,14 @@ Completed pieces:
   through `read_two_view_matches_txt`, and the resulting VO priors feed the
   external-prior tracking path on a short multi-frame sequence in the
   `track_sequence_with_two_view_match_vo_prior` example.
+- A classical essential-matrix two-view geometry pipeline now lives in
+  `visloc-vision::two_view` with a Hartley-normalized 8-point estimator,
+  Sampson-distance scored RANSAC, and 4-fold cheirality disambiguation.
+- `EssentialMatrixVisualOdometryFrontend` exposes that pipeline as a
+  `VisualOdometryFrontend`, returning a full SE3 relative pose with
+  caller-supplied translation scale; `two_view_vo_compare` runs the new
+  frontend alongside the flow-only adapter on the same synthetic three-frame
+  sequence to make the difference visible.
 - Online SLAM composition exists over tracking and local mapping.
 - Loop-closure candidates can be detected from shared verified landmarks.
 - Loop-candidate HTML/SVG reporting exists for synthetic sequence demos.
@@ -41,7 +50,7 @@ Remaining pieces before this milestone is considered complete:
 Development updates should report this value as:
 
 ```text
-Deep VO / Loop Close completion: 55%
+Deep VO / Loop Close completion: 60%
 ```
 
 Increase the number only when a runnable example, test, or documented API

--- a/examples/two_view_vo_compare.rs
+++ b/examples/two_view_vo_compare.rs
@@ -1,0 +1,501 @@
+use std::env;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nalgebra::{Point3, UnitQuaternion, Vector3};
+use visloc_rs::core::geometry::Pose;
+use visloc_rs::core::types::{Camera, Frame, Landmark, VisualMap};
+use visloc_rs::{
+    parse_two_view_matches_txt, EssentialMatrixVisualOdometryConfig,
+    EssentialMatrixVisualOdometryFrontend, InMemoryMapProvider, LocalizationPipeline,
+    LocalizationPrior, Tracker, TrackingConfig, TrackingStats, TwoViewMatchVisualOdometryConfig,
+    TwoViewMatchVisualOdometryFrontend, VisualOdometryFrontend, VisualOdometryPriorProvider,
+};
+
+const VO_PRIOR_RADIUS: f64 = 8.0;
+const FRAME_PAIRS: [(u64, u64); 2] = [(100, 101), (101, 102)];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args().skip(1).collect::<Vec<_>>();
+    let output_dir = parse_output_dir(&mut args);
+    if !args.is_empty() {
+        eprintln!("usage: cargo run --example two_view_vo_compare -- [--out-dir <dir>]");
+        std::process::exit(2);
+    }
+
+    let camera = Camera::pinhole(1, 640, 480, 500.0, 500.0, 320.0, 240.0);
+    // Map points span depth and X/Y so the essential-matrix solver gets a
+    // well-conditioned configuration; for the same reason DLT PnP tracking
+    // also benefits from non-coplanar map points.
+    let map_points = [
+        Point3::new(-1.0, -1.0, 4.5),
+        Point3::new(1.0, -1.0, 4.6),
+        Point3::new(-1.0, 1.0, 5.5),
+        Point3::new(1.0, 1.0, 5.4),
+        Point3::new(0.0, 0.0, 5.0),
+        Point3::new(0.5, -0.25, 6.0),
+        Point3::new(-0.6, 0.4, 4.8),
+        Point3::new(0.4, 0.7, 5.2),
+    ];
+    let frame_specs: [(u64, Pose); 3] = [
+        (
+            100,
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0)),
+        ),
+        (
+            101,
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.30, 0.0, 0.0)),
+        ),
+        (
+            102,
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.60, 0.0, -0.05)),
+        ),
+    ];
+    let frames: Vec<Frame> = frame_specs
+        .iter()
+        .map(|(frame_id, pose)| {
+            frame_from_projected_landmarks(*frame_id, &camera, pose, &map_points)
+        })
+        .collect();
+    let provider = InMemoryMapProvider::new(build_map(&camera, &map_points));
+
+    let two_view_matches = build_two_view_match_strings(&frames);
+    let truth_translations = relative_truth_translations(&frame_specs);
+
+    let flow_diagnostics =
+        run_with_flow_frontend(&frames, &provider, &two_view_matches, &truth_translations);
+    let essential_diagnostics = run_with_essential_frontend(
+        &frames,
+        &provider,
+        &camera,
+        &two_view_matches,
+        &truth_translations,
+    );
+
+    println!("== Flow-only frontend (TwoViewMatchVisualOdometryFrontend) ==");
+    print_diagnostics(&flow_diagnostics);
+    println!("== Essential-matrix frontend (EssentialMatrixVisualOdometryFrontend) ==");
+    print_diagnostics(&essential_diagnostics);
+
+    if let Some(output_dir) = output_dir {
+        fs::create_dir_all(&output_dir)?;
+        let report_path = output_dir.join("two_view_vo_compare.txt");
+        write_report(
+            &report_path,
+            &flow_diagnostics,
+            &essential_diagnostics,
+            &truth_translations,
+        )?;
+        println!(
+            "wrote two-view VO comparison report: {}",
+            report_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct FrameDiagnostics {
+    frame_id: u64,
+    used_vo_prior: bool,
+    match_count: usize,
+    inlier_count: usize,
+    estimated_relative_translation: Option<Vector3<f64>>,
+    truth_relative_translation: Option<Vector3<f64>>,
+    candidate_landmark_count: usize,
+    localization_succeeded: bool,
+    estimated_camera_center: Option<Point3<f64>>,
+}
+
+#[derive(Debug)]
+struct RunDiagnostics {
+    label: &'static str,
+    frames: Vec<FrameDiagnostics>,
+    stats: TrackingStats,
+}
+
+fn run_with_flow_frontend(
+    frames: &[Frame],
+    provider: &InMemoryMapProvider,
+    two_view_matches: &[(u64, u64, String)],
+    truth_translations: &[((u64, u64), Vector3<f64>)],
+) -> RunDiagnostics {
+    let mut frontend = TwoViewMatchVisualOdometryFrontend::new(TwoViewMatchVisualOdometryConfig {
+        min_matches: 6,
+        min_inliers: 6,
+        max_residual_pixels: 4.0,
+        pixel_translation_scale: 0.01,
+        forward_translation: 0.0,
+    });
+    for (previous_id, current_id, contents) in two_view_matches {
+        let matches =
+            parse_two_view_matches_txt(contents).expect("flow frontend matches must parse");
+        frontend.insert_matches(*previous_id, *current_id, matches);
+    }
+    drive_tracker_with_frontend("flow-only", frontend, frames, provider, truth_translations)
+}
+
+fn run_with_essential_frontend(
+    frames: &[Frame],
+    provider: &InMemoryMapProvider,
+    camera: &Camera,
+    two_view_matches: &[(u64, u64, String)],
+    truth_translations: &[((u64, u64), Vector3<f64>)],
+) -> RunDiagnostics {
+    let mut frontend = EssentialMatrixVisualOdometryFrontend::new(
+        camera.clone(),
+        EssentialMatrixVisualOdometryConfig {
+            ransac_iterations: 256,
+            sampson_threshold: 5.0e-3,
+            ransac_seed: 7,
+            default_translation_scale: 1.0,
+            min_inliers: 6,
+        },
+    );
+    for (previous_id, current_id, contents) in two_view_matches {
+        let matches =
+            parse_two_view_matches_txt(contents).expect("essential frontend matches must parse");
+        let scale = truth_translations
+            .iter()
+            .find(|((p, c), _)| *p == *previous_id && *c == *current_id)
+            .map(|(_, translation)| translation.norm())
+            .unwrap_or(1.0);
+        frontend.insert_matches_with_scale(*previous_id, *current_id, matches, scale);
+    }
+    drive_tracker_with_frontend(
+        "essential-matrix",
+        frontend,
+        frames,
+        provider,
+        truth_translations,
+    )
+}
+
+fn drive_tracker_with_frontend<F>(
+    label_text: &str,
+    frontend: F,
+    frames: &[Frame],
+    provider: &InMemoryMapProvider,
+    truth_translations: &[((u64, u64), Vector3<f64>)],
+) -> RunDiagnostics
+where
+    F: VisualOdometryFrontend<Error = std::convert::Infallible>,
+{
+    let label: &'static str = match label_text {
+        "flow-only" => "flow-only",
+        "essential-matrix" => "essential-matrix",
+        _ => "unknown",
+    };
+    let provider_vo = VisualOdometryPriorProvider::new(frontend);
+    let mut tracker = Tracker::new(LocalizationPipeline::default(), TrackingConfig::default());
+    let mut previous_frame: Option<&Frame> = None;
+    let mut previous_pose: Option<Pose> = None;
+    let mut diagnostics: Vec<FrameDiagnostics> = Vec::new();
+
+    for frame in frames {
+        let vo_prior =
+            previous_frame
+                .zip(previous_pose.as_ref())
+                .and_then(|(prev_frame, prev_pose)| {
+                    provider_vo
+                        .predict_pose_prior(prev_frame, prev_pose, frame)
+                        .expect("two-view frontends are infallible")
+                });
+
+        let truth_translation = previous_frame.and_then(|prev| {
+            truth_translations
+                .iter()
+                .find(|((p, c), _)| *p == prev.id && *c == frame.id)
+                .map(|(_, translation)| *translation)
+        });
+
+        let (result, diagnostic) = if let Some(vo_prior) = vo_prior {
+            let prior = LocalizationPrior::from_pose(vo_prior.pose.clone(), VO_PRIOR_RADIUS);
+            let result = tracker
+                .track_frame_with_localization_prior_submap_provider(frame, provider, &prior);
+            let diagnostic = FrameDiagnostics {
+                frame_id: result.frame_id,
+                used_vo_prior: true,
+                match_count: vo_prior.estimate.match_count,
+                inlier_count: vo_prior.estimate.inlier_count,
+                estimated_relative_translation: Some(
+                    vo_prior.estimate.previous_to_current.translation,
+                ),
+                truth_relative_translation: truth_translation,
+                candidate_landmark_count: result.localization.candidate_landmark_count,
+                localization_succeeded: result.localization.success,
+                estimated_camera_center: result
+                    .localization
+                    .pose
+                    .as_ref()
+                    .map(Pose::camera_center_world),
+            };
+            (result, diagnostic)
+        } else {
+            let result = tracker.track_frame_with_provider(frame, provider);
+            let diagnostic = FrameDiagnostics {
+                frame_id: result.frame_id,
+                used_vo_prior: false,
+                match_count: 0,
+                inlier_count: 0,
+                estimated_relative_translation: None,
+                truth_relative_translation: truth_translation,
+                candidate_landmark_count: result.localization.candidate_landmark_count,
+                localization_succeeded: result.localization.success,
+                estimated_camera_center: result
+                    .localization
+                    .pose
+                    .as_ref()
+                    .map(Pose::camera_center_world),
+            };
+            (result, diagnostic)
+        };
+
+        previous_frame = Some(frame);
+        previous_pose = result.localization.pose.clone();
+        diagnostics.push(diagnostic);
+    }
+
+    let stats = tracker.stats().clone();
+    RunDiagnostics {
+        label,
+        frames: diagnostics,
+        stats,
+    }
+}
+
+fn build_map(camera: &Camera, points: &[Point3<f64>]) -> VisualMap {
+    let mut map = VisualMap::new();
+    map.cameras.insert(camera.id, camera.clone());
+    for (index, point) in points.iter().enumerate() {
+        let descriptor = vec![index as f32, 9.0];
+        let mut landmark = Landmark::new(index as u64 + 1, *point);
+        landmark.descriptor = Some(descriptor);
+        map.landmarks.insert(landmark.id, landmark);
+    }
+    map
+}
+
+fn frame_from_projected_landmarks(
+    frame_id: u64,
+    camera: &Camera,
+    pose: &Pose,
+    points: &[Point3<f64>],
+) -> Frame {
+    let mut frame = Frame::new(frame_id, camera.id);
+    for (index, point) in points.iter().enumerate() {
+        let keypoint = camera
+            .project(&pose.transform_world_point(point))
+            .expect("synthetic point must project in front of the camera");
+        frame.keypoints.push(keypoint);
+        frame.descriptors.push(vec![index as f32, 9.0]);
+    }
+    frame
+}
+
+fn build_two_view_match_strings(frames: &[Frame]) -> Vec<(u64, u64, String)> {
+    let mut result = Vec::new();
+    for (previous_id, current_id) in FRAME_PAIRS {
+        let previous = frames
+            .iter()
+            .find(|frame| frame.id == previous_id)
+            .expect("previous frame must exist");
+        let current = frames
+            .iter()
+            .find(|frame| frame.id == current_id)
+            .expect("current frame must exist");
+        let mut contents = String::from("# PREV_IDX CURR_IDX PREV_X PREV_Y CURR_X CURR_Y\n");
+        let count = previous.keypoints.len().min(current.keypoints.len());
+        for index in 0..count {
+            let prev_xy = previous.keypoints[index];
+            let curr_xy = current.keypoints[index];
+            writeln!(
+                contents,
+                "{index} {index} {:.4} {:.4} {:.4} {:.4}",
+                prev_xy.x, prev_xy.y, curr_xy.x, curr_xy.y
+            )
+            .ok();
+        }
+        result.push((previous_id, current_id, contents));
+    }
+    result
+}
+
+fn relative_truth_translations(frame_specs: &[(u64, Pose)]) -> Vec<((u64, u64), Vector3<f64>)> {
+    let mut translations = Vec::new();
+    for window in frame_specs.windows(2) {
+        let (prev_id, prev_pose) = (window[0].0, &window[0].1);
+        let (curr_id, curr_pose) = (window[1].0, &window[1].1);
+        // previous_to_current.translation = curr.t - rotation * prev.t with rotation = curr_R * prev_R^-1.
+        // For identity rotations (this synthetic setup), it reduces to curr.t - prev.t.
+        let prev_t = prev_pose.world_to_camera.translation;
+        let curr_t = curr_pose.world_to_camera.translation;
+        let relative_translation = curr_t - prev_t;
+        translations.push(((prev_id, curr_id), relative_translation));
+    }
+    translations
+}
+
+fn print_diagnostics(run: &RunDiagnostics) {
+    for frame in &run.frames {
+        let estimated = frame
+            .estimated_relative_translation
+            .map(format_vector)
+            .unwrap_or_else(|| "n/a".to_string());
+        let truth = frame
+            .truth_relative_translation
+            .map(format_vector)
+            .unwrap_or_else(|| "n/a".to_string());
+        let center = frame
+            .estimated_camera_center
+            .map(|center| format!("[{:.3}, {:.3}, {:.3}]", center.x, center.y, center.z))
+            .unwrap_or_else(|| "n/a".to_string());
+        println!(
+            "frame={} vo_prior={} matches={} inliers={} relative_t_estimated={} relative_t_truth={} candidates={} success={} center={}",
+            frame.frame_id,
+            frame.used_vo_prior,
+            frame.match_count,
+            frame.inlier_count,
+            estimated,
+            truth,
+            frame.candidate_landmark_count,
+            frame.localization_succeeded,
+            center,
+        );
+    }
+    println!(
+        "stats[{}] frames={} success_rate={:.3} external_prior_rate={:.3} external_prior_count={}",
+        run.label,
+        run.stats.frame_count,
+        run.stats.success_rate(),
+        run.stats.external_localization_prior_usage_rate(),
+        run.stats.external_localization_prior_used_count,
+    );
+}
+
+fn write_report(
+    path: &Path,
+    flow: &RunDiagnostics,
+    essential: &RunDiagnostics,
+    truth_translations: &[((u64, u64), Vector3<f64>)],
+) -> std::io::Result<()> {
+    let mut report = String::new();
+    let _ = writeln!(report, "two-view VO comparison demo report");
+    let _ = writeln!(report, "ground-truth relative translations:");
+    for ((previous_id, current_id), translation) in truth_translations {
+        let _ = writeln!(
+            report,
+            "  {previous_id} -> {current_id}: [{:.3}, {:.3}, {:.3}]",
+            translation.x, translation.y, translation.z
+        );
+    }
+    write_run(&mut report, flow);
+    write_run(&mut report, essential);
+    fs::write(path, report)
+}
+
+fn write_run(report: &mut String, run: &RunDiagnostics) {
+    let _ = writeln!(report, "frontend={}", run.label);
+    for frame in &run.frames {
+        let estimated = frame
+            .estimated_relative_translation
+            .map(format_vector)
+            .unwrap_or_else(|| "n/a".to_string());
+        let truth = frame
+            .truth_relative_translation
+            .map(format_vector)
+            .unwrap_or_else(|| "n/a".to_string());
+        let center = frame
+            .estimated_camera_center
+            .map(|center| format!("[{:.3}, {:.3}, {:.3}]", center.x, center.y, center.z))
+            .unwrap_or_else(|| "n/a".to_string());
+        let _ = writeln!(
+            report,
+            "  frame={} vo_prior={} matches={} inliers={} relative_t_estimated={} relative_t_truth={} candidates={} success={} center={}",
+            frame.frame_id,
+            frame.used_vo_prior,
+            frame.match_count,
+            frame.inlier_count,
+            estimated,
+            truth,
+            frame.candidate_landmark_count,
+            frame.localization_succeeded,
+            center,
+        );
+    }
+    let _ = writeln!(
+        report,
+        "  stats frames={} success_rate={:.3} external_prior_rate={:.3} external_prior_count={}",
+        run.stats.frame_count,
+        run.stats.success_rate(),
+        run.stats.external_localization_prior_usage_rate(),
+        run.stats.external_localization_prior_used_count,
+    );
+}
+
+fn format_vector(translation: Vector3<f64>) -> String {
+    format!(
+        "[{:.3}, {:.3}, {:.3}]",
+        translation.x, translation.y, translation.z
+    )
+}
+
+fn parse_output_dir(args: &mut Vec<String>) -> Option<PathBuf> {
+    let output_flag_index = args.iter().position(|arg| arg == "--out-dir")?;
+    if output_flag_index + 1 >= args.len() {
+        eprintln!("--out-dir requires a directory path");
+        std::process::exit(2);
+    }
+    let output_dir = PathBuf::from(args.remove(output_flag_index + 1));
+    args.remove(output_flag_index);
+    Some(output_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_two_view_match_strings_emits_lines_per_pair() {
+        let camera = Camera::pinhole(1, 640, 480, 500.0, 500.0, 320.0, 240.0);
+        let pose_a =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0));
+        let pose_b =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.3, 0.0, 0.0));
+        let pose_c =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.6, 0.0, 0.0));
+        let points = [
+            Point3::new(-1.0, -1.0, 5.0),
+            Point3::new(1.0, -1.0, 5.0),
+            Point3::new(0.0, 0.5, 5.5),
+        ];
+        let frames = vec![
+            frame_from_projected_landmarks(100, &camera, &pose_a, &points),
+            frame_from_projected_landmarks(101, &camera, &pose_b, &points),
+            frame_from_projected_landmarks(102, &camera, &pose_c, &points),
+        ];
+        let strings = build_two_view_match_strings(&frames);
+        assert_eq!(strings.len(), FRAME_PAIRS.len());
+        for (_, _, contents) in &strings {
+            let line_count = contents
+                .lines()
+                .filter(|line| !line.starts_with('#'))
+                .count();
+            assert_eq!(line_count, points.len());
+        }
+    }
+
+    #[test]
+    fn relative_truth_translations_subtracts_camera_translations() {
+        let pose_a =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(0.0, 0.0, 0.0));
+        let pose_b =
+            Pose::from_world_to_camera(UnitQuaternion::identity(), Vector3::new(-0.3, 0.0, 0.0));
+        let translations = relative_truth_translations(&[(100, pose_a.clone()), (101, pose_b)]);
+        assert_eq!(translations.len(), 1);
+        assert_eq!(translations[0].0, (100, 101));
+        assert!((translations[0].1 - Vector3::new(-0.3, 0.0, 0.0)).norm() < 1.0e-12);
+    }
+}

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -21,6 +21,7 @@ track_sequence_with_extractor_dummy
 track_sequence_with_gnss_prior
 track_sequence_with_two_view_match_vo_prior
 track_sequence_with_visual_odometry_prior
+two_view_vo_compare
 visual_odometry_prior_dummy
 "
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,10 @@ pub use visloc_vision::pnp::{
 pub use visloc_vision::ransac::{PnPRansac, RansacReport, RobustPoseEstimator};
 
 mod two_view_vo;
-pub use two_view_vo::{TwoViewMatchVisualOdometryConfig, TwoViewMatchVisualOdometryFrontend};
+pub use two_view_vo::{
+    EssentialMatrixVisualOdometryConfig, EssentialMatrixVisualOdometryFrontend,
+    TwoViewMatchVisualOdometryConfig, TwoViewMatchVisualOdometryFrontend,
+};
 
 /// Common imports for applications using the default visual-localization stack.
 ///
@@ -160,7 +163,8 @@ pub mod prelude {
         ConstantPoseMotionModel, ConstantVelocityMotionModel, CornerFeatureConfig,
         CornerFeatureError, CornerFeatureExtractor, Correspondence2D3D, CorrespondenceBuildError,
         CorrespondenceBuilder, CorrespondenceSet, CrossCheckMatcher, DescriptorMatch,
-        DescriptorProvider, DltPnP, FeatureExtractor, FeatureSet, FeatureSetError,
+        DescriptorProvider, DltPnP, EssentialMatrixVisualOdometryConfig,
+        EssentialMatrixVisualOdometryFrontend, FeatureExtractor, FeatureSet, FeatureSetError,
         FixedLandmarkSelector, FixedLandmarkSubmapSelector, FnFeatureExtractor, Frame, FrameId,
         FrameLocalizationResult, FrameLocalizer, FramePriorSource, FramePriorSyncEvaluationConfig,
         FramePriorSyncEvaluationFailure, FramePriorSyncEvaluationResult, FramePriorSyncSummary,

--- a/src/two_view_vo.rs
+++ b/src/two_view_vo.rs
@@ -2,8 +2,14 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 
 use nalgebra::{UnitQuaternion, Vector2, Vector3};
+use visloc_vision::two_view::{
+    EightPointEssentialMatrixEstimator, EssentialMatrixEstimator, EssentialRansac,
+    RelativePoseEstimator, TwoViewCorrespondence,
+};
 
-use crate::{Frame, FrameId, TwoViewMatchSet, VisualOdometryEstimate, VisualOdometryFrontend, SE3};
+use crate::{
+    Camera, Frame, FrameId, TwoViewMatchSet, VisualOdometryEstimate, VisualOdometryFrontend, SE3,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TwoViewMatchVisualOdometryConfig {
@@ -172,5 +178,204 @@ fn median(mut values: Vec<f64>) -> f64 {
         (values[mid - 1] + values[mid]) * 0.5
     } else {
         values[mid]
+    }
+}
+
+/// Configures the essential-matrix VO frontend. The Sampson threshold and
+/// RANSAC iteration count tune the inlier search; `default_translation_scale`
+/// is the scale applied when no per-pair scale is supplied.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EssentialMatrixVisualOdometryConfig {
+    pub ransac_iterations: usize,
+    pub sampson_threshold: f64,
+    pub ransac_seed: u64,
+    pub default_translation_scale: f64,
+    pub min_inliers: usize,
+}
+
+impl Default for EssentialMatrixVisualOdometryConfig {
+    fn default() -> Self {
+        Self {
+            ransac_iterations: 256,
+            sampson_threshold: 5.0e-3,
+            ransac_seed: 7,
+            default_translation_scale: 1.0,
+            min_inliers: 8,
+        }
+    }
+}
+
+/// Two-view VO frontend backed by the classical essential-matrix RANSAC
+/// pipeline in `visloc-vision`. Compared to `TwoViewMatchVisualOdometryFrontend`
+/// — which estimates a translation-only flow — this frontend recovers a full
+/// SE3 relative pose (rotation + scaled translation) and reports inliers
+/// against the Sampson distance.
+///
+/// The translation is fundamentally up-to-scale. Callers can either:
+/// - Use `default_translation_scale` (a fixed metric scale, e.g., the typical
+///   inter-frame displacement);
+/// - Provide a per-pair scale through [`Self::insert_matches_with_scale`]
+///   sourced from GNSS displacement, the previous frame's translation, or
+///   another prior.
+///
+/// `VisualOdometryEstimate.mean_reprojection_error` stores the mean inlier
+/// Sampson distance in normalized image-plane units (i.e., divided by focal
+/// length). To convert to pixels, multiply by the camera's focal length.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EssentialMatrixVisualOdometryFrontend {
+    estimator: RelativePoseEstimator,
+    camera: Camera,
+    matches_by_frame_pair: HashMap<(FrameId, FrameId), TwoViewMatchSet>,
+    scale_overrides: HashMap<(FrameId, FrameId), f64>,
+    min_inliers: usize,
+}
+
+impl EssentialMatrixVisualOdometryFrontend {
+    pub fn new(camera: Camera, config: EssentialMatrixVisualOdometryConfig) -> Self {
+        let estimator = RelativePoseEstimator {
+            ransac: EssentialRansac {
+                estimator: EightPointEssentialMatrixEstimator::default(),
+                config: visloc_vision::two_view::EssentialRansacConfig {
+                    iterations: config.ransac_iterations,
+                    sampson_threshold: config.sampson_threshold,
+                    seed: config.ransac_seed,
+                },
+            },
+            default_translation_scale: config.default_translation_scale,
+        };
+        Self {
+            estimator,
+            camera,
+            matches_by_frame_pair: HashMap::new(),
+            scale_overrides: HashMap::new(),
+            min_inliers: config.min_inliers,
+        }
+    }
+
+    pub fn camera(&self) -> &Camera {
+        &self.camera
+    }
+
+    pub fn min_inliers(&self) -> usize {
+        self.min_inliers
+    }
+
+    pub fn default_translation_scale(&self) -> f64 {
+        self.estimator.default_translation_scale
+    }
+
+    pub fn insert_matches(
+        &mut self,
+        previous_frame_id: FrameId,
+        current_frame_id: FrameId,
+        matches: TwoViewMatchSet,
+    ) {
+        self.matches_by_frame_pair
+            .insert((previous_frame_id, current_frame_id), matches);
+    }
+
+    pub fn insert_matches_with_scale(
+        &mut self,
+        previous_frame_id: FrameId,
+        current_frame_id: FrameId,
+        matches: TwoViewMatchSet,
+        translation_scale: f64,
+    ) {
+        self.insert_matches(previous_frame_id, current_frame_id, matches);
+        self.scale_overrides
+            .insert((previous_frame_id, current_frame_id), translation_scale);
+    }
+
+    pub fn with_matches(
+        mut self,
+        previous_frame_id: FrameId,
+        current_frame_id: FrameId,
+        matches: TwoViewMatchSet,
+    ) -> Self {
+        self.insert_matches(previous_frame_id, current_frame_id, matches);
+        self
+    }
+
+    pub fn with_matches_and_scale(
+        mut self,
+        previous_frame_id: FrameId,
+        current_frame_id: FrameId,
+        matches: TwoViewMatchSet,
+        translation_scale: f64,
+    ) -> Self {
+        self.insert_matches_with_scale(
+            previous_frame_id,
+            current_frame_id,
+            matches,
+            translation_scale,
+        );
+        self
+    }
+
+    pub fn matches_for(
+        &self,
+        previous_frame_id: FrameId,
+        current_frame_id: FrameId,
+    ) -> Option<&TwoViewMatchSet> {
+        self.matches_by_frame_pair
+            .get(&(previous_frame_id, current_frame_id))
+    }
+
+    fn translation_scale_for(&self, previous_frame_id: FrameId, current_frame_id: FrameId) -> f64 {
+        self.scale_overrides
+            .get(&(previous_frame_id, current_frame_id))
+            .copied()
+            .unwrap_or(self.estimator.default_translation_scale)
+    }
+}
+
+impl VisualOdometryFrontend for EssentialMatrixVisualOdometryFrontend {
+    type Error = Infallible;
+
+    fn estimate_relative_pose(
+        &self,
+        previous_frame: &Frame,
+        current_frame: &Frame,
+    ) -> Result<Option<VisualOdometryEstimate>, Self::Error> {
+        let Some(matches) = self.matches_for(previous_frame.id, current_frame.id) else {
+            return Ok(None);
+        };
+        if matches.len()
+            < self
+                .estimator
+                .ransac
+                .estimator
+                .minimum_correspondences()
+                .max(self.min_inliers)
+        {
+            return Ok(None);
+        }
+        let correspondences: Vec<TwoViewCorrespondence> = matches
+            .matches()
+            .iter()
+            .map(|feature_match| TwoViewCorrespondence {
+                previous_xy: feature_match.previous_xy,
+                current_xy: feature_match.current_xy,
+            })
+            .collect();
+        let scale = self.translation_scale_for(previous_frame.id, current_frame.id);
+        let Some(relative_pose) =
+            self.estimator
+                .estimate_with_scale(&correspondences, &self.camera, scale)
+        else {
+            return Ok(None);
+        };
+        if relative_pose.inliers.len() < self.min_inliers {
+            return Ok(None);
+        }
+        let mut estimate = VisualOdometryEstimate::new(
+            previous_frame.id,
+            current_frame.id,
+            relative_pose.previous_to_current,
+        );
+        estimate.match_count = matches.len();
+        estimate.inlier_count = relative_pose.inliers.len();
+        estimate.mean_reprojection_error = Some(relative_pose.mean_sampson_error);
+        Ok(Some(estimate))
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `visloc-vision::two_view` module with `TwoViewCorrespondence`, `EightPointEssentialMatrixEstimator` (Hartley-normalized, solved on `A^T A` so the 8-row minimal case still exposes the null vector), `EssentialRansac` (Sampson-distance scored), `recover_relative_pose` (Hartley-Zisserman 4-fold cheirality decomposition), and a composing `RelativePoseEstimator` with caller-supplied translation scale.
- Exposes the pipeline through a new `EssentialMatrixVisualOdometryFrontend` in the top-level visloc-rs crate, so externally supplied two-view correspondences can produce a full SE3 relative pose with optional per-pair scale (GNSS displacement, previous-frame translation, etc.).
- Adds `two_view_vo_compare` example that runs the new frontend alongside `TwoViewMatchVisualOdometryFrontend` on a synthetic three-frame sequence and prints per-frame relative-translation estimates against ground truth (essential-matrix recovers all three components, the flow-only adapter only the X-Y flow as expected).
- Updates README / docs / CHANGELOG / PLAN / `scripts/run_examples.sh`. Bumps Deep VO / loop-close completion to 60%.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (incl. new unit tests in `crates/vision/src/two_view/mod.rs` for pure translation, translation+yaw, 8-point minimal case, and the not-enough-points failure path)
- [x] `cargo run --example two_view_vo_compare`
- [x] `cargo run --example two_view_vo_compare -- --out-dir target/visloc_two_view_vo_compare_demo` and verify the generated `two_view_vo_compare.txt` report
- [x] `scripts/check.sh`

Deep VO / Loop Close completion: 60%