### PR TITLE
Sequential SfM: COLMAP FilterImages image de-registration

### DIFF
--- a/docs/sfm_vs_colmap_benchmark.md
+++ b/docs/sfm_vs_colmap_benchmark.md
@@ -222,6 +222,22 @@ repetitive scenes where a clustered-but-numerous candidate would otherwise be
 chosen over a better-distributed one (unit-tested in
 `visibility_pyramid_prefers_distribution_over_count`).
 
+**Image filtering — de-registration (`--filter-images`, ported, off by default).**
+COLMAP's `Reconstruction::FilterImages`: after each growth global refinement,
+de-register any image whose count of well-supported observations (triangulated,
+within the reprojection threshold) has fallen below
+`filter_min_image_observations` — a pose BA + point filtering stripped of support is
+unreliable. The two seed images are protected (they pin the gauge), the registered
+count never drops below three, and a filtered image keeps its trial count so it is
+re-registered at most `max_registration_trials` times (not indefinitely). On the
+clean South-Building / Gerrard-Hall sets it is an exact **no-op** (0.43 → 0.43 cm,
+128/128; 0.40 → 0.40 cm, 98/100 — byte-identical models): no registered image ever
+loses support, so nothing is filtered, confirming the safety property that it never
+drops a good image. Its value is registration robustness on degenerate / repetitive
+scenes where a contaminated pose would otherwise survive into the model (the
+de-registration mechanism is unit-tested in
+`filter_images_deregisters_unsupported_pose_and_protects_seed`).
+
 (Schedule ablation, separately: re-triangulation must run **both** during growth
 — dropping it collapses registration to 212/300 and ATE to 6.6 cm — **and** in
 the final refinement — filter-only there leaves 718 tracks and 2.21 cm; keeping

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -72,6 +72,7 @@ struct Args {
     refine_intrinsics: bool,
     refine_distortion: bool,
     colmap_style: bool,
+    filter_images: bool,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -93,6 +94,7 @@ fn parse_args() -> Result<Args, String> {
     let mut refine_intrinsics = false;
     let mut refine_distortion = false;
     let mut colmap_style = false;
+    let mut filter_images = false;
 
     let mut a: Vec<String> = env::args().skip(1).collect();
     let mut i = 0;
@@ -124,6 +126,7 @@ fn parse_args() -> Result<Args, String> {
             "--refine-intrinsics" => refine_intrinsics = true,
             "--refine-distortion" => refine_distortion = true,
             "--colmap-style" => colmap_style = true,
+            "--filter-images" => filter_images = true,
             other => return Err(format!("unknown argument: {other}")),
         }
         i += 1;
@@ -159,6 +162,7 @@ fn parse_args() -> Result<Args, String> {
         refine_intrinsics,
         refine_distortion,
         colmap_style,
+        filter_images,
     })
 }
 
@@ -363,6 +367,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ..IncrementalSfmConfig::default().ba_config
         },
         colmap_style_mapper: args.colmap_style,
+        filter_images: args.filter_images,
         ..IncrementalSfmConfig::default()
     };
     let result = incremental_sfm(&args.camera, &features, &pairwise, &config)?;

--- a/pipelines/slam/src/incremental_sfm.rs
+++ b/pipelines/slam/src/incremental_sfm.rs
@@ -204,6 +204,19 @@ pub struct IncrementalSfmConfig {
     /// intrinsics fixed; the refined camera emerges from the final solve and is
     /// returned in [`IncrementalSfmResult::refined_camera`]. `false` by default.
     pub refine_intrinsics: bool,
+    /// COLMAP `Reconstruction::FilterImages`: after each growth global refinement,
+    /// **de-register** any image whose count of well-supported 3D-point
+    /// observations (triangulated, within `max_reprojection_error_px`) has fallen
+    /// below `filter_min_image_observations`. A pose that BA + point filtering
+    /// stripped of support is unreliable; dropping it (its trial counter resets, so
+    /// it can re-register once the structure around it improves) keeps a bad pose
+    /// from dragging the global solve. The two seed images are never filtered (they
+    /// anchor the gauge), and the registered count is never taken below 3. Only
+    /// used when `colmap_style_mapper` is set. `false` by default.
+    pub filter_images: bool,
+    /// Minimum well-supported observations an image must keep to stay registered
+    /// under `filter_images`. Only consulted when `filter_images` is set.
+    pub filter_min_image_observations: usize,
 }
 
 /// Minimal PnP solver used to register a new image against the reconstruction.
