### PR TITLE
Sequential SfM: COLMAP-style schedule + intrinsics co-evolution

### DIFF
--- a/docs/sfm_vs_colmap_benchmark.md
+++ b/docs/sfm_vs_colmap_benchmark.md
@@ -64,10 +64,96 @@ VO frontend + windowed BA + loop closure dominates a from-scratch monocular
 incremental mapper on speed, accuracy, and scale recovery.** It is *not* a claim
 that visloc beats COLMAP on COLMAP's home turf — unordered internet photo
 collections, where retrieval + multi-hypothesis incremental mapping is COLMAP's
-strength. On a small-scene monocular subset (300 frames, same images, both
-monocular), COLMAP's full global BA wins accuracy (3.8 cm vs visloc's monocular
-`sequential_sfm_demo` at 11 cm); the win reported here is specifically the
-long-metric-video regime.
+strength.
+
+### Small-scene monocular subset (300 frames, both monocular) — COLMAP wins
+
+On the first 300 MH_03 frames reconstructed monocularly (left camera only, so
+both engines are scale-free and scored with a Sim(3) alignment against the same
+GT, same `colmap_images_to_tum.py` + `evo_ape -as` tooling):
+
+| engine | registered | Sim(3) ATE rmse | wall-clock |
+|---|---|---|---|
+| **COLMAP** mono incremental | **300 / 300** | **0.37 cm** | ~29 min |
+| visloc `--colmap-style` mapper | 299 / 300 | 1.64 cm | ~7 min |
+| visloc `sequential_sfm_demo` (simple) | 272 / 300 | 2.13 cm | ~7 min |
+
+**COLMAP still wins this turf, but the gap is closing.** COLMAP's repeated global
+bundle adjustment over a small, well-conditioned set is hard to beat on accuracy.
+Porting its `IncrementalMapper` schedule — per-registration **local BA**,
+**growth-triggered iterative global refinement**, and **registration retries** —
+into the incremental engine (`--colmap-style`, `IncrementalSfmConfig::colmap_style_mapper`)
+takes visloc from 2.13 → **1.64 cm** and from 272 → **299 / 300** registered,
+narrowing the accuracy gap from ~5.7× to ~4.4× and nearly matching COLMAP's full
+registration. (An earlier note in this file quoted 11 cm for visloc and 3.8 cm
+for COLMAP; both are superseded by these fresh same-subset measurements — COLMAP
+4.0.3's mapper reaches 0.37 cm.) visloc does **not** yet match COLMAP on its home
+turf; the headline win below is specifically the long metric **stereo** video
+regime.
+
+**Remaining gap to 0.37 cm — it is *not* track density (measured).** The
+COLMAP-style reconstruction keeps only ~2 k triangulated points against COLMAP's
+~15 k, so the obvious hypothesis is "denser structure → tighter poses." It is
+**wrong on this data**, and the ablation is worth recording:
+
+| variant | tracks | reg | Sim(3) ATE |
+|---|---|---|---|
+| strict 2° gate (shipped) | 2 062 | 299 | **1.64 cm** |
+| flat 1° gate | 12 632 | 278 | 15.1 cm |
+| multi-view exemption (keep <2° tracks with ≥6 views) | 10 047 | 208 | 16.5 cm |
+
+Relaxing the parallax gate *does* recover COLMAP-grade point counts, but ATE
+collapses by ~10×. The reason is the capture geometry: on a forward-flying
+trajectory a point near the heading direction subtends near-zero parallax **no
+matter how many frames see it**, so its depth is unconstrained; admitting such
+points (even long, many-view ones) injects depth-ambiguous structure that pulls
+the poses. The strict 2° gate is therefore the accuracy optimum here, and the
+sparse-but-clean reconstruction is *correct*, not a defect.
+
+**Intrinsics refinement — also *not* the lever here (measured).** The natural
+next hypothesis was COLMAP's focal-length + principal-point refinement: a
+slightly-off fixed calibration forces a residual onto the poses. So it was
+implemented (`BaConfig::refine_intrinsics` / `--refine-intrinsics`: alternating
+BA ↔ a damped Gauss-Newton on `(fx, fy, cx, cy)`, validated by a unit test that
+recovers a perturbed focal when the structure is fixed). On this benchmark it
+**does not help** — Sim(3) ATE 1.64 → 1.77 cm, a touch *worse*. Two measurements
+explain why, and it is the **same** geometry as the density result:
+
+- On the rectified EuRoC images the calibration is already accurate, so there is
+  no residual to absorb; refinement only overfits `fy` (436.2 → 439.1) to the
+  sparse structure and mildly biases the trajectory.
+- Deliberately starting from a wrong focal (`fx = fy = 460`, true ≈ 436) does
+  **not** get recovered — refinement leaves it at 460. On forward motion the
+  focal length is **weakly observable** (the focal/depth ambiguity): a wrong
+  focal is absorbed into structure during growth, leaving nothing for the
+  intrinsics step to pull on. (A uniform focal error is in any case largely
+  Sim(3)-absorbed in scoring.)
+
+So COLMAP's 0.37 cm edge on its home turf is neither intrinsics nor raw point
+count — it is most plausibly its **denser, better-distributed SIFT frontend** and
+mature global BA producing well-conditioned structure, which a sequential
+SuperPoint-window frontend does not match. That is the honest remaining gap.
+Intrinsics refinement is kept (off by default) because it *is* the right tool for
+unknown / inaccurate calibration on observable geometry (sideways, orbiting, or
+unordered photo collections) — just not for rectified forward video.
+
+(Schedule ablation, separately: re-triangulation must run **both** during growth
+— dropping it collapses registration to 212/300 and ATE to 6.6 cm — **and** in
+the final refinement — filter-only there leaves 718 tracks and 2.21 cm; keeping
+it everywhere is the 1.64 cm / 299-frame point above. The
+`low_parallax_min_observations` exemption remains available for sideways/orbiting
+capture, where many-view low-angle tracks *are* well-constrained, but is off by
+default.)
+
+**Re-triangulation (`--retriangulate`, off by default).** Adding COLMAP's
+post-BA re-triangulation step — complete tracks the narrow seed-time baseline
+missed, guarded-re-seed noisy points — grows the model by **+318 tracks / +2151
+observations (~3 %)**, useful structure density for a downstream 3DGS/NeRF
+model, but is **ATE-neutral-to-slightly-negative** here (Sim(3) 2.13 → 2.27 cm):
+the engine already triangulates greedily after every registration, so the extra
+tracks the post-BA pass recovers are the weakly-constrained, gate-grazing ones.
+It is therefore an opt-in density lever, not an accuracy lever, on this
+already-tight metric-video regime.
 
 ## Reproduce
 

--- a/docs/sfm_vs_colmap_benchmark.md
+++ b/docs/sfm_vs_colmap_benchmark.md
@@ -137,6 +137,47 @@ Intrinsics refinement is kept (off by default) because it *is* the right tool fo
 unknown / inaccurate calibration on observable geometry (sideways, orbiting, or
 unordered photo collections) — just not for rectified forward video.
 
+### Where refinement *does* pull — the observable orbit (measured)
+
+That last claim is now measured, on COLMAP's own **unordered** orbit set
+(South Building, 128 photos, scored by Sim(3) camera-centre RMSE against COLMAP's
+reference model — the [unordered SfM benchmark](../scripts/run_colmap_sfm_benchmark.sh)).
+Two findings:
+
+**1. The COLMAP-style schedule reaches near-parity on this turf.** With the same
+SuperPoint frontend and the true calibration, `--colmap-style` lands **0.44 cm**
+(128 / 128 registered) against COLMAP's own **0.37 cm** — versus 0.89 cm for the
+simple schedule. On observable orbit geometry the per-registration local BA +
+growth-triggered global refinement that *did not* help the forward EuRoC flight is
+exactly what closes the gap. (This is the unordered orbit, not the metric-video
+headline above; it does not contradict the "COLMAP wins forward video's small-scene
+mono subset" result, which is a different, low-parallax regime.)
+
+**2. Intrinsics refinement recovers an injected focal error here — but only when
+it co-evolves during growth.** Injecting an *anisotropic* miscalibration
+(`fx ×1.05`, `fy ×0.97`) degrades the colmap-style ATE 0.44 → **4.98 cm**.
+Refining intrinsics then pulls it back to **4.26 cm**, with `fx 2687.7 → 2662.1`
+and `fy 2483.9 → 2506.1` both moving toward the truth (2559.7) and the
+un-perturbed principal point staying put — a directionally-correct ~25 % recovery,
+where the *forward-video* refinement recovered nothing. The mechanism matters: the
+recovery only happens because the refinement is now wired into the **growth**
+global passes (`growth_global_refinement`), co-evolving the camera with the
+structure the way COLMAP does. The earlier *final-only* alternating refinement
+moved the focal by < 1 unit even here — once the growth has converged the structure
+into a wrong-focal basin, the structure-fixed intrinsics gradient is ≈ 0, so no
+amount of final alternation escapes it. Co-evolving from the small early model,
+before the basin forms, is what gives the intrinsics step a live signal.
+
+The recovery is **partial** (~25 %), not full self-calibration: each growth pass
+still uses the *alternating* (structure-fixed) intrinsics step, so it accumulates
+corrections across passes rather than solving for the focal jointly. Closing the
+rest needs the intrinsics carried as shared unknowns *inside* the Schur-complement
+BA (the COLMAP joint formulation) — the clear next lever, and a larger change to
+the core solver. (Validated by the `colmap_style_co_evolves_intrinsics_toward_truth`
+unit test: on the synthetic ring a wrong horizontal focal `fx 530` is pulled back
+toward 500 while `fy` / `(cx, cy)` — un-perturbed, and on this purely-azimuthal arc
+`fy` is not even observable — do not drift.)
+
 (Schedule ablation, separately: re-triangulation must run **both** during growth
 — dropping it collapses registration to 212/300 and ATE to 6.6 cm — **and** in
 the final refinement — filter-only there leaves 718 tracks and 2.21 cm; keeping

--- a/examples/sequential_sfm_demo.rs
+++ b/examples/sequential_sfm_demo.rs
@@ -38,6 +38,15 @@
 //!     --window 5 --min-matches 30 \
 //!     --out-colmap /tmp/seq_sfm_colmap
 //! ```
+//!
+//! Flags of note. `--colmap-style` runs COLMAP's `IncrementalMapper` BA schedule
+//! (per-registration local BA + growth-triggered iterative global refinement +
+//! registration retries) instead of the simple "global BA every N + final BA"
+//! path; on a 300-frame EuRoC MH_03 monocular subset this lifts accuracy from
+//! 2.13 to 1.64 cm and registration from 272 to 299 / 300 (see
+//! `docs/sfm_vs_colmap_benchmark.md`). `--retriangulate` (simple path only)
+//! re-triangulates tracks after the final BA — a structure-density lever,
+//! ATE-neutral, off by default.
 
 use std::collections::HashMap;
 use std::env;
@@ -68,6 +77,10 @@ struct Args {
     max_reproj: f64,
     final_ba: bool,
     seed_trials: usize,
+    retriangulate: bool,
+    colmap_style: bool,
+    min_tri_angle: f64,
+    refine_intrinsics: bool,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -84,6 +97,10 @@ fn parse_args() -> Result<Args, String> {
     let mut max_reproj = 4.0f64;
     let mut final_ba = true;
     let mut seed_trials = 12usize;
+    let mut retriangulate = false;
+    let mut colmap_style = false;
+    let mut min_tri_angle = 2.0f64;
+    let mut refine_intrinsics = false;
 
     let mut a: Vec<String> = env::args().skip(1).collect();
     let mut i = 0;
@@ -107,6 +124,12 @@ fn parse_args() -> Result<Args, String> {
             }
             "--max-reproj" => max_reproj = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
             "--no-final-ba" => final_ba = false,
+            "--retriangulate" => retriangulate = true,
+            "--colmap-style" => colmap_style = true,
+            "--min-tri-angle" => {
+                min_tri_angle = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?
+            }
+            "--refine-intrinsics" => refine_intrinsics = true,
             "--seed-trials" => seed_trials = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
             other => return Err(format!("unknown argument: {other}")),
         }
@@ -142,6 +165,10 @@ fn parse_args() -> Result<Args, String> {
         max_reproj,
         final_ba,
         seed_trials,
+        retriangulate,
+        colmap_style,
+        min_tri_angle,
+        refine_intrinsics,
     })
 }
 
@@ -290,6 +317,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_reprojection_error_px: args.max_reproj,
         final_global_ba: args.final_ba,
         seed_trials: args.seed_trials,
+        retriangulate: args.retriangulate,
+        colmap_style_mapper: args.colmap_style,
+        refine_intrinsics: args.refine_intrinsics,
+        min_triangulation_angle_deg: args.min_tri_angle,
+        // NB: the low-parallax multi-view exemption (`low_parallax_min_observations`)
+        // is deliberately left off. On this forward-flying trajectory it is a trap —
+        // even tracks seen by ≥6 views stay near-zero-parallax (the camera barely
+        // sideways-translates), so keeping them injects depth-ambiguous points that
+        // corrupt the poses: measured 10 k tracks but ATE blows up to 16 cm vs the
+        // strict 2° gate's 1.64 cm. The exemption is for sideways/orbiting capture,
+        // not forward video. See `docs/sfm_vs_colmap_benchmark.md`.
         ..IncrementalSfmConfig::default()
     };
     let t_sfm = std::time::Instant::now();
@@ -302,6 +340,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         result.mean_reprojection_px,
         t_sfm.elapsed().as_secs_f64(),
     );
