### PR TITLE
7-Scenes relocalization: learned retrieval gate (end-to-end loc-rate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Details and reproduction: [KITTI multi-sequence vs published SLAM](docs/kitti_mu
 [EuRoC SfM reconstruction](docs/euroc_sfm_benchmark.md) ·
 [sequential SfM vs COLMAP](docs/sfm_vs_colmap_benchmark.md) ·
 [unordered SfM](docs/unordered_sfm_benchmark.md) ·
+[learned retrieval for relocalization](docs/learned_retrieval_relocalization.md) ·
 [pose-graph / BA internals + GTSAM parity](docs/pgo_internals.md) ·
 [EuRoC vs published baselines](docs/phase_20_to_27_closeout.md).
 

--- a/docs/learned_retrieval_relocalization.md
+++ b/docs/learned_retrieval_relocalization.md
@@ -1,0 +1,88 @@
+# Learned retrieval for relocalization (7-Scenes)
+
+Relocalization — placing a single query image into a prebuilt map with no
+temporal or odometry prior — is gated by *appearance retrieval*: the query must
+first find the handful of map keyframes it could match against. That retrieval
+is the binding constraint here (unlike VO loop closure, where the candidate is
+easy to find and the geometric verifier is the lever). So a better global
+descriptor should translate directly into a higher localization rate.
+
+`examples/relocalization_7scenes_demo.rs` gates retrieval with a hand-built
+`normalized_mean` (the L2-normalized mean of a frame's SuperPoint descriptors, a
+bag-of-features centroid). This benchmark swaps in a **learned** global
+descriptor — EigenPlaces, run in-process through the same ONNX the Rust
+`GlobalDescriptorOnnxExtractor` loads — via `--global-descriptor-dir`, and
+measures the difference. Everything downstream (per-keyframe PnP, the SuperPoint
+features, the thresholds) is identical, so the only variable is the retrieval
+descriptor.
+
+The dataset is 7-Scenes `chess` (train sequences 1/2/4/6, test 3/5). EigenPlaces
+is trained on outdoor Street View imagery, so this is also a cross-domain
+transfer test.
+
+## Retrieval recall
+
+Isolating the retrieval stage: for each test query, is a geometrically correct
+train keyframe (camera centre within 0.3 m) ranked in the descriptor's top-K?
+(`scripts/eval_relocalization_recall.py`, 200 train keyframes, 49 valid queries.)
+
+| recall@K | normalized_mean (incumbent) | EigenPlaces (learned) |
+|---------:|:---------------------------:|:---------------------:|
+| @1       | 42.9% | **57.1%** |
+| @5       | 69.4% | **75.5%** |
+| @10      | 79.6% | **87.8%** |
+| @20      | 85.7% | **89.8%** |
+
+The learned descriptor wins at every K; the gap is largest at @1 (+14.2 pts),
+exactly where a tight retrieval gate operates.
+
+## End-to-end localization
+
+Running the full relocalization pipeline (retrieve top-K, per-keyframe PnP, keep
+the best-inlier pose) with each gate, over a sweep of the retrieval depth K:
+
+| `--retrieve-topk` | localized (baseline / learned) | within 5 cm / 5 deg (baseline / learned) |
+|:-----------------:|:------------------------------:|:----------------------------------------:|
+| 1  | 35.0% / **60.0%** | 27.5% / **35.0%** |
+| 3  | 55.0% / **72.5%** | 30.0% / **35.0%** |
+| 5  | 65.0% / **82.5%** | 30.0% / **42.5%** |
+| 10 | 82.5% / **87.5%** | 42.5% / **47.5%** |
+
+The learned descriptor's edge is largest when the gate is tightest: at top-1 it
+nearly doubles the localization rate (35% to 60%), because it ranks the true
+keyframe first far more often. As K grows both gates eventually retrieve the
+correct keyframe, so the gap narrows — i.e. the learned descriptor reaches a
+given recall at a *lower* candidate budget (less per-query matching work).
+
+This is the converse of the KITTI seq02 VO loop-closure finding (see the
+`--loop-min-inlier-ratio` flag and its commit), where retrieval is *not* the
+bottleneck and a learned descriptor changes nothing end-to-end: the lever there
+is geometric verification. Learned place-recognition pays off precisely where
+retrieval is the binding constraint, and relocalization is that regime.
+
+## Reproduce
+
+```sh
+DS=~/datasets/7scenes/chess
+
+# 1. SuperPoint features (for PnP) and EigenPlaces globals (for the gate).
+scripts/export_vpr_onnx.py --out models/eigenplaces_r50_2048.onnx
+scripts/export_superpoint_7scenes.py --dataset $DS --seqs 1,2,4,6 --stride 20 --out-dir /tmp/sp_7scenes_chess
+scripts/export_superpoint_7scenes.py --dataset $DS --seqs 3,5   --stride 50 --out-dir /tmp/sp_7scenes_chess
+scripts/export_vpr_globals_7scenes.py --dataset $DS --seqs 1,2,4,6 --stride 20 --out-dir /tmp/vpr_7scenes_chess
+scripts/export_vpr_globals_7scenes.py --dataset $DS --seqs 3,5   --stride 50 --out-dir /tmp/vpr_7scenes_chess
+
+# 2. Retrieval recall (isolated):
+scripts/eval_relocalization_recall.py --dataset $DS
+
+# 3. End-to-end loc-rate A/B (per-keyframe PnP):
+EX=target/release/examples/relocalization_7scenes_demo
+cargo build --release --example relocalization_7scenes_demo --features image-io
+$EX --dataset $DS --sp-features-dir /tmp/sp_7scenes_chess --retrieve-topk 5             # baseline
+$EX --dataset $DS --sp-features-dir /tmp/sp_7scenes_chess \
+    --global-descriptor-dir /tmp/vpr_7scenes_chess --retrieve-topk 5                    # learned
+```
+
+The SuperPoint export needs a Python env with `lightglue`; the EigenPlaces
+export needs `torch` + `torchvision` and the cached EigenPlaces weights (see
+`scripts/export_vpr_onnx.py`). Model `.onnx` files are git-ignored.

--- a/examples/relocalization_7scenes_demo.rs
+++ b/examples/relocalization_7scenes_demo.rs
@@ -94,6 +94,7 @@ struct Args {
     accumulate_corrs: bool,
     correspondences_dir: Option<PathBuf>,
     grouped_corrs: bool,
+    global_descriptor_dir: Option<PathBuf>,
 }
 
 impl Default for Args {
@@ -123,6 +124,7 @@ impl Default for Args {
             accumulate_corrs: false,
             correspondences_dir: None,
             grouped_corrs: false,
+            global_descriptor_dir: None,
         }
     }
 }
@@ -153,6 +155,26 @@ fn normalized_mean(descriptors: &[Vec<f32>]) -> Vec<f32> {
         }
     }
     acc