@@ -248,6 +261,8 @@ impl Default for IncrementalSfmConfig {
             low_parallax_min_observations: None,
             low_parallax_min_angle_deg: 1.0,
             refine_intrinsics: false,
+            filter_images: false,
+            filter_min_image_observations: 15,
         }
     }
 }
@@ -827,6 +842,13 @@ fn grow_from_seed(
                     if poses[i].is_none() {
                         *t = 0;
                     }
+                }
+                // COLMAP `FilterImages`: de-register images whose pose lost support
+                // after the global solve. Done AFTER the retry reset so a filtered
+                // image keeps its accumulated trial count (it is re-registered at
+                // most `max_registration_trials` times, not indefinitely).
+                if config.filter_images {
+                    filter_images(&cam, features, tracks, config, &mut poses, &track_point);
                 }
             }
         } else {
@@ -1460,6 +1482,65 @@ fn count_observations(
             .count();
     }
     n
+}
+
+/// COLMAP `Reconstruction::FilterImages`: de-register registered images whose
+/// well-supported observation count has collapsed. For each registered image,
+/// count its observations that are triangulated and reproject within
+/// `max_reprojection_error_px`; if that count is below
+/// `config.filter_min_image_observations`, set its pose to `None`. The two
+/// lowest-index registered images (the seed pair) are protected as the gauge
+/// anchor, and the registered count is never driven below 3. Returns how many
+/// images were de-registered. The caller's grow loop resets the trial counter of
+/// any now-unregistered image, so a filtered image can re-register once the
+/// surrounding structure improves.
+fn filter_images(
+    camera: &Camera,
+    features: &[FeatureSet],
+    tracks: &[Vec<(usize, usize)>],
+    config: &IncrementalSfmConfig,
+    poses: &mut [Option<Pose>],
+    track_point: &[Option<Point3<f64>>],
+) -> usize {
+    let threshold = config.max_reprojection_error_px;
+    let min_obs = config.filter_min_image_observations;
+
+    // Per-image count of well-supported (triangulated, in-threshold) observations.
+    let mut good_obs = vec![0usize; poses.len()];
+    for (track_id, track) in tracks.iter().enumerate() {
+        let Some(point) = track_point[track_id] else {
+            continue;
+        };
+        for &(image, kp) in track {
+            let Some(pose) = &poses[image] else { continue };
+            let Some(px) = features[image].keypoints.get(kp).copied() else {
+                continue;
+            };
+            if matches!(reprojection_error_px(camera, pose, &point, &px), Some(e) if e <= threshold)
+            {
+                good_obs[image] += 1;
+            }
+        }
+    }
+
+    // Protect the seed pair (the two lowest-index registered images) — they pin the
+    // 7-DoF monocular gauge — and keep at least three registered images alive.
+    let registered: Vec<usize> = (0..poses.len()).filter(|&i| poses[i].is_some()).collect();
+    let protected: std::collections::HashSet<usize> = registered.iter().take(2).copied().collect();
+    let mut remaining = registered.len();
+
+    let mut removed = 0usize;
+    for &image in &registered {
+        if remaining <= 3 || protected.contains(&image) {
+            continue;
+        }
+        if good_obs[image] < min_obs {
+            poses[image] = None;
+            removed += 1;
+            remaining -= 1;
+        }
+    }
+    removed
 }
 
 /// Clean every triangulated track after the current BA, on two grounds:
