### PR TITLE
Sequential SfM: self-calibrate radial distortion (SfM from raw images)

### DIFF
--- a/crates/core/src/types/camera.rs
+++ b/crates/core/src/types/camera.rs
@@ -53,6 +53,51 @@ impl Camera {
         }
     }
 
+    /// Construct a pinhole camera with two trailing radial-distortion
+    /// coefficients `(k1, k2)`. The intrinsics layout stays `[fx, fy, cx, cy]`
+    /// (so [`Self::intrinsics`] is unchanged); the distortion lives in the two
+    /// extra `params` slots and is read back by [`Self::radial_distortion`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn pinhole_radial(
+        id: CameraId,
+        width: u32,
+        height: u32,
+        fx: f64,
+        fy: f64,
+        cx: f64,
+        cy: f64,
+        k1: f64,
+        k2: f64,
+    ) -> Self {
+        Self {
+            id,
+            model: CameraModel::Pinhole,
+            width,
+            height,
+            params: vec![fx, fy, cx, cy, k1, k2],
+        }
+    }
+
+    /// Radial-distortion coefficients `(k1, k2)` carried alongside the
+    /// pinhole intrinsics, if any. A plain 4-parameter pinhole returns `None`
+    /// (distortion-free); `Pinhole` / `OpenCv` read the optional trailing
+    /// `[k1, k2]`, while COLMAP `SimpleRadial` / `Radial` read their native
+    /// `[f, cx, cy, k1(, k2)]` layout.
+    pub fn radial_distortion(&self) -> Option<(f64, f64)> {
+        match self.model {
+            CameraModel::Pinhole | CameraModel::OpenCv => self
+                .params
+                .get(4)
+                .map(|&k1| (k1, self.params.get(5).copied().unwrap_or(0.0))),
+            CameraModel::SimpleRadial => self.params.get(3).map(|&k1| (k1, 0.0)),
+            CameraModel::Radial => self
+                .params
+                .get(3)
+                .map(|&k1| (k1, self.params.get(4).copied().unwrap_or(0.0))),
+            CameraModel::SimplePinhole | CameraModel::Unknown(_) => None,
+        }
+    }
+
     pub fn intrinsics(&self) -> Option<(f64, f64, f64, f64)> {
         match self.model {
             CameraModel::Pinhole | CameraModel::OpenCv => Some((
@@ -69,9 +114,20 @@ impl Camera {
         }
     }
 
+    /// Back-project a pixel to a normalized (undistorted) bearing `(x, y, 1)`.
+    /// When the camera carries radial distortion the pixel is undistorted first
+    /// (fixed-point inverse of `1 + k1·r² + k2·r⁴`), so the returned coordinates
+    /// match an ideal pinhole — what the geometric front-end (essential matrix,
+    /// PnP, triangulation) expects. A distortion-free camera is the unchanged
+    /// linear back-projection.
     pub fn normalize_pixel(&self, point: &Point2<f64>) -> Option<Point2<f64>> {
         let (fx, fy, cx, cy) = self.intrinsics()?;
-        Some(Point2::new((point.x - cx) / fx, (point.y - cy) / fy))
+        let xd = (point.x - cx) / fx;
+        let yd = (point.y - cy) / fy;
+        match self.radial_distortion() {
+            Some((k1, k2)) if k1 != 0.0 || k2 != 0.0 => Some(undistort_radial(xd, yd, k1, k2)),
+            _ => Some(Point2::new(xd, yd)),
+        }
     }
 
     pub fn project(&self, point_camera: &Point3<f64>) -> Option<Point2<f64>> {
@@ -79,9 +135,36 @@ impl Camera {
             return None;
         }
         let (fx, fy, cx, cy) = self.intrinsics()?;
-        Some(Point2::new(
-            fx * point_camera.x / point_camera.z + cx,
-            fy * point_camera.y / point_camera.z + cy,
-        ))
+        let mut x = point_camera.x / point_camera.z;
+        let mut y = point_camera.y / point_camera.z;
+        if let Some((k1, k2)) = self.radial_distortion() {
+            if k1 != 0.0 || k2 != 0.0 {
+                let r2 = x * x + y * y;
+                let d = 1.0 + k1 * r2 + k2 * r2 * r2;
+                x *= d;
+                y *= d;
+            }
+        }
+        Some(Point2::new(fx * x + cx, fy * y + cy))
     }
+}
+
+/// Fixed-point inverse of the radial-distortion map `(x, y) ↦ (x, y)·(1 + k1·r²
+/// + k2·r⁴)` on normalized coordinates. Converges in well under 20 steps for
+/// realistic lens distortion; mirrors `visloc_vision::distortion` (kept here so
+/// `visloc-core` stays dependency-free).
+fn undistort_radial(xd: f64, yd: f64, k1: f64, k2: f64) -> Point2<f64> {
+    let (mut x, mut y) = (xd, yd);
+    for _ in 0..20 {
+        let r2 = x * x + y * y;
+        let d = 1.0 + k1 * r2 + k2 * r2 * r2;
+        let nx = xd / d;
+        let ny = yd / d;
+        if (nx - x).abs() + (ny - y).abs() < 1.0e-12 {
+            return Point2::new(nx, ny);
+        }
+        x = nx;
+        y = ny;
+    }
+    Point2::new(x, y)
 }

--- a/docs/sfm_vs_colmap_benchmark.md
+++ b/docs/sfm_vs_colmap_benchmark.md
@@ -188,6 +188,29 @@ orthogonal, un-perturbed `fy` / `cy` stay fixed; `cx` co-adjusts within the look
 arc's focal/centre ambiguity, a confound absent on the richer South-Building
 viewpoints.)
 
+**3. The same solve self-calibrates radial distortion — SfM straight from
+uncorrected images.** `--refine-distortion` extends the joint camera block to six
+unknowns `(fx, fy, cx, cy, k1, k2)`, so the lens distortion is estimated alongside
+the intrinsics (the `1 + k1·r² + k2·r⁴` model now lives in `Camera::project` /
+`normalize_pixel`, used by the whole front-end). To measure it on real scene
+structure, a known distortion `(k1 = −0.10, k2 = 0.02)` was injected into the
+South-Building keypoints (so the input is now "raw" distorted pixels) and the
+reconstruction started from a distortion-free pinhole:
+
+| condition (distorted input) | recovered distortion | ATE |
+|---|---|---|
+| no refinement (pinhole) | — | 11.71 cm |
+| **joint distortion self-calibration** | `k1 → −0.1003`, `k2 → 0.0247` | **1.43 cm** |
+
+From a zero start the solve recovers `k1` essentially exactly (`−0.1003` vs the
+injected `−0.10`) and `k2` closely, taking the trajectory from a distortion-wrecked
+11.71 cm back to 1.43 cm (≈ 8×). This is end-to-end self-calibrating SfM: register,
+triangulate, and solve for the lens from uncorrected images with no prior
+calibration — COLMAP's `RADIAL` workflow, in the same Schur framework. (Restricted
+to monocular reconstruction; rectified stereo is already undistorted. The residual
+vs the 0.44 cm undistorted baseline is the focal/principal-point co-adjustment,
+mainly `cy`, that soaks up part of the radial term.)
+
 (Schedule ablation, separately: re-triangulation must run **both** during growth
 — dropping it collapses registration to 212/300 and ATE to 6.6 cm — **and** in
 the final refinement — filter-only there leaves 718 tracks and 2.21 cm; keeping

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -47,8 +47,8 @@ use visloc_rs::vision::place_recognition::{cosine_similarity, vlad, Vocabulary};
 use visloc_rs::vision::two_view::{RelativePoseEstimator, TwoViewCorrespondence};
 use visloc_rs::{
     incremental_sfm, read_external_deep_features_txt, write_colmap_reconstruction_for_3dgs,
-    BruteForceMatcher, Camera, CrossCheckMatcher, FeatureSet, IncrementalSfmConfig, Matcher,
-    PairwiseMatches, Pose,
+    BaConfig, BruteForceMatcher, Camera, CrossCheckMatcher, FeatureSet, IncrementalSfmConfig,
+    Matcher, PairwiseMatches, Pose,
 };
 
 /// A COLMAP-export landmark: world position + `(image, keypoint, pixel)` track.
@@ -70,6 +70,7 @@ struct Args {
     final_ba: bool,
     seed_trials: usize,
     refine_intrinsics: bool,
+    refine_distortion: bool,
     colmap_style: bool,
 }
 
@@ -90,6 +91,7 @@ fn parse_args() -> Result<Args, String> {
     let mut final_ba = true;
     let mut seed_trials = 12usize;
     let mut refine_intrinsics = false;
+    let mut refine_distortion = false;
     let mut colmap_style = false;
 
     let mut a: Vec<String> = env::args().skip(1).collect();
@@ -120,6 +122,7 @@ fn parse_args() -> Result<Args, String> {
             "--no-final-ba" => final_ba = false,
             "--seed-trials" => seed_trials = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
             "--refine-intrinsics" => refine_intrinsics = true,
+            "--refine-distortion" => refine_distortion = true,
             "--colmap-style" => colmap_style = true,
             other => return Err(format!("unknown argument: {other}")),
         }
@@ -154,6 +157,7 @@ fn parse_args() -> Result<Args, String> {
         final_ba,
         seed_trials,
         refine_intrinsics,
+        refine_distortion,
         colmap_style,
     })
 }