+
+    // If intrinsics were refined, the poses/tracks are expressed against the
+    // refined camera — export with it, not the input calibration.
+    let export_camera = result
+        .refined_camera
+        .clone()
+        .unwrap_or_else(|| args.camera.clone());
+    if let Some(refined) = &result.refined_camera {
+        if let (Some((fx0, fy0, cx0, cy0)), Some((fx, fy, cx, cy))) =
+            (args.camera.intrinsics(), refined.intrinsics())
+        {
+            println!(
+                "refined intrinsics: fx {fx0:.2}->{fx:.2}  fy {fy0:.2}->{fy:.2}  \
+                 cx {cx0:.2}->{cx:.2}  cy {cy0:.2}->{cy:.2}",
+            );
+        }
+    }
 
     // Compact to registered images (the COLMAP writer expects a dense pose list)
     // and remap each track observation's image index.
@@ -334,7 +389,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let summary = write_colmap_reconstruction_for_3dgs(
         &args.out_colmap,
-        &args.camera,
+        &export_camera,
         &poses_out,
         &features_out,
         &landmarks_out,

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -69,6 +69,8 @@ struct Args {
     max_reproj: f64,
     final_ba: bool,
     seed_trials: usize,
+    refine_intrinsics: bool,
+    colmap_style: bool,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -87,6 +89,8 @@ fn parse_args() -> Result<Args, String> {
     let mut max_reproj = 4.0f64;
     let mut final_ba = true;
     let mut seed_trials = 12usize;
+    let mut refine_intrinsics = false;
+    let mut colmap_style = false;
 
     let mut a: Vec<String> = env::args().skip(1).collect();
     let mut i = 0;
@@ -115,6 +119,8 @@ fn parse_args() -> Result<Args, String> {
             "--max-reproj" => max_reproj = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
             "--no-final-ba" => final_ba = false,
             "--seed-trials" => seed_trials = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
+            "--refine-intrinsics" => refine_intrinsics = true,
+            "--colmap-style" => colmap_style = true,
             other => return Err(format!("unknown argument: {other}")),
         }
         i += 1;
@@ -147,6 +153,8 @@ fn parse_args() -> Result<Args, String> {
         max_reproj,
         final_ba,
         seed_trials,
+        refine_intrinsics,
+        colmap_style,
     })
 }
 
@@ -343,6 +351,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_reprojection_error_px: args.max_reproj,
         final_global_ba: args.final_ba,
         seed_trials: args.seed_trials,
+        refine_intrinsics: args.refine_intrinsics,
+        colmap_style_mapper: args.colmap_style,
         ..IncrementalSfmConfig::default()
     };
     let result = incremental_sfm(&args.camera, &features, &pairwise, &config)?;
@@ -353,6 +363,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         result.tracks.len(),
         result.mean_reprojection_px,
     );
+
+    // When intrinsics were refined, export with the refined camera (and report the
+    // before→after pull — on observable, wide-parallax capture this is where focal
+    // length is recoverable, unlike low-parallax forward video).
+    let export_camera = result.refined_camera.clone().unwrap_or(args.camera.clone());
+    if let (Some(i0), Some(i1)) = (args.camera.intrinsics(), export_camera.intrinsics()) {
+        if result.refined_camera.is_some() {
+            println!(
+                "refined intrinsics: fx {:.2}->{:.2}  fy {:.2}->{:.2}  cx {:.2}->{:.2}  cy {:.2}->{:.2}",
+                i0.0, i1.0, i0.1, i1.1, i0.2, i1.2, i0.3, i1.3,
+            );
+        }
+    }
 
     // Compact to registered images (the COLMAP writer expects a dense pose list)
     // and remap each track observation's image index.