@@ -2129,6 +2210,59 @@ mod tests {
         assert!(
             track_point[0].is_none(),
             "track with < 2 inlier observations is dropped"
+        );
+    }
+
+    #[test]
+    fn filter_images_deregisters_unsupported_pose_and_protects_seed() {
+        // Register all six ring cameras with their true poses, triangulate, then
+        // corrupt one non-seed image's pose so none of its observations reproject.
+        // FilterImages must de-register exactly that image, keep the well-supported
+        // ones, and never touch the two seed (lowest-index) images.
+        let scene = build_scene();
+        let (features, pairwise) = render(&scene);
+        let tracks = build_tracks(features.len(), &pairwise, 2);
+        let config = IncrementalSfmConfig {
+            filter_images: true,
+            filter_min_image_observations: 5,
+            ..IncrementalSfmConfig::default()
+        };
+        let mut poses: Vec<Option<Pose>> = scene.poses.iter().map(|p| Some(p.clone())).collect();
+        let mut track_point = vec![None; tracks.len()];
+        triangulate_pending(
+            &scene.camera,
+            &features,
+            &tracks,
+            &poses,
+            &config,
+            &mut track_point,
+        );
+
+        // Corrupt image 3 (not in the protected seed pair): aim it away from the
+        // cloud so every observation reprojects far off or behind the camera.
+        let bad = Pose::from_world_to_camera(
+            UnitQuaternion::from_axis_angle(&Vector3::y_axis(), std::f64::consts::PI),
+            Vector3::new(0.0, 0.0, 0.0),
+        );
+        poses[3] = Some(bad);
+
+        let removed = filter_images(
+            &scene.camera,
+            &features,
+            &tracks,
+            &config,
+            &mut poses,
+            &track_point,
+        );
+        assert_eq!(removed, 1, "only the unsupported image is de-registered");
+        assert!(poses[3].is_none(), "the corrupted-pose image is filtered");
+        assert!(
+            poses[0].is_some() && poses[1].is_some(),
+            "the seed pair is protected from filtering"
+        );
+        assert!(
+            poses[2].is_some() && poses[4].is_some() && poses[5].is_some(),
+            "well-supported images stay registered"
         );
     }
 


### PR DESCRIPTION
## Summary

Ports COLMAP's `Reconstruction::FilterImages` de-registration feedback loop into
the sequential SfM engine: drop a registered image whose pose has lost support after
bundle adjustment, so it can no longer drag the global solve (and may re-register
once the surrounding structure improves).

## What changed

After each growth global refinement (under `colmap_style_mapper`), `filter_images`
de-registers any image whose count of well-supported observations (triangulated,
within `max_reprojection_error_px`) has fallen below
`filter_min_image_observations`. Safeguards:

- The two seed images are protected (they pin the 7-DoF monocular gauge).
- The registered count never drops below three.
- De-registration runs *after* the retry-reset, so a filtered image keeps its
  accumulated trial count and is re-registered at most `max_registration_trials`
  times — bounded, not a thrash loop.

Adds `IncrementalSfmConfig::filter_images` / `filter_min_image_observations`
(default off / 15), the `--filter-images` demo flag, and a unit test.

## Measured

Exact **no-op** on the clean COLMAP sets (Sim(3) ATE vs COLMAP's model):

| dataset | baseline | `--filter-images` |
|---|---|---|
| South Building | 0.43 cm (128/128) | 0.43 cm (128/128) |
| Gerrard Hall | 0.40 cm (98/100) | 0.40 cm (98/100) |

Byte-identical models — no registered image loses support, so nothing is filtered,
confirming the safety property that it never drops a good image. The value is
registration robustness on degenerate / repetitive scenes where a contaminated pose
would otherwise survive into the model.

## Testing

`filter_images_deregisters_unsupported_pose_and_protects_seed` pins the
de-registration mechanism (a corrupted-pose image is dropped; the seed pair and
well-supported images are kept). 180 slam-lib tests pass; clippy and fmt clean.