@@ -351,7 +355,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_reprojection_error_px: args.max_reproj,
         final_global_ba: args.final_ba,
         seed_trials: args.seed_trials,
-        refine_intrinsics: args.refine_intrinsics,
+        // Distortion self-calibration runs inside the joint intrinsics BA, so it
+        // implies intrinsics refinement; the (k1, k2) flag rides on `ba_config`.
+        refine_intrinsics: args.refine_intrinsics || args.refine_distortion,
+        ba_config: BaConfig {
+            refine_distortion: args.refine_distortion,
+            ..IncrementalSfmConfig::default().ba_config
+        },
         colmap_style_mapper: args.colmap_style,
         ..IncrementalSfmConfig::default()
     };
@@ -374,6 +384,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "refined intrinsics: fx {:.2}->{:.2}  fy {:.2}->{:.2}  cx {:.2}->{:.2}  cy {:.2}->{:.2}",
                 i0.0, i1.0, i0.1, i1.1, i0.2, i1.2, i0.3, i1.3,
             );
+            if let Some((k1, k2)) = export_camera.radial_distortion() {
+                let (k1_0, k2_0) = args.camera.radial_distortion().unwrap_or((0.0, 0.0));
+                println!("refined distortion: k1 {k1_0:.5}->{k1:.5}  k2 {k2_0:.5}->{k2:.5}");
+            }
         }
     }
 

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -22,8 +22,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use nalgebra::{
-    DMatrix, DVector, Matrix2x3, Matrix2x4, Matrix2x6, Matrix3, Matrix3x4, Matrix3x6, Matrix6,
-    Matrix6x3, Point2, Point3, Vector2, Vector3, Vector6,
+    DMatrix, DVector, Matrix2x3, Matrix2x6, Matrix3, Matrix3x4, Matrix3x6, Matrix6, Matrix6x3,
+    Point2, Point3, Vector2, Vector3, Vector6,
 };
 
 use visloc_core::geometry::{Pose, SE3, SO3};