@@ -385,7 +408,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let summary = write_colmap_reconstruction_for_3dgs(
         &args.out_colmap,
-        &args.camera,
+        &export_camera,
         &poses_out,
         &features_out,
         &landmarks_out,

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -22,8 +22,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use nalgebra::{
-    DMatrix, DVector, Matrix2x3, Matrix2x6, Matrix3, Matrix3x6, Matrix6, Matrix6x3, Point2, Point3,
-    Vector2, Vector3, Vector6,
+    DMatrix, DVector, Matrix2x3, Matrix2x4, Matrix2x6, Matrix3, Matrix3x4, Matrix3x6, Matrix4,
+    Matrix6, Matrix6x3, Point2, Point3, Vector2, Vector3, Vector4, Vector6,
 };
 
 use visloc_core::geometry::{Pose, SE3, SO3};
@@ -815,7 +815,142 @@ impl BundleAdjustment {
     /// Run Levenberg-Marquardt bundle adjustment with Schur-complement
     /// landmark elimination. Returns iteration trace and final cost.
     pub fn optimize(&mut self, config: &BaConfig) -> Result<BaResult, BaError> {
-        self.optimize_weighted(config, None)
+        if !config.refine_intrinsics {
+            return self.optimize_weighted(config, None);
+        }
+        // Alternating pose/structure ↔ intrinsics refinement. Solve the BA with
+        // the current camera, refine the intrinsics against the fixed result,
+        // then re-solve — repeating until the camera stops moving.
+        let mut result = self.optimize_weighted(config, None)?;
+        for _ in 0..config.intrinsics_refinement_rounds.max(1) {
+            let change = self.refine_intrinsics(&config.robust_kernel, None);
+            if change == 0.0 {
+                break; // not a refinable pinhole, or nothing to do
+            }
+            result = self.optimize_weighted(config, None)?;
+            if change < 1e-3 {
+                break; // intrinsics converged (sub-millipixel focal/centre move)
+            }
+        }
+        Ok(result)
+    }
+
+    /// One alternating refinement of the shared pinhole intrinsics
+    /// `(fx, fy, cx, cy)` with the poses and landmarks held fixed: a small damped
+    /// Gauss-Newton over every (monocular + stereo) reprojection residual w.r.t.
+    /// the 4 intrinsics, applied in place to `self.camera`. Reuses the same
+    /// `predicted − observed` residual sign and IRLS weighting as the main solve.
+    /// Returns the L2 norm of the applied `(fx, fy, cx, cy)` update — `0.0` if the
+    /// camera is not a 4-parameter [`CameraModel::Pinhole`] or there is nothing to
+    /// refine. The intrinsics-only normal equations are full-rank given fixed
+    /// structure (no gauge freedom), so no extra anchoring is needed.
+    fn refine_intrinsics(&mut self, kernel: &RobustKernel, gnc_weights: Option<&[f64]>) -> f64 {
+        if self.camera.model != CameraModel::Pinhole {
+            return 0.0;
+        }
+        let Some((mut fx, mut fy, mut cx, mut cy)) = self.camera.intrinsics() else {
+            return 0.0;
+        };
+        let baseline = match self.stereo_baseline {
+            Some(b) if b.is_finite() && b > 0.0 => Some(b),
+            _ => None,
+        };
+        let mono_count = self.observations.len();
+
+        let mut total_change = 0.0;
+        // A few internal Gauss-Newton steps (structure is fixed, so this is cheap
+        // and converges in a handful of iterations).
+        for _ in 0..5 {
+            let mut h = Matrix4::<f64>::zeros();
+            let mut g = Vector4::<f64>::zeros();
+
+            for (idx, obs) in self.observations.iter().enumerate() {
+                let (Some(pose), Some(point)) = (
+                    self.poses.get(&obs.keyframe_id),
+                    self.landmarks.get(&obs.landmark_id),
+                ) else {
+                    continue;
+                };
+                let xc = pose.transform_world_point(point);
+                if xc.z <= 0.0 {
+                    continue;
+                }
+                let zi = 1.0 / xc.z;
+                let r = Vector2::new(
+                    fx * xc.x * zi + cx - obs.xy.x,
+                    fy * xc.y * zi + cy - obs.xy.y,
+                );
+                let s = r.x * r.x + r.y * r.y;
+                let w = kernel.weight(s) * gnc_weights.map_or(1.0, |gw| gw[idx]);
+                // ∂r/∂[fx, fy, cx, cy].
+                let mut j = Matrix2x4::<f64>::zeros();
+                j[(0, 0)] = xc.x * zi;
+                j[(0, 2)] = 1.0;
+                j[(1, 1)] = xc.y * zi;
+                j[(1, 3)] = 1.0;
+                h += w * (j.transpose() * j);
+                g += w * (j.transpose() * r);
+            }
+
+            if let Some(b) = baseline {
+                for (k, obs) in self.stereo_observations.iter().enumerate() {
+                    let (Some(pose), Some(point)) = (
+                        self.poses.get(&obs.keyframe_id),
+                        self.landmarks.get(&obs.landmark_id),
+                    ) else {
+                        continue;
+                    };
+                    let xc = pose.transform_world_point(point);
+                    if xc.z <= 0.0 {
+                        continue;
+                    }
+                    let zi = 1.0 / xc.z;
+                    let pred_x = fx * xc.x * zi + cx;
+                    let pred_y = fy * xc.y * zi + cy;
+                    // u_r_pred = u_l_pred − fx·b/Z = fx·(X−b)/Z + cx.
+                    let u_r_pred = pred_x - fx * b * zi;
+                    let r =
+                        Vector3::new(pred_x - obs.xy.x, pred_y - obs.xy.y, u_r_pred - obs.u_right);
+                    let s = r.x * r.x + r.y * r.y + r.z * r.z;
+                    let w = kernel.weight(s) * gnc_weights.map_or(1.0, |gw| gw[mono_count + k]);
+                    let mut j = Matrix3x4::<f64>::zeros();
+                    j[(0, 0)] = xc.x * zi;
+                    j[(0, 2)] = 1.0;
+                    j[(1, 1)] = xc.y * zi;
+                    j[(1, 3)] = 1.0;
+                    j[(2, 0)] = (xc.x - b) * zi;
+                    j[(2, 2)] = 1.0;
+                    h += w * (j.transpose() * j);
+                    g += w * (j.transpose() * r);
+                }
+            }
+
+            // Tikhonov-damped solve (the system is well-conditioned; the small
+            // ridge only guards against a degenerate all-frontal configuration).
+            let ridge = 1e-9 * h.diagonal().max().max(1.0);
+            let h_damped = h + Matrix4::<f64>::identity() * ridge;
+            let Some(delta) = h_damped.lu().solve(&(-g)) else {
+                break;
+            };
+            if !delta.iter().all(|x| x.is_finite()) {
+                break;
+            }
+            fx += delta[0];
+            fy += delta[1];
+            cx += delta[2];
+            cy += delta[3];
+            let step = delta.norm();
+            total_change += step;
+            if step < 1e-6 {
+                break;
+            }
+        }
+
+        self.camera.params[0] = fx;
+        self.camera.params[1] = fy;
+        self.camera.params[2] = cx;
+        self.camera.params[3] = cy;
+        total_change
     }
 
     /// Outlier-robust bundle adjustment via Graduated Non-Convexity (GNC).
@@ -1274,6 +1409,21 @@ pub struct BaConfig {
     /// number of bad correspondences cannot pull the solution away from
     /// the inlier consensus.
     pub robust_kernel: RobustKernel,
+    /// Also refine the shared pinhole intrinsics `(fx, fy, cx, cy)` by
+    /// **alternation**: after the pose+structure LM solve converges, the
+    /// intrinsics are updated by a small damped Gauss-Newton over every
+    /// reprojection residual (poses + landmarks held fixed), then the whole BA
+    /// is re-run with the new camera — repeated up to
+    /// `intrinsics_refinement_rounds` times. This is COLMAP's lever for the last
+    /// of the small-scene accuracy gap: a slightly-off fixed calibration forces a
+    /// residual onto the poses, and letting the camera absorb it tightens the
+    /// trajectory. Only the 4-parameter [`CameraModel::Pinhole`] is refined; for
+    /// any other model this is a no-op. **`false` by default** (the public
+    /// [`Self::optimize`] is then bit-identical to before).
+    pub refine_intrinsics: bool,
+    /// Max alternation rounds when `refine_intrinsics` is set; the loop also
+    /// stops early once the intrinsics update falls below a small threshold.
+    pub intrinsics_refinement_rounds: usize,
 }
 
 impl Default for BaConfig {
@@ -1289,6 +1439,8 @@ impl Default for BaConfig {
             cost_tolerance: 1e-9,
             linear_solver: LinearSolver::Dense,
             robust_kernel: RobustKernel::None,
+            refine_intrinsics: false,
+            intrinsics_refinement_rounds: 5,
         }
     }
 }

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -1419,7 +1419,7 @@ pub struct BaConfig {
     /// residual onto the poses, and letting the camera absorb it tightens the
     /// trajectory. Only the 4-parameter [`CameraModel::Pinhole`] is refined; for
     /// any other model this is a no-op. **`false` by default** (the public
-    /// [`Self::optimize`] is then bit-identical to before).
+    /// [`BundleAdjustment::optimize`] is then bit-identical to before).
     pub refine_intrinsics: bool,
     /// Max alternation rounds when `refine_intrinsics` is set; the loop also
     /// stops early once the intrinsics update falls below a small threshold.

--- a/pipelines/slam/src/incremental_sfm.rs
+++ b/pipelines/slam/src/incremental_sfm.rs
@@ -29,16 +29,21 @@
 //!    ([`crate::bundle`]). Monocular has a 7-DoF gauge (6 rigid + scale), so two
 //!    poses are fixed — the anchor and the longest-baseline pose — to pin scale
 //!    as well as the frame.
-//! 5. **Filter.** Post-BA, strip observations that reproject past the gate (a
-//!    contaminated union-find track) and drop tracks whose re-measured parallax
-//!    is below the gate (depth-ambiguous far-flung points), then re-optimise, a
-//!    few rounds. No image is ever un-posed, so registration is invariant.
+//! 5. **Filter (+ optional re-triangulate).** Post-BA, strip observations that
+//!    reproject past the gate (a contaminated union-find track) and drop tracks
+//!    whose re-measured parallax is below the gate (depth-ambiguous far-flung
+//!    points); optionally also **re-triangulate** against the BA-refined poses
+//!    (`retriangulate`, off by default) — completing tracks the narrow seed-time
+//!    baseline could not triangulate and re-seeding noisy points (guarded so an
+//!    already-better point is never regressed), a density lever for downstream
+//!    3DGS/NeRF — then re-optimise, a few rounds. No image is ever un-posed, so
+//!    registration is invariant.
 //!
 //! The output ([`IncrementalSfmResult`]) carries per-image poses (`None` for
 //! images that never registered) and merged multi-view tracks, ready for a
 //! COLMAP `points3D.txt` export and downstream 3DGS / NeRF training.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use nalgebra::{Point2, Point3, Vector3};
 use visloc_core::geometry::Pose;
@@ -109,6 +114,96 @@ pub struct IncrementalSfmConfig {
     /// and can never drop a registered camera; on a clean reconstruction it is
     /// a near-no-op. `0` disables it.
     pub track_filter_iterations: usize,
+    /// Re-triangulate tracks in each post-BA refinement round (COLMAP's
+    /// completeness/refinement step the single-pass growth lacks). Once a global
+    /// BA has moved the poses, two things change: a track that failed the
+    /// parallax gate at growth time (a narrow baseline *then*) can now triangulate
+    /// against the BA-refined wide-baseline views, and a point first triangulated
+    /// from a narrow seed-time baseline can be re-seeded from the current widest
+    /// pair. Completion is unconditional; the re-seed of an existing point is a
+    /// **guarded swap** — kept only if it lowers that track's mean reprojection —
+    /// so a multi-view point BA already placed better is never regressed. When
+    /// enabled, at least one post-BA refinement round always runs (even if
+    /// `track_filter_iterations` is `0`).
+    ///
+    /// **`false` by default.** Growth already triangulates greedily (every
+    /// un-triangulated track is retried after *every* registration against all
+    /// registered views), so by the end the structure is near-complete and the
+    /// post-BA pass only mops up the marginal, gate-grazing tracks. Measured on a
+    /// 300-frame EuRoC MH_03 monocular subset it adds ~3 % more tracks / ~1.5 %
+    /// more observations — useful **density** for a downstream 3DGS/NeRF model —
+    /// but is **ATE-neutral-to-slightly-negative** (Sim(3) 2.13 → 2.27 cm), since
+    /// the extra tracks are the weakly-constrained ones. Enable it when you want
+    /// the densest possible structure and can spend the extra BA rounds; leave it
+    /// off when trajectory accuracy is the goal. See
+    /// `docs/sfm_vs_colmap_benchmark.md`.
+    pub retriangulate: bool,
+    /// Use COLMAP's `IncrementalMapper` bundle-adjustment **schedule** instead of
+    /// the simple "global BA every `ba_every` registrations + final BA" path.
+    /// This is a faithful port of COLMAP's defaults — the lever that closes the
+    /// small-scene monocular accuracy gap on COLMAP's home turf:
+    ///
+    ///  - **Local BA after every registration.** Optimise only the new image and
+    ///    its most-covisible neighbours (`local_ba_num_images`) plus the points
+    ///    they see, holding the rest of the reconstruction fixed — cheap, and it
+    ///    keeps the freshly added geometry tight before drift can compound.
+    ///  - **Growth-triggered global refinement.** When the registered-image count
+    ///    has grown by `global_ba_images_ratio` since the last global solve, run
+    ///    an iterative global refinement: global BA → re-triangulate/complete →
+    ///    filter, looped until the changed-observation fraction falls below
+    ///    `global_ba_change_rate` (≤ `global_ba_max_refinements` rounds).
+    ///  - **Registration retries.** A PnP failure is not permanent; after a
+    ///    global refinement adds structure, failed images are retried, up to
+    ///    `max_registration_trials` attempts each — COLMAP registers every frame
+    ///    where the simple single-attempt path leaves a tail unregistered.
+    ///
+    /// The final refinement is always the iterative global form when this is on.
+    /// `false` by default (preserves the simple schedule and every existing test).
+    pub colmap_style_mapper: bool,
+    /// COLMAP `Mapper.ba_local_num_images`: how many most-covisible registered
+    /// images (besides the newly registered one) the per-registration local BA
+    /// optimises. Only used when `colmap_style_mapper` is set.
+    pub local_ba_num_images: usize,
+    /// COLMAP `Mapper.ba_global_images_ratio`: trigger a global refinement once
+    /// the registered-image count has grown by this factor since the last one.
+    /// Only used when `colmap_style_mapper` is set.
+    pub global_ba_images_ratio: f64,
+    /// COLMAP `Mapper.ba_global_max_refinements`: max global BA → complete →
+    /// filter rounds per global refinement. Only used when `colmap_style_mapper`.
+    pub global_ba_max_refinements: usize,
+    /// COLMAP `Mapper.ba_global_max_refinement_change_rate`: stop the global
+    /// refinement loop once `changed_observations / total_observations` drops
+    /// below this. Only used when `colmap_style_mapper` is set.
+    pub global_ba_change_rate: f64,
+    /// COLMAP `Mapper.max_reg_trials`: how many times a single image may be
+    /// retried for registration (across global-refinement boundaries) before it
+    /// is given up on. Only used when `colmap_style_mapper` is set.
+    pub max_registration_trials: usize,
+    /// Multi-view exemption to the `min_triangulation_angle_deg` gate. A point on
+    /// a forward-flying trajectory often subtends a parallax angle below the gate
+    /// yet is **well-constrained** when many views observe it (each view adds a
+    /// reprojection constraint on its 3 DoF). `None` keeps the strict angle gate
+    /// for every track (the simple path). `Some(n)` keeps — and triangulates — a
+    /// track whose widest parallax is between `low_parallax_min_angle_deg` and
+    /// `min_triangulation_angle_deg` **if it has ≥ n registered observations**, so
+    /// long low-parallax tracks survive while 2-view depth-ambiguous ones (which
+    /// would slide freely along their ray and corrupt the poses) are still
+    /// rejected. This is the lever that recovers COLMAP-grade structure density on
+    /// forward-motion video without the accuracy collapse a blanket low gate
+    /// causes. Used by both the simple and COLMAP-style paths when set.
+    pub low_parallax_min_observations: Option<usize>,
+    /// Lower parallax floor (degrees) for the multi-view exemption above: a track
+    /// below this angle is dropped regardless of how many views see it (truly
+    /// degenerate). Only consulted when `low_parallax_min_observations` is `Some`.
+    pub low_parallax_min_angle_deg: f64,
+    /// Refine the shared pinhole intrinsics `(fx, fy, cx, cy)` in the **final**
+    /// global refinement (alternating BA ↔ intrinsics, see
+    /// [`crate::BaConfig::refine_intrinsics`]). A slightly-off fixed calibration
+    /// forces a residual onto the poses; letting the camera absorb it is COLMAP's
+    /// lever for the last of the small-scene accuracy gap. Growth keeps the input
+    /// intrinsics fixed; the refined camera emerges from the final solve and is
+    /// returned in [`IncrementalSfmResult::refined_camera`]. `false` by default.
+    pub refine_intrinsics: bool,
 }
 
 /// Minimal PnP solver used to register a new image against the reconstruction.
@@ -142,6 +237,17 @@ impl Default for IncrementalSfmConfig {
             },
             pnp_solver: PnpSolver::default(),
             track_filter_iterations: 2,
+            retriangulate: false,
+            // COLMAP IncrementalMapper defaults (off unless colmap_style_mapper).
+            colmap_style_mapper: false,
+            local_ba_num_images: 8,
+            global_ba_images_ratio: 1.1,
+            global_ba_max_refinements: 5,
+            global_ba_change_rate: 0.0005,
+            max_registration_trials: 3,
+            low_parallax_min_observations: None,
+            low_parallax_min_angle_deg: 1.0,
+            refine_intrinsics: false,
         }
     }
 }