+}
+
+/// Load a precomputed learned global descriptor for one frame from
+/// `<dir>/seq-SS_frame-NNNNNN.txt` (one whitespace-separated line of floats),
+/// written by `scripts/export_vpr_globals_7scenes.py`. Returns `None` if the
+/// directory is unset or the file is absent, so the caller falls back to
+/// `normalized_mean`. This is the learned-VPR retrieval gate (the A/B against
+/// the bag-of-features `normalized_mean`).
+fn frame_global(dir: Option<&PathBuf>, seq: u32, idx: usize) -> Option<Vec<f32>> {
+    let path = dir?.join(format!("seq-{seq:02}_frame-{idx:06}.txt"));
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: Vec<f32> = text
+        .split_whitespace()
+        .filter_map(|t| t.parse().ok())
+        .collect();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
 }
 
 fn dot(a: &[f32], b: &[f32]) -> f32 {
@@ -208,6 +230,7 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
             "--accumulate-corrs" => args.accumulate_corrs = true,
             "--correspondences-dir" => args.correspondences_dir = Some(PathBuf::from(val()?)),
             "--grouped-corrs" => args.grouped_corrs = true,
+            "--global-descriptor-dir" => args.global_descriptor_dir = Some(PathBuf::from(val()?)),
             other => return Err(format!("unknown flag: {other}").into()),
         }
     }