@@ -605,7 +605,9 @@ impl BundleAdjustment {
             if xc.z <= 0.0 {
                 continue;
             }
-            if let Some(predicted) = project_pinhole(&intrinsics, &xc) {
+            // Distortion-aware projection (identical to `project_pinhole` when the
+            // camera carries no distortion, so all existing callers are unchanged).
+            if let Some(predicted) = self.camera.project(&xc) {
                 let r = predicted - obs.xy;
                 let s = r.x * r.x + r.y * r.y;
                 let w = gnc_weights.map_or(1.0, |gw| gw[obs_idx]);
@@ -869,7 +871,21 @@ impl BundleAdjustment {
         }
         let p_count = pose_index.len();
         let k_off = p_count * 6;
-        let cam_dim = k_off + 4;
+        // Also self-calibrate radial distortion (k1, k2) when asked — but only on
+        // a monocular reconstruction (rectified stereo is already undistorted, and
+        // its baseline term does not carry a distortion model). The two coefficients
+        // get appended to the camera block, so `k_dim` is 6 instead of 4.
+        let refine_dist = config.refine_distortion
+            && self.camera.model == CameraModel::Pinhole
+            && self.stereo_observations.is_empty();
+        if refine_dist {
+            // Ensure the camera carries the two distortion slots (start at 0).
+            while self.camera.params.len() < 6 {
+                self.camera.params.push(0.0);
+            }
+        }
+        let k_dim = if refine_dist { 6 } else { 4 };
+        let cam_dim = k_off + k_dim;
 
         let initial_cost = self.robust_cost_weighted(&kernel, None);
         let mut iterations: Vec<BaIterationStats> = Vec::with_capacity(config.max_iterations);
@@ -878,8 +894,16 @@ impl BundleAdjustment {
         let mut converged = false;
 
         for iteration in 0..config.max_iterations {
-            let (cam_dim_n, h_cc, b_c, lm_blocks) =
-                self.build_joint_intrinsics_system(&pose_index, &landmark_index, &kernel);
+            // Current distortion (reflects the running k1, k2 estimate) drives the
+            // distortion-aware projection / Jacobians inside the build.
+            let dist = self.camera.radial_distortion();
+            let (cam_dim_n, h_cc, b_c, lm_blocks) = self.build_joint_intrinsics_system(
+                &pose_index,
+                &landmark_index,
+                &kernel,
+                k_dim,
+                dist,
+            );
             debug_assert_eq!(cam_dim_n, cam_dim);
 
             // Damped Schur reduction (Levenberg I·λ on both the camera and the
@@ -974,8 +998,8 @@ impl BundleAdjustment {
                 let pt = self.landmarks.get_mut(&id).expect("landmark exists");
                 *pt = Point3::from(pt.coords + dl);
             }
-            // Intrinsics block.
-            for j in 0..4 {
+            // Intrinsics (and, when k_dim == 6, distortion) block.
+            for j in 0..k_dim {
                 self.camera.params[j] += delta_cam[k_off + j];
             }
 
@@ -1047,12 +1071,14 @@ impl BundleAdjustment {
         pose_index: &BTreeMap<u64, usize>,
         landmark_index: &BTreeMap<u64, usize>,
         kernel: &RobustKernel,
+        k_dim: usize,
+        dist: Option<(f64, f64)>,
     ) -> (usize, DMatrix<f64>, DVector<f64>, Vec<JointLandmarkBlock>) {
         let intrinsics = self.intrinsics().expect("pinhole checked by caller");
-        let (fx, fy, _, _) = intrinsics;
+        let (fx, fy, cx, cy) = intrinsics;
         let p_count = pose_index.len();
         let k_off = p_count * 6;
-        let cam_dim = k_off + 4;
+        let cam_dim = k_off + k_dim;
         let mut h_cc = DMatrix::<f64>::zeros(cam_dim, cam_dim);
         let mut b_c = DVector::<f64>::zeros(cam_dim);
         let mut lm_blocks: Vec<JointLandmarkBlock> = landmark_index
@@ -1082,21 +1108,36 @@ impl BundleAdjustment {
             if xc.z <= 0.0 {
                 continue;
             }
-            let Some(predicted) = project_pinhole(&intrinsics, &xc) else {
-                continue;
-            };
-            let residual = Vector2::new(predicted.x - obs.xy.x, predicted.y - obs.xy.y);
             let z_inv = 1.0 / xc.z;
+            let x = xc.x * z_inv;
+            let y = xc.y * z_inv;
+            let r2 = x * x + y * y;
+            // Radial distortion factor d = 1 + k1·r² + k2·r⁴ and its radial
+            // derivative helper g = k1 + 2·k2·r² (d=1, g=0 when distortion-free).
+            let (k1, k2) = dist.unwrap_or((0.0, 0.0));
+            let d = 1.0 + k1 * r2 + k2 * r2 * r2;
+            let g = k1 + 2.0 * k2 * r2;
+            let (xd, yd) = (x * d, y * d);
+            let predicted = Point2::new(fx * xd + cx, fy * yd + cy);
+            let residual = Vector2::new(predicted.x - obs.xy.x, predicted.y - obs.xy.y);
             let r_mat = pose
                 .world_to_camera
                 .rotation
                 .to_rotation_matrix()
                 .into_inner();
+            // J_π = diag(fx, fy) · D · ∂(x, y)/∂X_c, where the distortion Jacobian
+            //   D = [[d + 2x²g, 2xyg], [2xyg, d + 2y²g]]  (= I when distortion-free)
+            // and ∂(x, y)/∂X_c = (1/Z)·[[1, 0, -x], [0, 1, -y]].
+            let d11 = d + 2.0 * x * x * g;
+            let d12 = 2.0 * x * y * g;
+            let d22 = d + 2.0 * y * y * g;
             let mut j_pi = Matrix2x3::<f64>::zeros();
-            j_pi[(0, 0)] = fx * z_inv;
-            j_pi[(0, 2)] = -fx * xc.x * z_inv * z_inv;
-            j_pi[(1, 1)] = fy * z_inv;
-            j_pi[(1, 2)] = -fy * xc.y * z_inv * z_inv;
+            j_pi[(0, 0)] = fx * d11 * z_inv;
+            j_pi[(0, 1)] = fx * d12 * z_inv;
+            j_pi[(0, 2)] = -fx * (d11 * x + d12 * y) * z_inv;
+            j_pi[(1, 0)] = fy * d12 * z_inv;
+            j_pi[(1, 1)] = fy * d22 * z_inv;
+            j_pi[(1, 2)] = -fy * (d12 * x + d22 * y) * z_inv;
             let mut dx_dxi = Matrix3x6::<f64>::zeros();
             dx_dxi.fixed_view_mut::<3, 3>(0, 0).copy_from(&r_mat);
             dx_dxi
@@ -1104,26 +1145,32 @@ impl BundleAdjustment {
                 .copy_from(&(-r_mat * skew(&point.coords)));
             let j_pose: Matrix2x6<f64> = j_pi * dx_dxi;
             let j_lm: Matrix2x3<f64> = j_pi * r_mat;
-            // ∂(predicted)/∂(fx, fy, cx, cy).
-            let mut j_k = Matrix2x4::<f64>::zeros();
-            j_k[(0, 0)] = xc.x * z_inv;
+            // ∂(predicted)/∂K with K = (fx, fy, cx, cy[, k1, k2]) (2×k_dim).
+            let mut j_k = DMatrix::<f64>::zeros(2, k_dim);
+            j_k[(0, 0)] = xd;
             j_k[(0, 2)] = 1.0;
-            j_k[(1, 1)] = xc.y * z_inv;
+            j_k[(1, 1)] = yd;
             j_k[(1, 3)] = 1.0;
+            if k_dim == 6 {
+                j_k[(0, 4)] = fx * x * r2;
+                j_k[(0, 5)] = fx * x * r2 * r2;
+                j_k[(1, 4)] = fy * y * r2;
+                j_k[(1, 5)] = fy * y * r2 * r2;
+            }
 
             let s = residual.x * residual.x + residual.y * residual.y;
             let w = kernel.weight(s);
             let i_pose = pose_index.get(&obs.keyframe_id).copied();
             let i_lm = landmark_index.get(&obs.landmark_id).copied();
 
+            // Dynamic-sized residual / pose for the K-coupled products.
+            let res2 = DVector::from_column_slice(&[residual.x, residual.y]);
+            let jkt = j_k.transpose(); // k_dim×2
+
             // K-K and K gradient (intrinsics are always variable).
-            add_cc(
-                k_off,
-                k_off,
-                &DMatrix::from_fn(4, 4, |r, c| w * (j_k.transpose() * j_k)[(r, c)]),
-            );
-            let bk = w * (j_k.transpose() * residual);
-            for j in 0..4 {
+            add_cc(k_off, k_off, &(w * (&jkt * &j_k)));
+            let bk = w * (&jkt * &res2);
+            for j in 0..k_dim {
                 b_c[k_off + j] += bk[j];
             }
             if let Some(p) = i_pose {
@@ -1134,9 +1181,10 @@ impl BundleAdjustment {
                     b_c[p * 6 + r] += bp[r];
                 }
                 // pose-K coupling (and its transpose).
-                let hpk = w * (j_pose.transpose() * j_k); // 6×4
-                add_cc(p * 6, k_off, &DMatrix::from_fn(6, 4, |r, c| hpk[(r, c)]));
-                add_cc(k_off, p * 6, &DMatrix::from_fn(4, 6, |r, c| hpk[(c, r)]));
+                let jp_dyn = DMatrix::from_iterator(2, 6, j_pose.iter().copied());
+                let hpk = w * (jp_dyn.transpose() * &j_k); // 6×k_dim
+                add_cc(p * 6, k_off, &hpk);
+                add_cc(k_off, p * 6, &hpk.transpose());
             }
             if let Some(l) = i_lm {
                 lm_blocks[l].h_ll += w * (j_lm.transpose() * j_lm);
@@ -1150,13 +1198,9 @@ impl BundleAdjustment {
                         &DMatrix::from_fn(6, 3, |r, c| cr[(r, c)]),
                     );
                 }
-                let crk = w * (j_k.transpose() * j_lm); // 4×3
-                add_cross(
-                    &mut lm_blocks[l].cross,
-                    k_off,
-                    4,
-                    &DMatrix::from_fn(4, 3, |r, c| crk[(r, c)]),
-                );
+                let jl_dyn = DMatrix::from_iterator(2, 3, j_lm.iter().copied());
+                let crk = w * (&jkt * &jl_dyn); // k_dim×3
+                add_cross(&mut lm_blocks[l].cross, k_off, k_dim, &crk);
             }
         }
 
@@ -1732,6 +1776,13 @@ pub struct BaConfig {
     /// pose/structure-only solve. **`false` by default** (the public
     /// [`BundleAdjustment::optimize`] is then bit-identical to before).
     pub refine_intrinsics: bool,
+    /// Additionally self-calibrate the two radial-distortion coefficients
+    /// `(k1, k2)` jointly with the intrinsics (the camera block grows from 4 to 6).
+    /// Requires `refine_intrinsics`; only applies to a **monocular** pinhole
+    /// reconstruction (rectified stereo is already undistorted). The coefficients
+    /// are appended to `Camera::params` as `[fx, fy, cx, cy, k1, k2]`. **`false`
+    /// by default.**
+    pub refine_distortion: bool,
 }
 
 impl Default for BaConfig {
@@ -1748,6 +1799,7 @@ impl Default for BaConfig {
             linear_solver: LinearSolver::Dense,
             robust_kernel: RobustKernel::None,
             refine_intrinsics: false,
+            refine_distortion: false,
         }
     }
 }

--- a/pipelines/slam/tests/bundle_adjustment.rs
+++ b/pipelines/slam/tests/bundle_adjustment.rs
@@ -70,6 +70,79 @@ fn truth_bundle() -> BundleAdjustment {
     ba
 }
 
+/// Like [`truth_bundle`] but the measurements are rendered through a camera that
+/// carries radial distortion `(k1, k2)`, so a distortion-free BA cannot fit them.
+fn truth_bundle_distorted(k1: f64, k2: f64) -> BundleAdjustment {
+    let camera = Camera::pinhole_radial(1, 640, 480, 500.0, 500.0, 320.0, 240.0, k1, k2);
+    let mut ba = BundleAdjustment::new(camera.clone());
+    let truth_poses = [
+        (10u64, pose_at(Vector3::new(0.0, 0.0, 0.0))),
+        (20u64, pose_at(Vector3::new(0.5, 0.0, 0.0))),
+        (30u64, pose_at(Vector3::new(1.0, 0.0, 0.0))),
+    ];
+    for (id, pose) in &truth_poses {
+        ba.add_pose(*id, pose.clone());
+    }
+    let points = world_grid();
+    for (id, point) in &points {
+        ba.add_landmark(*id, *point);
+    }
+    for (kf_id, pose) in &truth_poses {
+        for (lm_id, point) in &points {
+            let xc = pose.transform_world_point(point);
+            // `Camera::project` applies the radial distortion baked into `camera`.
+            let uv = camera.project(&xc).expect("point in front of camera");
+            ba.add_observation(BaObservation {
+                keyframe_id: *kf_id,
+                landmark_id: *lm_id,
+                xy: uv,
+            });
+        }
+    }
+    ba
+}
+
+#[test]
+fn joint_ba_self_calibrates_radial_distortion() {
+    // Measurements are rendered through a lens with radial distortion
+    // (k1 = -0.05, k2 = 0.01). Start the BA from a distortion-free pinhole and
+    // let the joint solve self-calibrate (k1, k2) alongside the intrinsics. As
+    // with the focal-length test, fixing the structure makes the distortion
+    // observable on this tiny scene (a large many-view reconstruction does so for
+    // free).
+    let (true_k1, true_k2) = (-0.05, 0.01);
+    let mut ba = truth_bundle_distorted(true_k1, true_k2);
+    ba.camera = pinhole(); // distortion-free start (k1 = k2 = 0)
+    ba.fix_pose(10);
+    ba.fix_pose(20);
+    for (id, _) in world_grid() {
+        ba.fix_landmark(id);
+    }
+
+    let cost_before = ba.cost();
+    let config = BaConfig {
+        refine_intrinsics: true,
+        refine_distortion: true,
+        ..BaConfig::default()
+    };
+    ba.optimize(&config)
+        .expect("joint BA with distortion refinement");
+
+    let (k1, k2) = ba
+        .camera
+        .radial_distortion()
+        .expect("distortion slots populated");
+    assert!(
+        (k1 - true_k1).abs() < 5.0e-3 && (k2 - true_k2).abs() < 5.0e-3,
+        "distortion not recovered: k1={k1}, k2={k2} (truth {true_k1}/{true_k2})"
+    );
+    assert!(
+        ba.cost() < 0.1 && ba.cost() < cost_before,
+        "cost must collapse once the lens is recovered: {} (was {cost_before})",
+        ba.cost()
+    );
+}
+
 #[test]
 fn refine_intrinsics_recovers_perturbed_focal_length() {
     // Exact observations are generated with the true camera (fx = fy = 500).


### PR DESCRIPTION
## Summary

Extends the joint intrinsics bundle adjustment (PR #31) to also **self-calibrate
radial distortion**, so the engine can run SfM directly on **uncorrected images**
with no prior lens calibration — COLMAP's `RADIAL` workflow, in the same
Schur-complement framework.

## What changed

- `--refine-distortion` grows the joint camera block from 4 to 6 unknowns
  `(fx, fy, cx, cy, k1, k2)`, co-estimated with the poses and eliminated landmarks.
- The `1 + k1·r² + k2·r⁴` model now lives in `Camera::project` / `normalize_pixel`
  (a no-op for a distortion-free pinhole, so **every existing pipeline is
  bit-identical**), so the whole front-end — essential matrix, PnP, triangulation —
  back-projects through it.
- The monocular reprojection Jacobian `J_π` is now distortion-aware (via the 2×2
  distortion Jacobian `D`, which reduces to `I` when distortion-free) and `J_K`
  gains the `k1`/`k2` columns. Restricted to monocular reconstruction (rectified
  stereo is already undistorted). The general `optimize_weighted` /
  `build_normal_equations` / `solve_step` path is untouched.
- Adds `Camera::pinhole_radial` / `radial_distortion`, `BaConfig::refine_distortion`,
  the `--refine-distortion` demo flag, and a unit test.

## Measured (South Building, real scene structure, injected distortion)

A known distortion `(k1 = −0.10, k2 = 0.02)` was injected into the keypoints (so the
input is now "raw" distorted pixels) and the reconstruction started from a
distortion-free pinhole; Sim(3) ATE vs COLMAP's model:

| condition (distorted input) | recovered distortion | ATE |
|---|---|---|
| no refinement (pinhole) | — | 11.71 cm |
| **joint distortion self-calibration** | `k1 → −0.1003`, `k2 → 0.0247` | **1.43 cm** |

From a zero start the solve recovers `k1` essentially exactly and `k2` closely,
taking the trajectory from a distortion-wrecked 11.71 cm back to 1.43 cm (≈ 8×),
reprojection 1.529 → 1.344 px.

## Testing

The `joint_ba_self_calibrates_radial_distortion` unit test recovers `(k1, k2)` from
a distortion-free start with fixed structure. 178 slam-lib + 45 bundle tests and the
full workspace pass; clippy, fmt, and `cargo doc -D warnings` clean.