@@ -169,6 +275,11 @@ pub struct IncrementalSfmResult {
     pub mean_reprojection_px: f64,
     /// Result of the final BA solve, if one ran.
     pub ba_result: Option<BaResult>,
+    /// Refined camera intrinsics, when `config.refine_intrinsics` was set. The
+    /// poses, tracks, and `mean_reprojection_px` are all expressed against *this*
+    /// camera, so a COLMAP / 3DGS export must use it rather than the input camera.
+    /// `None` when intrinsics refinement was off.
+    pub refined_camera: Option<Camera>,
 }
 
 /// Why [`incremental_sfm`] could not build a reconstruction.
@@ -279,13 +390,20 @@ pub fn incremental_sfm(
     }
     let (_, mut poses, mut track_point) = best.ok_or(IncrementalSfmError::NoSeedPair)?;
 
-    // ---- 4. Final global bundle adjustment ----
-    let mut ba_result = if config.final_global_ba {
+    // ---- 4 + 5. Final refinement ----
+    // Growth used the fixed input intrinsics; the final solve may refine them
+    // (alternating BA ↔ intrinsics) into `cam`, which then expresses the output
+    // poses/tracks/reprojection and is returned to the caller for export.
+    let mut cam = camera.clone();
+    let ba_result = if config.colmap_style_mapper {
+        // COLMAP's final pass IS an iterative global refinement (global BA →
+        // complete/re-triangulate → filter, to convergence). The grow loop has
+        // already run local BAs + growth-triggered refinements throughout.
         Some(
-            run_bundle_adjustment(
-                camera,
+            iterative_global_refinement(
+                &mut cam,
                 features,
-                &tracks,
+                &mut tracks,
                 config,
                 &mut poses,
                 &mut track_point,
@@ -293,34 +411,67 @@ pub fn incremental_sfm(
             .map_err(IncrementalSfmError::Ba)?,
         )
     } else {
-        None
-    };
-
-    // ---- 5. Post-BA track refinement: drop contaminated observations, re-BA ----
-    for _ in 0..config.track_filter_iterations {
-        let removed = filter_outlier_observations(
-            camera,
-            features,
-            &mut tracks,
-            config,
-            &poses,
-            &mut track_point,
-        );
-        if removed == 0 {
-            break;
-        }
-        ba_result = Some(
-            run_bundle_adjustment(
-                camera,
+        // Simple schedule: one final global BA, then a few filter (+ optional
+        // re-triangulate) rounds. With re-triangulation on, run at least one
+        // round even when the filter budget is zero — the completion/re-seed pass
+        // is the point of the round.
+        let mut ba_result = if config.final_global_ba {
+            let (res, refined) = run_bundle_adjustment(
+                &cam,
                 features,
                 &tracks,
                 config,
                 &mut poses,
                 &mut track_point,
+                config.refine_intrinsics,
             )
-            .map_err(IncrementalSfmError::Ba)?,
-        );
-    }
+            .map_err(IncrementalSfmError::Ba)?;
+            if let Some(c) = refined {
+                cam = c;
+            }
+            Some(res)
+        } else {
+            None
+        };
+        let refine_rounds = if config.retriangulate {
+            config.track_filter_iterations.max(1)
+        } else {
+            config.track_filter_iterations
+        };
+        for _ in 0..refine_rounds {
+            let removed = filter_outlier_observations(
+                &cam,
+                features,
+                &mut tracks,
+                config,
+                &poses,
+                &mut track_point,
+            );
+            let retriangulated = if config.retriangulate {
+                retriangulate_tracks(&cam, features, &tracks, config, &poses, &mut track_point)
+            } else {
+                0
+            };
+            if removed == 0 && retriangulated == 0 {
+                break;
+            }
+            let (res, refined) = run_bundle_adjustment(
+                &cam,
+                features,
+                &tracks,
+                config,
+                &mut poses,
+                &mut track_point,
+                config.refine_intrinsics,
+            )
+            .map_err(IncrementalSfmError::Ba)?;
+            if let Some(c) = refined {
+                cam = c;
+            }
+            ba_result = Some(res);
+        }
+        ba_result
+    };
 
     // ---- Assemble output tracks (only triangulated, registered observations) ----
     let mut out_tracks = Vec::new();
@@ -337,7 +488,7 @@ pub fn incremental_sfm(
                 continue;
             };
             observations.push((image, kp, pixel));
-            if let Some(err) = reprojection_error_px(camera, pose, &position, &pixel) {
+            if let Some(err) = reprojection_error_px(&cam, pose, &position, &pixel) {
                 reproj_sum += err;
                 reproj_count += 1;
             }
@@ -363,6 +514,7 @@ pub fn incremental_sfm(
         registered_images,
         mean_reprojection_px,
         ba_result,
+        refined_camera: config.refine_intrinsics.then_some(cam),
     })
 }
 
@@ -505,7 +657,6 @@ fn place_seed_pair(
     poses: &mut [Option<Pose>],
 ) -> bool {
     let estimator = RelativePoseEstimator::default();
-    let min_cos = config.min_triangulation_angle_deg.to_radians().cos();
 
     // Build correspondences, keeping the (kp_i, kp_j) map aligned so a
     // relative-pose inlier index maps back to the right keypoints.
@@ -541,15 +692,7 @@ fn place_seed_pair(
     for &inl in &relative.inliers {
         let (px_i, px_j) = corr_kp[inl];
         let obs = [(pair.image_i, px_i), (pair.image_j, px_j)];
-        if triangulate_track(
-            camera,
-            poses,
-            &obs,
-            min_cos,
-            config.max_reprojection_error_px,
-        )
-        .is_some()
-        {
+        if triangulate_track(camera, poses, &obs, config).is_some() {
             well_triangulated += 1;
         }
     }
@@ -586,14 +729,31 @@ fn grow_from_seed(
     }
     triangulate_pending(camera, features, tracks, &poses, config, &mut track_point);
 
-    let mut failed: Vec<bool> = vec![false; n_images];
+    // `trials[i]` counts PnP attempts on image `i`. In the simple schedule one
+    // failed attempt is permanent (the cap is 1); the COLMAP schedule retries up
+    // to `max_registration_trials` across global-refinement boundaries.
+    let max_trials = if config.colmap_style_mapper {
+        config.max_registration_trials.max(1)
+    } else {
+        1
+    };
+    let mut trials: Vec<usize> = vec![0; n_images];
     let mut registrations_since_ba = 0usize;
+    // COLMAP triggers a global refinement once the registered-image count has
+    // grown by `global_ba_images_ratio` since the last one.
+    let mut reg_at_last_global = poses.iter().filter(|p| p.is_some()).count();
     loop {
-        let Some((next_image, corrs)) =
-            select_next_image(features, obs_by_image, &poses, &failed, &track_point)
-        else {
+        let Some((next_image, corrs)) = select_next_image(
+            features,
+            obs_by_image,
+            &poses,
+            &trials,
+            max_trials,
+            &track_point,
+        ) else {
             break;
         };
+        trials[next_image] += 1;
 
         // P3P (Grunert) is the default minimal solver — well-posed on coplanar
         // façades where the linear DLT degenerates. Both share the Gauss-Newton
@@ -615,25 +775,70 @@ fn grow_from_seed(
             }
             .estimate(&corrs, camera),
         };
-        match report {
-            Some(report) if report.inliers.len() >= config.min_pnp_inliers => {
-                poses[next_image] = Some(report.pose);
-                triangulate_pending(camera, features, tracks, &poses, config, &mut track_point);
-                registrations_since_ba += 1;
-                if config.ba_every > 0 && registrations_since_ba >= config.ba_every {
-                    run_bundle_adjustment(
-                        camera,
-                        features,
-                        tracks,
-                        config,
-                        &mut poses,
-                        &mut track_point,
-                    )
-                    .map_err(IncrementalSfmError::Ba)?;
-                    registrations_since_ba = 0;
+        let Some(report) = report.filter(|r| r.inliers.len() >= config.min_pnp_inliers) else {
+            continue; // registration failed this attempt (may be retried)
+        };
+        poses[next_image] = Some(report.pose);
+        triangulate_pending(camera, features, tracks, &poses, config, &mut track_point);
+
+        if config.colmap_style_mapper {
+            // COLMAP `AdjustLocalBundle`: tighten the new image + its covisible
+            // neighbourhood after every registration.
+            adjust_local_bundle(
+                camera,
+                features,
+                tracks,
+                config,
+                &mut poses,
+                &mut track_point,
+                next_image,
+            )
+            .map_err(IncrementalSfmError::Ba)?;
+
+            // Growth-ratio global refinement (COLMAP `IterativeGlobalRefinement`).
+            // During the seed search `tracks` is shared read-only across trials,
+            // so the in-growth refinement only re-triangulates + re-BAs (touching
+            // this trial's own poses/points); the track-membership *filter* that
+            // would mutate the shared tracks is deferred to the final refinement,
+            // after a seed has been committed. The BA's Huber kernel keeps
+            // outliers down-weighted in the meantime.
+            let n_reg = poses.iter().filter(|p| p.is_some()).count();
+            if n_reg as f64 >= reg_at_last_global as f64 * config.global_ba_images_ratio {
+                growth_global_refinement(
+                    camera,
+                    features,
+                    tracks,
+                    config,
+                    &mut poses,
+                    &mut track_point,
+                )
+                .map_err(IncrementalSfmError::Ba)?;
+                reg_at_last_global = n_reg;
+                // Structure changed — give previously-failed images a fresh shot
+                // by resetting their trial counters (COLMAP retries on change).
+                for (i, t) in trials.iter_mut().enumerate() {
+                    if poses[i].is_none() {
+                        *t = 0;
+                    }
                 }
             }
-            _ => failed[next_image] = true,
+        } else {
+            registrations_since_ba += 1;
+            if config.ba_every > 0 && registrations_since_ba >= config.ba_every {
+                // Growth never refines intrinsics (the camera is fixed until the
+                // final solve); the returned refined-camera slot is always None.
+                run_bundle_adjustment(
+                    camera,
+                    features,
+                    tracks,
+                    config,
+                    &mut poses,
+                    &mut track_point,
+                    false,
+                )
+                .map_err(IncrementalSfmError::Ba)?;
+                registrations_since_ba = 0;
+            }
         }
     }
 
@@ -651,7 +856,6 @@ fn triangulate_pending(
     config: &IncrementalSfmConfig,
     track_point: &mut [Option<Point3<f64>>],
 ) {
-    let min_cos = (config.min_triangulation_angle_deg.to_radians()).cos();
     for (track_id, track) in tracks.iter().enumerate() {
         if track_point[track_id].is_some() {
             continue;
@@ -669,15 +873,25 @@ fn triangulate_pending(
         if obs.len() < 2 {
             continue;
         }
-        if let Some(point) = triangulate_track(
-            camera,
-            poses,
-            &obs,
-            min_cos,
-            config.max_reprojection_error_px,
-        ) {
+        if let Some(point) = triangulate_track(camera, poses, &obs, config) {
             track_point[track_id] = Some(point);
         }
+    }
+}
+
+/// Whether a track's widest parallax `angle` (radians) clears the triangulation
+/// gate: the strict `min_triangulation_angle_deg`, or — with the multi-view
+/// exemption (`low_parallax_min_observations`) configured — the relaxed
+/// `low_parallax_min_angle_deg` floor once at least that many views observe it.
+fn parallax_angle_ok(angle: f64, num_obs: usize, config: &IncrementalSfmConfig) -> bool {
+    if angle >= config.min_triangulation_angle_deg.to_radians() {
+        return true;
+    }
+    match config.low_parallax_min_observations {
+        Some(min_obs) => {
+            num_obs >= min_obs && angle >= config.low_parallax_min_angle_deg.to_radians()
+        }
+        None => false,
     }
 }
 
@@ -688,9 +902,9 @@ fn triangulate_track(
     camera: &Camera,
     poses: &[Option<Pose>],
     obs: &[(usize, Point2<f64>)],
-    min_cos: f64,
-    max_reproj: f64,
+    config: &IncrementalSfmConfig,
 ) -> Option<Point3<f64>> {
+    let max_reproj = config.max_reprojection_error_px;
     // Precompute world-frame bearing rays for each observation.
     let mut rays: Vec<Vector3<f64>> = Vec::with_capacity(obs.len());
     for &(image, px) in obs {
@@ -711,7 +925,9 @@ fn triangulate_track(
         }
     }
     let (a, b, cos) = best?;
-    if cos > min_cos {
+    // Widest-pair parallax angle; accept on the strict gate or the multi-view
+    // exemption (a long low-parallax track is well-constrained by its many views).
+    if !parallax_angle_ok(cos.acos(), obs.len(), config) {
         return None; // insufficient parallax
     }
 
@@ -739,18 +955,20 @@ fn triangulate_track(
     Some(point_world)
 }
 
-/// Among unregistered, not-failed images, choose the one observing the most
-/// triangulated tracks, returning it with its 2D-3D correspondences.
+/// Among unregistered images still under the per-image trial cap, choose the one
+/// observing the most triangulated tracks, returning it with its 2D-3D
+/// correspondences.
 fn select_next_image(
     features: &[FeatureSet],
     obs_by_image: &[Vec<(usize, usize)>],
     poses: &[Option<Pose>],
-    failed: &[bool],
+    trials: &[usize],
+    max_trials: usize,
     track_point: &[Option<Point3<f64>>],
 ) -> Option<(usize, Vec<Correspondence2D3D>)> {
     let mut best: Option<(usize, Vec<Correspondence2D3D>)> = None;
     for (image, observations) in obs_by_image.iter().enumerate() {
-        if poses[image].is_some() || failed[image] {
+        if poses[image].is_some() || trials[image] >= max_trials {
             continue;
         }
         let mut corrs = Vec::new();
@@ -779,7 +997,10 @@ fn select_next_image(
 
 /// Global BA over all registered poses + triangulated landmarks. Seed pose
 /// (the lowest-index registered image) is fixed for gauge. Writes refined
-/// poses and points back in place.
+/// poses and points back in place. When `refine_intrinsics` is set, the BA also
+/// refines the pinhole intrinsics (alternating) and the refined camera is
+/// returned as `Some` (the caller propagates it); otherwise the second tuple
+/// element is `None` and the camera is untouched.
 fn run_bundle_adjustment(
     camera: &Camera,
     features: &[FeatureSet],
@@ -787,7 +1008,8 @@ fn run_bundle_adjustment(
     config: &IncrementalSfmConfig,
     poses: &mut [Option<Pose>],
     track_point: &mut [Option<Point3<f64>>],
-) -> Result<BaResult, BaError> {
+    refine_intrinsics: bool,
+) -> Result<(BaResult, Option<Camera>), BaError> {
     let mut ba = BundleAdjustment::new(camera.clone());
 
     for (image, pose) in poses.iter().enumerate() {
@@ -857,7 +1079,11 @@ fn run_bundle_adjustment(
         }
     }
 
-    let result = ba.optimize(&config.ba_config)?;
+    let ba_config = BaConfig {
+        refine_intrinsics,
+        ..config.ba_config
+    };
+    let result = ba.optimize(&ba_config)?;
 
     for (image, pose) in poses.iter_mut().enumerate() {
         if pose.is_some() {
@@ -873,7 +1099,306 @@ fn run_bundle_adjustment(
             }
         }
     }
+    let refined_camera = refine_intrinsics.then(|| ba.camera.clone());
+    Ok((result, refined_camera))
+}
+
+/// COLMAP `IncrementalMapper::AdjustLocalBundle`. After registering `new_image`,
+/// bundle-adjust only it and its `local_ba_num_images` most-covisible registered
+/// neighbours (sharing the most triangulated tracks) plus the points they see —
+/// every *other* registered image that observes one of those points is added as a
+/// **fixed** pose, so it constrains the local solve without being moved. This
+/// keeps the freshly grown geometry tight after every step at a fraction of a
+/// global solve's cost, the schedule that lets COLMAP hold sub-centimetre
+/// accuracy as the reconstruction grows. Poses/points outside the variable set
+/// are untouched.
+fn adjust_local_bundle(
+    camera: &Camera,
+    features: &[FeatureSet],
+    tracks: &[Vec<(usize, usize)>],
+    config: &IncrementalSfmConfig,
+    poses: &mut [Option<Pose>],
+    track_point: &mut [Option<Point3<f64>>],
+    new_image: usize,
+) -> Result<(), BaError> {
+    // Covisible registered images: how many triangulated tracks each shares with
+    // the newly registered one.
+    let mut covis: HashMap<usize, usize> = HashMap::new();
+    for (track_id, track) in tracks.iter().enumerate() {
+        if track_point[track_id].is_none() {
+            continue;
+        }
+        if !track
+            .iter()
+            .any(|&(img, _)| img == new_image && poses[img].is_some())
+        {
+            continue;
+        }
+        for &(img, _) in track {
+            if img != new_image && poses[img].is_some() {
+                *covis.entry(img).or_insert(0) += 1;
+            }
+        }
+    }
+    let mut neighbours: Vec<(usize, usize)> = covis.into_iter().collect();
+    // Most-covisible first; break ties by index for determinism.
+    neighbours.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    let mut variable: HashSet<usize> = neighbours
+        .into_iter()
+        .take(config.local_ba_num_images)
+        .map(|(img, _)| img)
+        .collect();
+    variable.insert(new_image);
+
+    bundle_adjust_local(
+        camera,
+        features,
+        tracks,
+        config,
+        poses,
+        track_point,
+        &variable,
+    )
+}
+
+/// Bundle-adjust a chosen `variable` set of poses plus every triangulated track
+/// they observe. Other registered images observing those tracks join as fixed
+/// poses (constraints). The gauge: with ≥2 fixed observers their baseline pins
+/// the 7-DoF monocular gauge for free; otherwise (an early, loosely connected
+/// neighbourhood) the variable set's own anchor + farthest pose are fixed, as in
+/// the global solve. Only variable poses and the solved landmarks are written back.
+fn bundle_adjust_local(
+    camera: &Camera,
+    features: &[FeatureSet],
+    tracks: &[Vec<(usize, usize)>],
+    config: &IncrementalSfmConfig,
+    poses: &mut [Option<Pose>],
+    track_point: &mut [Option<Point3<f64>>],
+    variable: &HashSet<usize>,
+) -> Result<(), BaError> {
+    let mut ba = BundleAdjustment::new(camera.clone());
+
+    // Landmarks touching ≥1 variable image, and the images that participate.
+    let mut used: HashSet<usize> = HashSet::new();
+    let mut lm_ids: Vec<usize> = Vec::new();
+    for (track_id, track) in tracks.iter().enumerate() {
+        if track_point[track_id].is_none() {
+            continue;
+        }
+        let mut obs_images: Vec<usize> = Vec::new();
+        let mut touches_variable = false;
+        for &(image, kp) in track {
+            if poses[image].is_none() {
+                continue;
+            }
+            if features[image].keypoints.get(kp).is_none() {
+                continue;
+            }
+            obs_images.push(image);
+            if variable.contains(&image) {
+                touches_variable = true;
+            }
+        }
+        if obs_images.len() < 2 || !touches_variable {
+            continue;
+        }
+        for image in obs_images {
+            used.insert(image);
+        }
+        lm_ids.push(track_id);
+    }
+    if lm_ids.is_empty() {
+        return Ok(());
+    }
+
+    for &image in &used {
+        ba.add_pose(image as u64, poses[image].clone().unwrap());
+        if !variable.contains(&image) {
+            ba.fix_pose(image as u64);
+        }
+    }
+
+    // Need ≥2 fixed poses to pin metric scale; otherwise fix the variable gauge.
+    let n_fixed = used.iter().filter(|i| !variable.contains(i)).count();
+    if n_fixed < 2 {
+        let var_used: Vec<usize> = used
+            .iter()
+            .copied()
+            .filter(|i| variable.contains(i))
+            .collect();
+        fix_monocular_scale_gauge(&mut ba, poses, &var_used);
+    }
+
+    for &track_id in &lm_ids {
+        ba.add_landmark(track_id as u64, track_point[track_id].unwrap());
+        for &(image, kp) in &tracks[track_id] {
+            if poses[image].is_none() {
+                continue;
+            }
+            if let Some(px) = features[image].keypoints.get(kp).copied() {
+                ba.add_observation(BaObservation {
+                    keyframe_id: image as u64,
+                    landmark_id: track_id as u64,
+                    xy: px,
+                });
+            }
+        }
+    }
+
+    ba.optimize(&config.ba_config)?;
+
+    for &image in &used {
+        if variable.contains(&image) {
+            if let Some(refined) = ba.poses.get(&(image as u64)) {
+                poses[image] = Some(refined.clone());
+            }
+        }
+    }
+    for &track_id in &lm_ids {
+        if let Some(refined) = ba.landmarks.get(&(track_id as u64)) {
+            track_point[track_id] = Some(*refined);
+        }
+    }
+    Ok(())
+}
+
+/// Pin the 7-DoF monocular gauge (6 rigid + scale) by fixing two of `candidates`:
+/// the lowest-index pose (rigid anchor) and the one farthest from it (the scale
+/// anchor — longest, best-conditioned baseline). Mirrors the global solve's gauge
+/// handling; used by a local solve that lacks two fixed-observer poses of its own.
+fn fix_monocular_scale_gauge(
+    ba: &mut BundleAdjustment,
+    poses: &[Option<Pose>],
+    candidates: &[usize],
+) {
+    let Some(&anchor) = candidates.iter().min() else {
+        return;
+    };
+    ba.fix_pose(anchor as u64);
+    let anchor_center = poses[anchor]
+        .as_ref()
+        .unwrap()
+        .camera_to_world()
+        .translation;
+    let mut farthest = None;
+    let mut best_d2 = 0.0;
+    for &image in candidates {
+        if image == anchor {
+            continue;
+        }
+        let d2 = (poses[image].as_ref().unwrap().camera_to_world().translation - anchor_center)
+            .norm_squared();
+        if d2 > best_d2 {
+            best_d2 = d2;
+            farthest = Some(image);
+        }
+    }
+    if let Some(scale_anchor) = farthest {
+        ba.fix_pose(scale_anchor as u64);
+    }
+}
+
+/// COLMAP `IncrementalMapper::IterativeGlobalRefinement`: a global BA, then a loop
+/// of {re-triangulate/complete tracks, filter outliers, global BA} until the
+/// changed-observation fraction falls below `global_ba_change_rate` (or
+/// `global_ba_max_refinements` rounds run). Re-triangulation is forced on here
+/// regardless of `config.retriangulate` — completing tracks between global solves
+/// is integral to COLMAP's schedule, not the opt-in density lever of the simple
+/// path.
+fn iterative_global_refinement(
+    camera: &mut Camera,
+    features: &[FeatureSet],
+    tracks: &mut [Vec<(usize, usize)>],
+    config: &IncrementalSfmConfig,
+    poses: &mut [Option<Pose>],
+    track_point: &mut [Option<Point3<f64>>],
+) -> Result<BaResult, BaError> {
+    // Refine intrinsics on each global solve when enabled; the refined camera is
+    // carried forward so the next round's filter / re-triangulation / BA all use
+    // it (and the caller reads the final camera back from `*camera`).
+    let refine = config.refine_intrinsics;
+    let run_ba = |cam: &mut Camera,
+                  tr: &[Vec<(usize, usize)>],
+                  p: &mut [Option<Pose>],
+                  tp: &mut [Option<Point3<f64>>]|
+     -> Result<BaResult, BaError> {
+        let (res, refined) = run_bundle_adjustment(cam, features, tr, config, p, tp, refine)?;
+        if let Some(c) = refined {
+            *cam = c;
+        }
+        Ok(res)
+    };
+
+    let mut result = run_ba(camera, tracks, poses, track_point)?;
+    for _ in 0..config.global_ba_max_refinements {
+        let total_obs = count_observations(tracks, poses, track_point).max(1);
+        // Filter outlier observations, then complete/re-triangulate tracks the
+        // tightened frame can now place. Completing between solves is integral to
+        // the schedule — it gives the next global BA more constraints and, on this
+        // metric video, measurably beats filter-only (1.64 cm vs 2.21 cm); the
+        // forward-motion low-parallax churn it induces against the filter is the
+        // price, and the track-density ceiling it leaves is the next lever.
+        let mut changed =
+            filter_outlier_observations(camera, features, tracks, config, poses, track_point);
+        changed += retriangulate_tracks(camera, features, tracks, config, poses, track_point);
+        if (changed as f64 / total_obs as f64) < config.global_ba_change_rate {
+            break;
+        }
+        result = run_ba(camera, tracks, poses, track_point)?;
+    }
     Ok(result)
+}
+
+/// In-growth global refinement, used during the seed search where `tracks` is
+/// shared read-only across trials: global BA, then up to a couple rounds of
+/// {re-triangulate/complete, global BA} while it keeps completing tracks. The
+/// completion is what keeps registration moving — a freshly tightened global
+/// frame lets [`retriangulate_tracks`] triangulate tracks the narrow growth-time
+/// baseline had missed, and those new 3D points give the next PnP enough
+/// 2D-3D matches to register (without it, registration stalls well short of full
+/// coverage and the trajectory develops ATE-wrecking gaps). The track-membership
+/// *filter* (which would mutate the shared tracks) is deferred to the final
+/// [`iterative_global_refinement`] after a seed is committed.
+fn growth_global_refinement(
+    camera: &Camera,
+    features: &[FeatureSet],
+    tracks: &[Vec<(usize, usize)>],
+    config: &IncrementalSfmConfig,
+    poses: &mut [Option<Pose>],
+    track_point: &mut [Option<Point3<f64>>],
+) -> Result<(), BaError> {
+    // Growth keeps the input intrinsics fixed (refine = false), so the returned
+    // refined-camera slot is always None and is ignored.
+    run_bundle_adjustment(camera, features, tracks, config, poses, track_point, false)?;
+    for _ in 0..config.global_ba_max_refinements.min(2) {
+        let changed = retriangulate_tracks(camera, features, tracks, config, poses, track_point);
+        if changed == 0 {
+            break;
+        }
+        run_bundle_adjustment(camera, features, tracks, config, poses, track_point, false)?;
+    }
+    Ok(())
+}
+
+/// Total triangulated observations: for every track with a 3D point, the number
+/// of its registered observations. The denominator for the refinement-loop
+/// change-rate stop test.
+fn count_observations(
+    tracks: &[Vec<(usize, usize)>],
+    poses: &[Option<Pose>],
+    track_point: &[Option<Point3<f64>>],
+) -> usize {
+    let mut n = 0usize;
+    for (track_id, track) in tracks.iter().enumerate() {
+        if track_point[track_id].is_none() {
+            continue;
+        }
+        n += track
+            .iter()
+            .filter(|&&(img, _)| poses[img].is_some())
+            .count();
+    }
+    n
 }
 
 /// Clean every triangulated track after the current BA, on two grounds:
@@ -904,7 +1429,6 @@ fn filter_outlier_observations(
 ) -> usize {
     let threshold = config.max_reprojection_error_px;
     let min_obs = config.min_track_length.max(2);
-    let min_angle = config.min_triangulation_angle_deg.to_radians();
     let mut changed = 0usize;
 
     for (track_id, track) in tracks.iter_mut().enumerate() {
@@ -937,10 +1461,91 @@ fn filter_outlier_observations(
             continue;
         }
 
-        if track_max_parallax(poses, track, &point) < min_angle
+        // Drop a low-parallax track unless the multi-view exemption keeps it: a
+        // long forward-motion track below the strict angle but seen by many views
+        // is well-constrained, while a 2-view depth-ambiguous one is not.
+        if !parallax_angle_ok(track_max_parallax(poses, track, &point), posed_obs, config)
             && track_point[track_id].take().is_some()
         {
             changed += 1;
+        }
+    }
+    changed
+}
+
+/// Re-triangulate tracks after a bundle adjustment has moved the poses — the
+/// COLMAP completeness/refinement step the single-pass growth lacks. For each
+/// track with ≥2 registered observations, triangulate a fresh point from the
+/// current widest-parallax view pair ([`triangulate_track`], so it still passes
+/// the parallax + reprojection gates) and either:
+///
+///  1. **Complete** an un-triangulated track. At growth time its registered
+///     views were a narrow baseline and the parallax gate rejected it; the
+///     BA-refined geometry (more views registered, wider baselines) can now place
+///     it. The new point constrains the next BA.
+///  2. **Re-seed** an existing point, but only as a **guarded swap**: keep the
+///     re-triangulation only if it lowers the track's mean reprojection over its
+///     registered observations. A point a multi-view BA already placed better is
+///     never regressed, so the step is monotone per track.
+///
+/// Poses are read-only here; the caller re-runs the BA afterwards. Returns how
+/// many tracks gained or improved a point (zero ⇒ nothing changed, converged).
+fn retriangulate_tracks(
+    camera: &Camera,
+    features: &[FeatureSet],
+    tracks: &[Vec<(usize, usize)>],
+    config: &IncrementalSfmConfig,
+    poses: &[Option<Pose>],
+    track_point: &mut [Option<Point3<f64>>],
+) -> usize {
+    let mut changed = 0usize;
+
+    for (track_id, track) in tracks.iter().enumerate() {
+        // Registered observations of this track: (image, pixel).
+        let mut obs: Vec<(usize, Point2<f64>)> = Vec::new();
+        for &(image, kp) in track {
+            if poses[image].is_none() {
+                continue;
+            }
+            if let Some(px) = features[image].keypoints.get(kp).copied() {
+                obs.push((image, px));
+            }
+        }
+        if obs.len() < 2 {
+            continue;
+        }
+        let Some(candidate) = triangulate_track(camera, poses, &obs, config) else {
+            continue;
+        };
+
+        match track_point[track_id] {
+            None => {
+                track_point[track_id] = Some(candidate);
+                changed += 1;
+            }
+            Some(current) => {
+                // Mean reprojection of a point over this track's registered obs.
+                let mean_reproj = |p: &Point3<f64>| -> f64 {
+                    let mut sum = 0.0;
+                    let mut n = 0usize;
+                    for &(image, px) in &obs {
+                        let Some(pose) = &poses[image] else { continue };
+                        if let Some(err) = reprojection_error_px(camera, pose, p, &px) {
+                            sum += err;
+                            n += 1;
+                        }
+                    }
+                    if n > 0 {
+                        sum / n as f64
+                    } else {
+                        f64::INFINITY
+                    }
+                };
+                if mean_reproj(&candidate) + 1e-9 < mean_reproj(&current) {
+                    track_point[track_id] = Some(candidate);
+                    changed += 1;
+                }
+            }
         }
     }
     changed
@@ -1428,6 +2033,145 @@ mod tests {
         assert!(
             track_point[0].is_none(),
             "track with < 2 inlier observations is dropped"
+        );
+    }
+
+    #[test]
+    fn retriangulate_completes_untriangulated_track() {
+        // Three identity-rotation views with a real lateral baseline see one
+        // world point. The track exists in the union-find but was never given a
+        // 3D point (it failed the parallax gate at growth time, say). With the
+        // poses now fixed, re-triangulation must complete it.
+        let camera = Camera::pinhole(0, 640, 480, 500.0, 500.0, 320.0, 240.0);
+        let point = Point3::new(0.1, -0.2, 5.0);
+        let mut features = Vec::new();
+        let mut poses = Vec::new();
+        for k in 0..3 {
+            let pose = Pose::from_world_to_camera(
+                UnitQuaternion::identity(),
+                Vector3::new(k as f64 * 0.5 - 0.5, 0.0, 0.0),
+            );
+            let px = camera.project(&pose.transform_world_point(&point)).unwrap();
+            features.push(FeatureSet::new(vec![px], vec![vec![k as f32, 1.0]]).unwrap());
+            poses.push(Some(pose));
+        }
+        let tracks = vec![vec![(0, 0), (1, 0), (2, 0)]];
+        let mut track_point: Vec<Option<Point3<f64>>> = vec![None]; // not yet triangulated
+        let config = IncrementalSfmConfig::default();
+        let changed = retriangulate_tracks(
+            &camera,
+            &features,
+            &tracks,
+            &config,
+            &poses,
+            &mut track_point,
+        );
+        assert_eq!(changed, 1, "the un-triangulated track is completed");
+        let p = track_point[0].expect("track now has a 3D point");
+        assert!(
+            (p - point).norm() < 1e-6,
+            "re-triangulated point {p:?} should recover the true point {point:?}"
+        );
+    }
+
+    #[test]
+    fn retriangulate_guarded_swap_replaces_noisy_point_only_when_better() {
+        // Same three-view geometry, but the track already carries a *noisy* point
+        // displaced far along the depth ray. Re-triangulation from the true
+        // observations fits them better, so the guarded swap must replace it; a
+        // second pass (now exact) must be a no-op (never regress an exact point).
+        let camera = Camera::pinhole(0, 640, 480, 500.0, 500.0, 320.0, 240.0);
+        let point = Point3::new(0.1, -0.2, 5.0);
+        let mut features = Vec::new();
+        let mut poses = Vec::new();
+        for k in 0..3 {
+            let pose = Pose::from_world_to_camera(
+                UnitQuaternion::identity(),
+                Vector3::new(k as f64 * 0.5 - 0.5, 0.0, 0.0),
+            );
+            let px = camera.project(&pose.transform_world_point(&point)).unwrap();
+            features.push(FeatureSet::new(vec![px], vec![vec![k as f32, 1.0]]).unwrap());
+            poses.push(Some(pose));
+        }
+        let tracks = vec![vec![(0, 0), (1, 0), (2, 0)]];
+        let noisy = Point3::new(0.3, -0.6, 8.0);
+        let mut track_point = vec![Some(noisy)];
+        let config = IncrementalSfmConfig::default();
+
+        let changed = retriangulate_tracks(
+            &camera,
+            &features,
+            &tracks,
+            &config,
+            &poses,
+            &mut track_point,
+        );
+        assert_eq!(changed, 1, "the noisy point is replaced by a better fit");
+        let p = track_point[0].unwrap();
+        assert!(
+            (p - point).norm() < 1e-6,
+            "guarded swap should land on the true point, got {p:?}"
+        );
+
+        // Re-running on the now-exact point changes nothing.
+        let again = retriangulate_tracks(
+            &camera,
+            &features,
+            &tracks,
+            &config,
+            &poses,
+            &mut track_point,
+        );
+        assert_eq!(again, 0, "an already-exact point must not be regressed");
+    }
+
+    #[test]
+    fn colmap_style_mapper_reconstructs_ring_scene() {
+        // The COLMAP schedule (per-registration local BA + growth-triggered
+        // iterative global refinement + registration retries) must reconstruct the
+        // synthetic ring at least as completely as the simple schedule, with tight
+        // reprojection and a similarity-correct camera geometry.
+        let scene = build_scene();
+        let (features, pairwise) = render(&scene);
+        let config = IncrementalSfmConfig {
+            min_seed_matches: 8,
+            min_pnp_inliers: 6,
+            colmap_style_mapper: true,
+            ..IncrementalSfmConfig::default()
+        };
+        let result = incremental_sfm(&scene.camera, &features, &pairwise, &config).unwrap();
+        assert!(
+            result.registered_images >= 5,
+            "registered only {}",
+            result.registered_images
+        );
+        assert!(
+            result.tracks.len() >= 20,
+            "triangulated only {} tracks",
+            result.tracks.len()
+        );
+        assert!(
+            result.mean_reprojection_px < 1.0,
+            "mean reprojection {} px too high",
+            result.mean_reprojection_px
+        );
+        let registered: Vec<usize> = (0..scene.poses.len())
+            .filter(|&i| result.poses[i].is_some())
+            .collect();
+        let center = |i: usize| {
+            result.poses[i]
+                .as_ref()
+                .unwrap()
+                .camera_to_world()
+                .translation
+        };
+        let gt_center = |i: usize| scene.poses[i].camera_to_world().translation;
+        let (a, b, c) = (registered[0], registered[1], registered[2]);
+        let est_ratio = (center(a) - center(b)).norm() / (center(b) - center(c)).norm();
+        let gt_ratio = (gt_center(a) - gt_center(b)).norm() / (gt_center(b) - gt_center(c)).norm();
+        assert!(
+            (est_ratio - gt_ratio).abs() / gt_ratio < 0.1,
+            "camera-spacing ratio {est_ratio} != GT {gt_ratio} (similarity-invariant)"
         );
     }
 

--- a/pipelines/slam/src/incremental_sfm.rs
+++ b/pipelines/slam/src/incremental_sfm.rs
@@ -311,7 +311,7 @@ impl std::error::Error for IncrementalSfmError {}
 
 /// A grown reconstruction the seed search compares: how many images it
 /// registered, the per-image poses and the per-track points.
-type SeedGrowth = (usize, Vec<Option<Pose>>, Vec<Option<Point3<f64>>>);
+type SeedGrowth = (usize, Vec<Option<Pose>>, Vec<Option<Point3<f64>>>, Camera);
 
 /// Run incremental SfM over an unordered image set.
 ///
@@ -366,7 +366,7 @@ pub fn incremental_sfm(
     let mut best: Option<SeedGrowth> = None;
     let mut grows = 0usize;
     for &pi in &seed_order {
-        let (trial_poses, trial_points, reach) = grow_from_seed(
+        let (trial_poses, trial_points, reach, trial_cam) = grow_from_seed(
             camera,
             features,
             &tracks,
@@ -380,21 +380,23 @@ pub fn incremental_sfm(
         grows += 1;
         if best
             .as_ref()
-            .is_none_or(|(best_reach, _, _)| reach > *best_reach)
+            .is_none_or(|(best_reach, _, _, _)| reach > *best_reach)
         {
-            best = Some((reach, trial_poses, trial_points));
+            best = Some((reach, trial_poses, trial_points, trial_cam));
         }
         if reach >= not_trapped || grows >= trials {
             break;
         }
     }
-    let (_, mut poses, mut track_point) = best.ok_or(IncrementalSfmError::NoSeedPair)?;
+    let (_, mut poses, mut track_point, grown_cam) = best.ok_or(IncrementalSfmError::NoSeedPair)?;
 
     // ---- 4 + 5. Final refinement ----
-    // Growth used the fixed input intrinsics; the final solve may refine them
-    // (alternating BA ↔ intrinsics) into `cam`, which then expresses the output
-    // poses/tracks/reprojection and is returned to the caller for export.
-    let mut cam = camera.clone();
+    // When intrinsics refinement is on, growth already co-evolved them into
+    // `grown_cam` (COLMAP keeps the camera moving with the structure so a wrong
+    // focal cannot be silently absorbed). The final solve continues refining from
+    // there; `cam` expresses the output poses/tracks/reprojection and is returned
+    // to the caller for export.
+    let mut cam = grown_cam;
     let ba_result = if config.colmap_style_mapper {
         // COLMAP's final pass IS an iterative global refinement (global BA →
         // complete/re-triangulate → filter, to convergence). The grow loop has
@@ -719,15 +721,19 @@ fn grow_from_seed(
     obs_by_image: &[Vec<(usize, usize)>],
     config: &IncrementalSfmConfig,
     seed_pair: &PairwiseMatches,
-) -> Result<(Vec<Option<Pose>>, Vec<Option<Point3<f64>>>, usize), IncrementalSfmError> {
+) -> Result<(Vec<Option<Pose>>, Vec<Option<Point3<f64>>>, usize, Camera), IncrementalSfmError> {
     let n_images = features.len();
     let mut poses: Vec<Option<Pose>> = vec![None; n_images];
     let mut track_point: Vec<Option<Point3<f64>>> = vec![None; tracks.len()];
 
-    if !place_seed_pair(camera, features, seed_pair, config, &mut poses) {
-        return Ok((poses, track_point, 0));
+    // Per-trial camera clone: the seed search grows several reconstructions over
+    // the same shared `tracks`, so each trial co-evolves intrinsics on its own
+    // copy (no cross-trial contamination). The winning trial's camera is returned.
+    let mut cam = camera.clone();
+    if !place_seed_pair(&cam, features, seed_pair, config, &mut poses) {
+        return Ok((poses, track_point, 0, cam));
     }
-    triangulate_pending(camera, features, tracks, &poses, config, &mut track_point);
+    triangulate_pending(&cam, features, tracks, &poses, config, &mut track_point);
 
     // `trials[i]` counts PnP attempts on image `i`. In the simple schedule one
     // failed attempt is permanent (the cap is 1); the COLMAP schedule retries up
@@ -768,24 +774,24 @@ fn grow_from_seed(
                 early_stop_min_iterations: 0,
                 early_stop_inlier_ratio: None,
             }
-            .estimate(&corrs, camera),
+            .estimate(&corrs, &cam),
             PnpSolver::Dlt => PnPRansac {
                 reprojection_threshold: config.max_reprojection_error_px,
                 ..PnPRansac::default()
             }
-            .estimate(&corrs, camera),
+            .estimate(&corrs, &cam),
         };
         let Some(report) = report.filter(|r| r.inliers.len() >= config.min_pnp_inliers) else {
             continue; // registration failed this attempt (may be retried)
         };
         poses[next_image] = Some(report.pose);
-        triangulate_pending(camera, features, tracks, &poses, config, &mut track_point);
+        triangulate_pending(&cam, features, tracks, &poses, config, &mut track_point);
 
         if config.colmap_style_mapper {
             // COLMAP `AdjustLocalBundle`: tighten the new image + its covisible
             // neighbourhood after every registration.
             adjust_local_bundle(
-                camera,
+                &cam,
                 features,
                 tracks,
                 config,
@@ -805,7 +811,7 @@ fn grow_from_seed(
             let n_reg = poses.iter().filter(|p| p.is_some()).count();
             if n_reg as f64 >= reg_at_last_global as f64 * config.global_ba_images_ratio {
                 growth_global_refinement(
-                    camera,
+                    &mut cam,
                     features,
                     tracks,
                     config,
@@ -825,10 +831,10 @@ fn grow_from_seed(
         } else {
             registrations_since_ba += 1;
             if config.ba_every > 0 && registrations_since_ba >= config.ba_every {
-                // Growth never refines intrinsics (the camera is fixed until the
-                // final solve); the returned refined-camera slot is always None.
+                // The simple schedule keeps intrinsics fixed during growth (refine
+                // is a colmap-style / final-solve concern); refined slot is None.
                 run_bundle_adjustment(
-                    camera,
+                    &cam,
                     features,
                     tracks,
                     config,
@@ -843,7 +849,7 @@ fn grow_from_seed(
     }
 
     let registered = poses.iter().filter(|p| p.is_some()).count();
-    Ok((poses, track_point, registered))
+    Ok((poses, track_point, registered, cam))
 }
 
 /// Triangulate every track that has ≥2 registered observations and is not yet
@@ -1360,22 +1366,38 @@ fn iterative_global_refinement(
 /// *filter* (which would mutate the shared tracks) is deferred to the final
 /// [`iterative_global_refinement`] after a seed is committed.
 fn growth_global_refinement(
-    camera: &Camera,
+    camera: &mut Camera,
     features: &[FeatureSet],
     tracks: &[Vec<(usize, usize)>],
     config: &IncrementalSfmConfig,
     poses: &mut [Option<Pose>],
     track_point: &mut [Option<Point3<f64>>],
 ) -> Result<(), BaError> {
-    // Growth keeps the input intrinsics fixed (refine = false), so the returned
-    // refined-camera slot is always None and is ignored.
-    run_bundle_adjustment(camera, features, tracks, config, poses, track_point, false)?;
+    // When intrinsics refinement is on, co-evolve them in these periodic global
+    // passes (COLMAP's IterativeGlobalRefinement keeps the camera moving with the
+    // structure, so a wrong focal is corrected while the model is still small
+    // enough to expose it — the well-conditioned global solve, not the narrow
+    // per-registration local one, is where the focal is observable). Otherwise the
+    // intrinsics stay fixed and the refined slot is always None.
+    let refine = config.refine_intrinsics;
+    let run_global = |cam: &mut Camera,
+                      p: &mut [Option<Pose>],
+                      tp: &mut [Option<Point3<f64>>]|
+     -> Result<(), BaError> {
+        let (_, refined) = run_bundle_adjustment(cam, features, tracks, config, p, tp, refine)?;
+        if let Some(c) = refined {
+            *cam = c;
+        }
+        Ok(())
+    };
+
+    run_global(camera, poses, track_point)?;
     for _ in 0..config.global_ba_max_refinements.min(2) {
         let changed = retriangulate_tracks(camera, features, tracks, config, poses, track_point);
         if changed == 0 {
             break;
         }
-        run_bundle_adjustment(camera, features, tracks, config, poses, track_point, false)?;
+        run_global(camera, poses, track_point)?;
     }
     Ok(())
 }
@@ -2173,6 +2195,50 @@ mod tests {
             (est_ratio - gt_ratio).abs() / gt_ratio < 0.1,
             "camera-spacing ratio {est_ratio} != GT {gt_ratio} (similarity-invariant)"
         );
+    }
+
+    #[test]
+    fn colmap_style_co_evolves_intrinsics_toward_truth() {
+        // The synthetic ring is observable geometry, so a focal error is
+        // recoverable. Render with the TRUE camera (fx=fy=500) but reconstruct from
+        // a WRONG horizontal focal (fx=530). The arc moves the cameras only in the
+        // x-z plane, so the *horizontal* focal fx is well constrained by the
+        // azimuthal parallax (fy would need elevation change — exercised instead by
+        // the anisotropic South-Building benchmark). With intrinsics co-evolution on,
+        // the COLMAP-style growth schedule must pull fx back toward 500 (the
+        // final-only alternating refinement can't — converged structure absorbs the
+        // error before the intrinsics step sees it), while leaving the un-perturbed
+        // fy and principal point essentially fixed (no spurious drift).
+        let scene = build_scene();
+        let (features, pairwise) = render(&scene);
+        let wrong = Camera::pinhole(0, 640, 480, 530.0, 500.0, 320.0, 240.0);
+        let config = IncrementalSfmConfig {
+            min_seed_matches: 8,
+            min_pnp_inliers: 6,
+            colmap_style_mapper: true,
+            refine_intrinsics: true,
+            ..IncrementalSfmConfig::default()
+        };
+        let result = incremental_sfm(&wrong, &features, &pairwise, &config).unwrap();
+        let cam = result
+            .refined_camera
+            .expect("refine_intrinsics returns the refined camera");
+        let (fx, fy, cx, cy) = cam.intrinsics().unwrap();
+        eprintln!("co-evolved intrinsics: fx {fx} fy {fy} cx {cx} cy {cy}");
+        // fx moves down from 530 toward 500 — directional recovery is the claim (the
+        // final-only alternating refinement can't move at all once converged
+        // structure absorbs the error). The magnitude scales with the number of
+        // growth global passes, i.e. image count: a clear move on this 6-camera ring,
+        // ~25% of the injected error on the 128-image South-Building benchmark.
+        assert!(
+            fx < 530.0 - 1.0,
+            "fx {fx} should recover toward 500 from 530"
+        );
+        // The un-perturbed parameters must not drift: fy within ~2 of 500, and the
+        // principal point within ~2 px of (320, 240).
+        assert!((fy - 500.0).abs() < 2.0, "fy {fy} drifted from 500");
+        assert!((cx - 320.0).abs() < 2.0, "cx {cx} drifted from 320");
+        assert!((cy - 240.0).abs() < 2.0, "cy {cy} drifted from 240");
     }
 
     #[test]

--- a/pipelines/slam/tests/bundle_adjustment.rs
+++ b/pipelines/slam/tests/bundle_adjustment.rs
@@ -71,6 +71,64 @@ fn truth_bundle() -> BundleAdjustment {
 }
 
 #[test]
+fn refine_intrinsics_recovers_perturbed_focal_length() {
+    // Exact observations are generated with the true camera (fx = fy = 500).
+    // Start the BA from a wrong focal length and let alternating intrinsics
+    // refinement pull it back, the COLMAP small-scene-accuracy lever.
+    let mut ba = truth_bundle();
+    // Perturb the intrinsics the solver starts from (truth is 500/500/320/240).
+    ba.camera = Camera::pinhole(1, 640, 480, 520.0, 515.0, 326.0, 233.0);
+    // Fix two poses and all landmarks so the wrong focal length cannot be absorbed
+    // into structure — on this tiny 3-camera scene a free point cloud would soak
+    // up the fx error (the focal/depth ambiguity), leaving nothing for the
+    // intrinsics step to correct. Pinning the structure makes fx observable, which
+    // is exactly what a large many-view reconstruction does for free.
+    ba.fix_pose(10);
+    ba.fix_pose(20);
+    for (id, _) in world_grid() {
+        ba.fix_landmark(id);
+    }
+
+    let cost_before = ba.cost();
+    let config = BaConfig {
+        refine_intrinsics: true,
+        ..BaConfig::default()
+    };
+    ba.optimize(&config).expect("BA with intrinsics refinement");
+
+    let (fx, fy, cx, cy) = ba.camera.intrinsics().unwrap();
+    assert!(
+        (fx - 500.0).abs() < 0.5 && (fy - 500.0).abs() < 0.5,
+        "focal length not recovered: fx={fx}, fy={fy} (truth 500)"
+    );
+    assert!(
+        (cx - 320.0).abs() < 0.5 && (cy - 240.0).abs() < 0.5,
+        "principal point not recovered: cx={cx}, cy={cy} (truth 320/240)"
+    );
+    assert!(
+        ba.cost() < 0.1 && ba.cost() < cost_before,
+        "cost must collapse once the camera is recovered: {} (was {cost_before})",
+        ba.cost()
+    );
+}
+
+#[test]
+fn refine_intrinsics_is_noop_when_disabled() {
+    // With the flag off, optimize() must leave the (wrong) intrinsics untouched —
+    // the default path is unchanged.
+    let mut ba = truth_bundle();
+    ba.camera = Camera::pinhole(1, 640, 480, 520.0, 520.0, 320.0, 240.0);
+    ba.fix_pose(10);
+    ba.fix_pose(20);
+    ba.optimize(&BaConfig::default()).expect("plain BA");
+    let (fx, _, _, _) = ba.camera.intrinsics().unwrap();
+    assert!(
+        (fx - 520.0).abs() < 1e-9,
+        "intrinsics must be untouched when refine_intrinsics is off, got fx={fx}"
+    );
+}
+
+#[test]
 fn bundle_cost_is_zero_at_truth() {
     let ba = truth_bundle();
     assert!(

--- a/scripts/run_colmap_sfm_benchmark.sh
+++ b/scripts/run_colmap_sfm_benchmark.sh
@@ -27,6 +27,14 @@
 #   Gerrard Hall   (100 photos)   98 / 100 registered, Sim(3) 0.68 cm RMSE
 # both ~0.1 % of the trajectory extent vs COLMAP's own model.
 #
+# Adding --extra-args "--colmap-style" runs the COLMAP IncrementalMapper schedule
+# (per-registration local BA + growth-triggered global refinement) instead of the
+# simple one; on the observable South-Building orbit it tightens the result to
+# 128/128 registered, Sim(3) 0.44 cm RMSE — near COLMAP's own 0.37 cm (slower).
+# Pair it with --extra-args "--colmap-style --refine-intrinsics" to additionally
+# co-evolve the pinhole intrinsics during growth (the right tool when the input
+# calibration is unknown / inaccurate; see docs/sfm_vs_colmap_benchmark.md).
+#
 # Requires: a Python env with torch + lightglue (the SuperPoint export stage) and
 # curl/wget + unzip. The export GPU step dominates the runtime; pass
 # --python /usr/bin/python3 (or wherever lightglue lives) and --device cpu/cuda.
@@ -41,12 +49,14 @@ max_keypoints="${COLMAP_SFM_MAX_KEYPOINTS:-2048}"
 retrieval_topk="${COLMAP_SFM_TOPK:-12}"
 min_matches="${COLMAP_SFM_MIN_MATCHES:-30}"
 base_url="${COLMAP_SFM_BASE_URL:-https://demuc.de/colmap/datasets}"
+extra_args="${COLMAP_SFM_EXTRA_ARGS:-}"
 
 usage() {
     sed -n '2,37p' "$0"
     echo
     echo "Flags: --dataset south-building|gerrard-hall  --data-root DIR  --out-dir DIR"
     echo "       --python BIN  --device cuda|cpu  --topk N  --min-matches N  --max-keypoints N"
+    echo "       --extra-args \"...\"  (pass-through to unordered_sfm_demo, e.g. --colmap-style)"
     exit "${1:-0}"
 }
 
@@ -60,6 +70,7 @@ while [ $# -gt 0 ]; do
         --topk) retrieval_topk="$2"; shift 2 ;;
         --min-matches) min_matches="$2"; shift 2 ;;
         --max-keypoints) max_keypoints="$2"; shift 2 ;;
+        --extra-args) extra_args="$2"; shift 2 ;;
         -h|--help) usage 0 ;;
         *) echo "unknown argument: $1" >&2; usage 1 ;;
     esac
@@ -149,6 +160,7 @@ echo "reconstructing with unordered_sfm_demo (top-k=$retrieval_topk, min-matches
     --feature-suffix _features.txt --image-suffix "$img_suffix" \
     $pinhole \
     --retrieval-topk "$retrieval_topk" --min-matches "$min_matches" \
+    $extra_args \
     --out-colmap "$colmap_out" )
 
 # ---- 5. Sim(3) comparison vs COLMAP's own model (+ overlay figure) -------------


### PR DESCRIPTION
## Summary

Brings the COLMAP `IncrementalMapper` schedule and intrinsics refinement into the
sequential SfM engine, and — the key fix — makes intrinsics **co-evolve with the
structure during growth** instead of only in the final solve. Measured on COLMAP's
own unordered orbit set (South Building), the COLMAP-style schedule reaches
near-parity with COLMAP and intrinsics refinement finally pulls a wrong focal back
toward the truth.

## Why

A slightly-wrong fixed calibration forces a residual onto the poses, so refining
`(fx, fy, cx, cy)` should help. The first cut refined intrinsics only in the final
solve — and it recovered **nothing**, even on observable orbit geometry (fx moved
< 1 unit on South Building). Once growth converges the structure into a wrong-focal
basin, the structure-fixed intrinsics gradient is ~0, so no amount of final
alternation escapes. COLMAP avoids this by co-evolving the camera with the
structure throughout incremental growth, before the basin forms.

## What changed

- **`incremental_sfm`**: `grow_from_seed` clones a per-trial `Camera` (so the seed
  search's shared tracks stay uncontaminated) and refines the intrinsics inside
  `growth_global_refinement` (the well-conditioned periodic global pass, where the
  focal is observable). The evolved camera is returned into the final refinement.
- **`unordered_sfm_demo`**: new `--colmap-style` and `--refine-intrinsics` flags;
  exports the refined camera.
- **`run_colmap_sfm_benchmark.sh`**: `--extra-args` pass-through (e.g.
  `--extra-args "--colmap-style --refine-intrinsics"`).
- Docs + a `colmap_style_co_evolves_intrinsics_toward_truth` unit test.

## Measured (South Building, 128 photos, Sim(3) camera-centre RMSE vs COLMAP)

| condition (`--colmap-style`) | registered | ATE |
|---|---|---|
| true calibration | 128 / 128 | **0.44 cm** (COLMAP 0.37 cm; simple schedule 0.89 cm) |
| anisotropic miscalibration (fx ×1.05, fy ×0.97) | 128 / 128 | 4.98 cm |
| + intrinsics co-evolution | 128 / 128 | **4.26 cm** (fx/fy pulled ~25% toward truth, principal point fixed) |

## Honest limits

Recovery is partial (~25%): each growth pass still uses the alternating
(structure-fixed) intrinsics step, so it accumulates corrections across passes
rather than solving jointly. Full self-calibration needs the intrinsics carried as
shared unknowns inside the Schur-complement BA — the clear next lever, and a larger
core-solver change. Intrinsics refinement remains off by default (zero regression
to the default path); it is the right tool for unknown/inaccurate calibration on
observable geometry, not for rectified forward video.

## Testing

178 slam-lib + 44 bundle tests pass; clippy and fmt clean. The default
(non-`--colmap-style`, no-refine) path is unchanged.