@@ -441,7 +464,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
                 if !kf_ids.is_empty() {
                     keyframe_index.push(KeyframeIndex {
-                        global: normalized_mean(&kf_descs),
+                        global: frame_global(args.global_descriptor_dir.as_ref(), seq, idx)
+                            .unwrap_or_else(|| normalized_mean(&kf_descs)),
                         landmark_ids: kf_ids,
                         positions: kf_positions,
                         descriptors: kf_descs,
@@ -515,7 +539,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             {
                 if args.retrieve_topk > 0 && !keyframe_index.is_empty() {
                     // Appearance-based retrieval: top-K most similar train keyframes.
-                    let qg = normalized_mean(&descriptors);
+                    let qg = frame_global(args.global_descriptor_dir.as_ref(), seq, idx)
+                        .unwrap_or_else(|| normalized_mean(&descriptors));
                     let mut scored: Vec<(f32, usize)> = keyframe_index
                         .iter()
                         .enumerate()

--- a/scripts/export_vpr_globals_7scenes.py
+++ b/scripts/export_vpr_globals_7scenes.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Export per-frame learned VPR global descriptors (EigenPlaces) for selected
+7-Scenes frames, one file per frame named  seq-SS_frame-NNNNNN.txt  in the
+output directory (mirroring scripts/export_superpoint_7scenes.py), each a single
+whitespace-separated line of float32 values.
+
+`examples/relocalization_7scenes_demo.rs --global-descriptor-dir <dir>` consumes
+these as the retrieval-gating descriptor, replacing the hand-built
+`normalized_mean` of SuperPoint descriptors — the same learned global descriptor
+the in-process Rust `GlobalDescriptorOnnxExtractor` runs. This is the *learned*
+side of the retrieval A/B; the SuperPoint features (for PnP) are exported
+separately by export_superpoint_7scenes.py.
+
+Uses the ONNX model exported by scripts/export_vpr_onnx.py (no upstream-repo
+code execution). ImageNet normalisation is baked into the graph, so the image is
+fed as RGB in [0, 1].
+
+Usage:
+  scripts/export_vpr_globals_7scenes.py \
+      --dataset /path/to/7scenes/chess --seqs 1,2,4,6 --stride 20 \
+      --model models/eigenplaces_r50_2048.onnx --out-dir /tmp/vpr_7scenes_chess
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+from PIL import Image
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", type=Path, required=True)
+    ap.add_argument("--seqs", required=True, help="comma list, e.g. 1,2,4,6")
+    ap.add_argument("--stride", type=int, default=20)
+    ap.add_argument("--frames-per-seq", type=int, default=1000)
+    ap.add_argument("--model", default="models/eigenplaces_r50_2048.onnx")
+    ap.add_argument("--width", type=int, default=640)
+    ap.add_argument("--height", type=int, default=480)
+    ap.add_argument("--out-dir", type=Path, required=True)
+    args = ap.parse_args()
+
+    avail = ort.get_available_providers()
+    providers = (
+        ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        if "CUDAExecutionProvider" in avail
+        else ["CPUExecutionProvider"]
+    )
+    sess = ort.InferenceSession(args.model, providers=providers)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    seqs = [int(s) for s in args.seqs.split(",") if s.strip()]
+    total = 0
+    for seq in seqs:
+        seq_dir = args.dataset / f"seq-{seq:02d}"
+        for idx in range(0, args.frames_per_seq, args.stride):
+            color = seq_dir / f"frame-{idx:06d}.color.png"
+            if not color.exists():
+                continue
+            im = Image.open(color).convert("RGB").resize((args.width, args.height))
+            x = (np.asarray(im, np.float32) / 255.0).transpose(2, 0, 1)[None]
+            desc = sess.run(None, {"image": x})[0].ravel()
+            out = args.out_dir / f"seq-{seq:02d}_frame-{idx:06d}.txt"
+            out.write_text(" ".join(f"{v:.7f}" for v in desc) + "\n")
+            total += 1
+    print(f"DONE: {total} frames -> {args.out_dir}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Completes the learned-VPR retrieval story (PR #25) end-to-end: wires the learned global descriptor into `examples/relocalization_7scenes_demo.rs`'s retrieval gate via `--global-descriptor-dir`, so EigenPlaces-vs-`normalized_mean` is measured as **localization rate**, not just retrieval recall. Per-frame globals come from the new `scripts/export_vpr_globals_7scenes.py` (mirrors the SuperPoint export; same `seq-SS_frame-NNNNNN.txt` keying). Downstream (per-keyframe PnP, SuperPoint features, thresholds) is unchanged — the retrieval descriptor is the only variable.

**7-Scenes chess** (train 1/2/4/6, test 3/5; EigenPlaces is outdoor-trained, so also a cross-domain transfer test). The learned gate lifts localization at every retrieval depth, most at the tightest gate where its recall@1 edge matters:

| `--retrieve-topk` | localized (baseline → learned) | within 5cm/5° (baseline → learned) |
|:---:|:---:|:---:|
| 1  | 35.0% → **60.0%** | 27.5% → **35.0%** |
| 3  | 55.0% → **72.5%** | 30.0% → **35.0%** |
| 5  | 65.0% → **82.5%** | 30.0% → **42.5%** |
| 10 | 82.5% → **87.5%** | 42.5% → **47.5%** |

Isolated retrieval recall (`scripts/eval_relocalization_recall.py`, from PR #25): EigenPlaces beats `normalized_mean` at every K (recall@1 42.9% → 57.1%, @10 79.6% → 87.8%).

This is the converse of the KITTI seq02 VO loop-closure finding (PR #25): there retrieval is *not* the bottleneck and the lever is the geometric verifier, so a learned descriptor changes nothing end-to-end. Learned place recognition pays off precisely where retrieval is the binding constraint — relocalization is that regime.

Full tables + reproduce: `docs/learned_retrieval_relocalization.md`. `fmt` clean; the example builds with `--features image-io` (not a CI default feature, so unchanged in the CI examples step).