### PR TITLE
feat: automate scalable unordered SfM validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ All notable changes to `visloc-rs` will be documented here.
 
 ### Added
 
+- **Milestone 4 large-scale unordered-SfM plan (2026-08-31).** Added a
+  planning-only, primary-source-linked runbook for scaling from the frozen
+  courtyard control to ETH3D `electro` (300-image probe, then 1,200 images),
+  10k+ scene-sharded validation, and optional 100k+/million-image datasets.
+  It defines licensing/availability caveats, O(NK) retrieval, bounded
+  candidate manifests, atomic resumable feature/match shards, component
+  recovery, resource ceilings, metrics, stop/go gates, and preservation of the
+  exhaustive 38/38 / 0.005379 m courtyard gate. No dataset was downloaded or
+  large run launched.
+
+- **Bounded pre-match candidate schedules (2026-08-31).** Milestone 3 adds
+  deterministic `vlad-mutual` and bounded `vlad-union` candidate sources plus
+  the image-name-bound, atomic `visloc_candidate_manifest_v1` export/import
+  path. Selection uses only numeric-stem local overlap and pre-match VLAD
+  retrieval; frozen raw matches are consumed only after selection for
+  verification replay, with no GT or extrinsic input. On the immutable
+  high-resolution courtyard artifact, exhaustive control was **703** candidates,
+  **366** verified / **261,724** inliers, **38/38**, **43,852 tracks / 152,432
+  observations**, 0.579 px and **0.5379 cm**. The local-window≤3 + VLAD top-8
+  union capped at **200** candidates (**172** verified / **199,871** inliers)
+  and retained **38/38**, **45,016 / 148,192**, 0.537 px and **0.66 cm**
+  (71.6% fewer proposed pairs; manifest SHA-256
+  `2d654b9e…5ed32c1`). Non-mutual VLAD top-8 used 188 candidates and reached
+  38/38 but 14.17 cm; mutual top-8 used 116 and reached 13/38 (33.97 cm on
+  its partial subset); sequential stem≤3 used 108 and reached 23/38 (1.08 cm
+  on its partial subset); vocab-tree top-4 used 104 and reached 38/38 but was
+  slower and not a ≤1 cm result. The Python benchmark now exposes named
+  schedules, manifest validation, `--allow-incomplete` negative A/B JSON,
+  candidate/verification/mapping counters and elapsed time; exhaustive remains
+  the default/control and the reduced 200-pair result is not the README
+  champion.
+
+- **Office milestone-2 evidence and Auto post quality guard (2026-08-31).** On
+  the frozen `office-authoritative-venv` feature cache, exhaustive `.8` +
+  cross-check raised the candidate graph to **325 pairs**, but the safe
+  verified graph still had a 23-image component and isolated `DSC_0238`–
+  `DSC_0240`; the exact current Auto run remained **17/26** before post and
+  **18/26** after one post-registration addition (`1,082` tracks / `3,037`
+  observations, `1.512 px`).  The missing no-flag images were
+  `DSC_0236`–`DSC_0241`, `DSC_0253`, and `DSC_0254`; `.8` cross-check had zero
+  verified support for `DSC_0238`–`DSC_0240`.  A bounded `.9` cross-check
+  control reached **21/26** but still left `DSC_0237`–`DSC_0241` incomplete;
+  no-cross-check rescue connected the graph but was rejected for unsafe
+  conflicts.  Auto post candidates now require both a strict registration
+  increase and finite, non-increasing mean reprojection error, so extra
+  registrations cannot silently replace a cleaner model.  The change is
+  general/default-safe and does not lower PnP thresholds or admit unverified
+  bridges; focused Auto tests, release example check, and the frozen Office
+  rerun passed.  Under safe `.8` verification, the graph gives a hard
+  connectivity ceiling below 26/26; no unsupported pose was fabricated.
+
+- **Office high-density frontend rescue diagnostic (2026-08-31).** A genuine
+  `colmap/colmap:latest` CPU run (COLMAP `4.2.0.dev0`) on the full-resolution
+  26-image Office set, with supplied PINHOLE intrinsics only, produced
+  **167,891** SIFT rows, **325/325** raw pairs and **173** non-empty verified
+  pairs (**83,438** inliers).  Official COLMAP mapping reached **26/26** with
+  13,425 points / 44,979 observations and 0.50 cm calibration-reference
+  centre RMSE.  The same exported keypoints/descriptors through visloc's
+  existing NN/full-verifier path reached **26/26**, 17,772 tracks / 47,503
+  observations, 0.380 px mean reprojection, and 0.34 cm centre RMSE.
+  Bounded SuperPoint/LightGlue rematching of the frozen cache reached only
+  **21/26** (88/325 verified, 7,641 inliers), with `DSC_0238`–`DSC_0240`
+  still lacking raw support.  The existing explicit supplement/import path
+  is the reusable deterministic artifact-merge mechanism; no automatic
+  cross-frontend trigger is added because the successful official SIFT arm is
+  a separate diagnostic frontend and the learned rescue does not provide a
+  safe complete candidate.  Durable models, DB, feature export, hashes and
+  logs are under
+  `runs/office-colmap-sift8192-20260831`; exact commands and per-image
+  support are recorded in the current handover.
+
+- **Courtyard benchmark automation (2026-08-31).** Added the
+  hash-pinned `scripts/benchmark_courtyard.sh` / JSON manifest entry point.
+  Its dependency-free verify-only smoke validates the durable 38-image,
+  439,481-feature, exhaustive 703-pair / 306,324-raw-match artifact, both
+  38/38 text models, and the README PNG/GIF/table claims; the stored visloc
+  control is **0.005379 m** centre RMSE (under the **0.01 m** gate). `--full`
+  reruns the recorded per-image-calibration mapping and emits deterministic
+  JSON/logs, with optional COLMAP validation/run and visual regeneration.
+  Large dataset-derived files remain external; hosted CI runs only parser,
+  hash/threshold tests and shell syntax, with self-hosted instructions in
+  [the benchmark guide](docs/courtyard_benchmark.md).
+
 - **Auto demo-default closure and snapshot compatibility (2026-08-31).** The
   two SfM demos now omit `--next-image-policy` as `Auto`, while
   `IncrementalSfmConfig::default()` remains historical `CorrespondenceCount`.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,55 @@
 
 <p align="center"><sub>Lower centre RMSE is better. The plot is aligned to the supplied calibration proxy; tracks versus points and reprojection reports are not identical accounting schemes. <a href="#courtyard-control-details">Details, provenance, and reproduction</a>.</sub></p>
 
+## Run the SfM demo
+
+Build the example with the `image-io` feature. The unordered demo accepts a
+directory of photos, estimates SIFT features in process, and writes a COLMAP
+text model (`cameras.txt`, `images.txt`, and `points3D.txt`) to the path given
+by `--out-colmap`. Supply either scalar intrinsics, as below, or a validated
+per-image model with `--input-colmap-calibration`; datasets and calibration
+files are external inputs and are not bundled with this repository.
+
+```bash
+cargo run --release --example unordered_sfm_demo --features image-io -- \
+  --feature-extractor sift \
+  --images-dir /path/to/my_photos \
+  --width 1920 --height 1080 --fx 1400 --fy 1400 --cx 960 --cy 540 \
+  --sift-max-keypoints 4096 \
+  --retrieval-topk 12 --min-matches 30 --match-ratio 0.8 \
+  --verification-mode full --mapper incremental \
+  --next-image-policy auto --post-refinement-registration \
+  --final-iterative-refinement \
+  --out-colmap /path/to/runs/my-photos-sfm
+```
+
+For the measured courtyard control, keep the artifact, image, and calibration
+paths explicit. `--verify-only` is fast and read-only; `--full` starts a fresh
+mapping run and writes its JSON summary/model under `--output-dir`.
+
+```bash
+ARTIFACT_ROOT=/path/to/colmap_highres_exhaustive_allpairs_20260830
+IMAGES_DIR=/path/to/dslr_images_undistorted
+CALIBRATION_MODEL=/path/to/dslr_calibration_undistorted
+
+scripts/benchmark_courtyard.sh --verify-only \
+  --artifact-root "$ARTIFACT_ROOT" \
+  --images-dir "$IMAGES_DIR" \
+  --calibration-model "$CALIBRATION_MODEL" \
+  --colmap-control validate --visuals check
+
+scripts/benchmark_courtyard.sh --full --no-build \
+  --artifact-root "$ARTIFACT_ROOT" \
+  --images-dir "$IMAGES_DIR" \
+  --calibration-model "$CALIBRATION_MODEL" \
+  --output-dir /path/to/runs/courtyard-sfm \
+  --colmap-control validate --visuals skip
+```
+
+The example header documents the complete unordered-SfM option set; the
+[courtyard benchmark guide](docs/courtyard_benchmark.md) documents artifact
+validation, candidate schedules, and reproducible large-run details.
+
 <p align="center">
   <img src="docs/assets/hero_euroc_mh01_slam.gif" alt="Online stereo SLAM on EuRoC MH_01: onboard camera footage beside the live map — estimated trajectory vs ground truth as stereo landmark replenishment grows the landmark map" width="820"><br>
   <sub>Online stereo SLAM on EuRoC MH_01 — onboard camera and the live map growing in real time: uninterrupted tracking throughout the shown 583-frame measured segment (100% coverage, 0.344 m rigid ATE RMSE), with the landmark map grown by stereo landmark replenishment. Still version: <a href="docs/assets/hero_euroc_mh01_light.png">light</a> · <a href="docs/assets/hero_euroc_mh01_dark.png">dark</a>.</sub>
@@ -85,6 +134,11 @@ python3 scripts/generate_courtyard_readme_visuals.py \
   --reference-model <calibration_model> \
   --output-dir docs/assets
 ```
+
+For a hash-checked, one-command validation or fresh rerun of this control, see
+[`docs/courtyard_benchmark.md`](docs/courtyard_benchmark.md) and run
+[`scripts/benchmark_courtyard.sh`](scripts/benchmark_courtyard.sh). Large
+dataset-derived artifacts remain external to the repository.
 
 Secondary frozen-cache measurements are kept separate from that central
 control:

--- a/benchmarks/courtyard/exhaustive_control.json
+++ b/benchmarks/courtyard/exhaustive_control.json
@@ -1,0 +1,232 @@
+{
+  "schema_version": 1,
+  "benchmark": {
+    "id": "courtyard-colmap-exhaustive-v1",
+    "name": "ETH3D courtyard exhaustive high-resolution control",
+    "description": "The official high-resolution CPU-SIFT feature/match control used by the README courtyard comparison."
+  },
+  "artifact_root": "/media/sasaki/aiueo1/visloc-rs/eth3d/courtyard/artifacts/colmap_highres_exhaustive_allpairs_20260830",
+  "inputs": {
+    "features": {
+      "manifest": {
+        "path": "features_sixcol/MANIFEST.tsv",
+        "sha256": "030b02982e263f3b5e3d94d1edd873b757894b4c20a9609feef264cadffd0d2a"
+      },
+      "file_count": 38,
+      "total_rows": 439481,
+      "row_order": "source COLMAP row order is preserved"
+    },
+    "matches": {
+      "path": "exhaustive/matches_import.txt",
+      "sha256": "3c6956571ebca49dff647c187beea2f602292f892d31f42500368d620011d986",
+      "pair_count": 703,
+      "raw_match_count": 306324,
+      "candidate_semantics": "all unordered pairs (38*37/2)"
+    },
+    "images": {
+      "directory": "/home/sasaki/datasets/eth3d/courtyard/images/dslr_images_undistorted",
+      "suffix": ".JPG",
+      "file_count": 38,
+      "sha256": {
+        "DSC_0286.JPG": "e06f96bb23ec05f92d28ee72022656e2f9df82aff470792c757b25596e7972f9",
+        "DSC_0287.JPG": "cf956f640104131e83f5bd3ff78adb734bbd1aab7519c55b77d59eceeb628729",
+        "DSC_0288.JPG": "e7f3d4f8e22995748ff68ad1891650ab2625c023c3d974e7b8245ecb98b11803",
+        "DSC_0289.JPG": "d9e8740ad9ed5736d27845a37761988ef988e2b7088c36ed4f4bd5dc9aa6e5fb",
+        "DSC_0290.JPG": "3accbd742bf34dd6e11bbc472efd69fddcf66724bbc871c028f021b8664d1f59",
+        "DSC_0291.JPG": "adc9601acef932c60474f6135a31b3566bb82f6ae5a5793fbb5823859d5fbf9f",
+        "DSC_0292.JPG": "c1cbfecf7f275ec65cc3651d91f7c9e5d4be6f96791a3c9ceb45e89006a07ba2",
+        "DSC_0293.JPG": "872e5bfac80d0f365fc371c5ac8685ee21c58197fbb64340efc63ed799aa88fb",
+        "DSC_0294.JPG": "bdeac021227c0b8ba9efb2e4fd148faf909f0fcabef610cb8e0dda0e0794ef68",
+        "DSC_0295.JPG": "ec36831bef9e38bcc2ec560d166c06d73389b7b73b879be9f775479ba281c572",
+        "DSC_0296.JPG": "a41bbcced9d332ae90a7ea81b3fb0d04565e4190661aa614b271ca915db30100",
+        "DSC_0297.JPG": "1c549f40ab2f500077c29023eb7590befaf46d201690dd5f506ac701ff949eae",
+        "DSC_0298.JPG": "1512a1b88df659e5db0c9dead7b567f8c77e984d3ba82442aca60d44f5d3b5a9",
+        "DSC_0299.JPG": "953b00ae237d1e8502e12341aea71ddabac713ff489011aa62fc832ad361f08e",
+        "DSC_0300.JPG": "7680b5a1f2525704f16979f1fbea2b935381d14e4d415faf465a6e082c23ed82",
+        "DSC_0301.JPG": "907de706d2bf95dafc3fd8968f1d0a0c76d34755ba29d70e6dd6779beeca46b3",
+        "DSC_0302.JPG": "26b6f823cbfdc3d7b821ddd4857c72f63355cf246b164b82326cbd2408fac891",
+        "DSC_0303.JPG": "7ddb837f50dbaf3ae49de0a18613411bc1bb017a663254275b264f33dd21941d",
+        "DSC_0304.JPG": "63104e1cad5f18658b0e9aa6b89c3546cbc8fe4fb8b37305a92bc9217c535d20",
+        "DSC_0305.JPG": "e2bebb6883b7db2e1448a1897fe6be86cedd2c43802e5fb47f89ad25afd3bb57",
+        "DSC_0306.JPG": "fceff602dd59c7bf96c0663f795d08c188a1188d2a2b105b3f001a1a265ed934",
+        "DSC_0307.JPG": "1c04b2bc2595b2e38fd095f7aef3e5cb40874a716a57a7b4dcd56c6facf3450c",
+        "DSC_0308.JPG": "d73e78ea4216e1bf32dcd19bb00edfc0cfb2842c83e84b80cd56cbcbbf146fc1",
+        "DSC_0309.JPG": "1794c28ed2b65c1085925216c3c4c6310bef56e5092ffa1abc29de3b5e654be7",
+        "DSC_0310.JPG": "b207988862e4e67a719c3a2ffd172514f2e78339e0429c51d72152456d8bc84a",
+        "DSC_0311.JPG": "112c1e981145042a528b926473dfd9013db7c6f403bb00ba7aad9cfcfd22f8bb",
+        "DSC_0312.JPG": "6ea452300bf67145c56d277c803d42aa134e36a476fc7d353bedf158e001e02e",
+        "DSC_0313.JPG": "0f14c27ef8b79939d19b40a28a0a0beee6fe0a7d0300fe7cf0d86ce4b90464a4",
+        "DSC_0314.JPG": "d2e6494d3e50bdd1a8c22b86cc110f3583ba348c84ab311654fefc533d6c6541",
+        "DSC_0315.JPG": "cff88f395b25887547e7359b1b540af797d66aa0a8da755d7c231f4f7e488142",
+        "DSC_0316.JPG": "433efa90ab766e07ff912f4b1bd8ff8f3d2455271fd62c385671cc5cf7a2b6a1",
+        "DSC_0317.JPG": "b77d5da14fbc812721c122e11c83f4094ae92b1f51d1fa945304b7ec36accc88",
+        "DSC_0318.JPG": "234d2c5fa16a7b9316505cc7867470712750f58f31912baaf43ef41de9db6a6a",
+        "DSC_0319.JPG": "d0f26268a5642fe36a5fa33ae2416e0ec0af863950b811e9da80afda7506c9f4",
+        "DSC_0320.JPG": "94ad73b669e5b147ca9f66863c410abe8e77076c2d386903fbc0e1b377f6e675",
+        "DSC_0321.JPG": "363db10460ae2157ebcc6c11d148bad2dc95c3dc0a77b3a84dc65719a1a2d219",
+        "DSC_0322.JPG": "0694af517a104252d8635d85e2c977db0513d172066e0a12851dcad49066198c",
+        "DSC_0323.JPG": "2c81ba423cc705a3e16fcd1ed452cd92415abd1f00b635dc7acb6016bab195cb"
+      }
+    },
+    "calibration": {
+      "model_dir": "/home/sasaki/datasets/eth3d/courtyard/dslr_calibration_undistorted",
+      "files": {
+        "cameras.txt": "0cf9d1f1615b89eed8e48a92ef0ee44352f0fbadbb1be0c00b12f15d01c1f83c",
+        "images.txt": "1afcc917c0538cf7168ca9c045574a786402553712be0ad2ae5affdc52b87f02",
+        "points3D.txt": "43e43c438a3abdb9b162fac935a77f87733efafb16b6cdc65983d6da00232b9d"
+      },
+      "registered": 38
+    }
+  },
+  "models": {
+    "visloc": {
+      "path": "visloc_model",
+      "files": {
+        "cameras.txt": "76fc758375228319300a5c076b6bcc84a88413d69cf3613eb40c980b60e8cc9c",
+        "images.txt": "a14ac6b958bf09481bfcc0ae72b59671d8e6405cd880e4711ff14c5c9432852e",
+        "points3D.txt": "d7b680e6d51a403a4962920e8f0e0615f382646a1ac9836f160ecb44622a3293"
+      },
+      "registered": 38,
+      "tracks": 43852,
+      "observations": 152432,
+      "reprojection_px": 0.579,
+      "score_file": {
+        "path": "visloc_model_score.txt",
+        "sha256": "e393a004fae4e448b34e6b219971601f7a0f0b9ddbe89a77d90c3cf71596e37b"
+      },
+      "score_rmse_m": 0.005379
+    },
+    "colmap": {
+      "path": "calibrated_mapper/sparse_single_txt",
+      "files": {
+        "cameras.txt": "1e612c4b481e01797aec1164c1e30e2f8982cd1eebfe3153c9eea247be08e879",
+        "images.txt": "4c6c5e52a57d59bc8494a3b5c50e61b73d5386590ad957764fa22bce6a4a6454",
+        "points3D.txt": "f91574c58a241cf446a692b2ab2c89c93b8a939ae0947488a6199cffe9a623bd"
+      },
+      "registered": 38,
+      "points": 38422,
+      "observations": 169590,
+      "reprojection_px": 0.744758,
+      "score_rmse_m": 0.016166
+    }
+  },
+  "expected": {
+    "image_count": 38,
+    "pair_count": 703,
+    "feature_file_count": 38,
+    "feature_row_count": 439481,
+    "visloc_registered": 38,
+    "visloc_rmse_m": 0.005379,
+    "max_rmse_m": 0.01,
+    "colmap_registered": 38,
+    "colmap_rmse_m": 0.016166
+  },
+  "mapping": {
+    "feature_suffix": "_features.txt",
+    "image_suffix": ".JPG",
+    "min_matches": 20,
+    "match_ratio": 0.8,
+    "verification_mode": "full",
+    "mapper": "incremental",
+    "pnp_max_iterations": 100000,
+    "min_pnp_inliers": 8,
+    "next_image_policy": "visibility",
+    "exhaustive": true,
+    "geometry_guided_conflict_recovery": true,
+    "post_refinement_registration": true,
+    "final_iterative_refinement": true
+  },
+  "candidate_schedules": {
+    "exhaustive": {
+      "strategy": "exhaustive",
+      "candidate_count": 703
+    },
+    "sequential-n3": {
+      "strategy": "sequential",
+      "stem_window": 3,
+      "candidate_count": 108
+    },
+    "vlad-topk-4": {
+      "strategy": "vlad",
+      "retrieval_topk": 4,
+      "candidate_count": 99
+    },
+    "vlad-topk-8": {
+      "strategy": "vlad",
+      "retrieval_topk": 8,
+      "candidate_count": 188
+    },
+    "vlad-topk-12": {
+      "strategy": "vlad",
+      "retrieval_topk": 12,
+      "candidate_count": 259
+    },
+    "vlad-mutual-topk-8": {
+      "strategy": "vlad-mutual",
+      "retrieval_topk": 8,
+      "candidate_count": 116
+    },
+    "local-vlad-union-3-8-200": {
+      "strategy": "vlad-union",
+      "local_stem_window": 3,
+      "retrieval_topk": 8,
+      "candidate_budget": 200,
+      "candidate_count": 200
+    },
+    "adaptive-vocab4": {
+      "strategy": "adaptive",
+      "vocab_tree_num_images": 4,
+      "candidate_count": 104,
+      "note": "transitive expansion is intentionally measured separately; the base candidate pass is cacheable"
+    }
+  },
+  "runtime": {
+    "rayon_threads": 1
+  },
+  "colmap_control": {
+    "database": "exhaustive/database_calibrated.db",
+    "note": "--colmap-control run is optional and writes a new external model; validate is the default."
+  },
+  "visuals": {
+    "readme": "README.md",
+    "assets": {
+      "png": {
+        "path": "docs/assets/courtyard_sfm_comparison.png",
+        "sha256": "d5d33b1a986debb1b6a99e64bbf937b8b07e8639d867789f01eae1446cb84665",
+        "width": 1458,
+        "height": 883
+      },
+      "gif": {
+        "path": "docs/assets/courtyard_sfm_comparison.gif",
+        "sha256": "a2b76c47f8680265872240caaba7fee6615a63f12b61e3021e9b1c91b98b2b8e",
+        "width": 772,
+        "height": 432,
+        "frames": 24
+      }
+    },
+    "readme_needles": [
+      "38/38 cameras registered at 0.5379 cm centre RMSE",
+      "versus 1.6166 cm for official COLMAP CPU SIFT",
+      "43,852 tracks / 152,432 observations",
+      "38,422 points / 169,590 observations",
+      "0.579 px",
+      "0.744758 px",
+      "docs/assets/courtyard_sfm_comparison.gif",
+      "docs/assets/courtyard_sfm_comparison.png"
+    ]
+  },
+  "future_scale": {
+    "feature_shards": null,
+    "candidate_manifest": {
+      "format": "visloc_candidate_manifest_v1",
+      "last_verified_sha256": "2d654b9ed124ec1732d65f4f3829dfadba5e3e978b085844b59c1ee5e5ed32c1",
+      "pairs": 200,
+      "provenance": "generated from pre-match VLAD top-8 plus numeric-stem window-3 local edges, budget 200"
+    },
+    "note": "The exhaustive control validates all 703 pairs. Candidate schedules are optional pre-match reductions; a versioned image-bound manifest can be generated with --write-candidate-manifest and replayed with --candidate-manifest."
+  },
+  "artifact_manifest": {
+    "path": "SHA256SUMS",
+    "sha256": "12e91cd3a2e595625ef167d8cd8a2af6310d3ea3cd1e3b1a0c2f8264004fa96e"
+  }
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -401,8 +401,8 @@ CLI 省略時は `NextImagePolicy::Auto`、`IncrementalSfmConfig::default()` は
 API/ライブラリ互換性のため `CorrespondenceCount` のままである。Auto は
 Visibility を先に試し、未登録画像が一つでもあれば同じ feature/pair 入力で
 Count も評価する。選択後に未完なら clean state から post-refinement を一度
-試し、登録画像数が strict に増えた時だけ採用する。tie または減少時は
-post 前のモデルを保持する。
+試し、登録画像数が strict に増え、かつ平均 reprojection が有限で既存以下の
+時だけ採用する。tie、減少、または誤差悪化時は post 前のモデルを保持する。
 
 凍結 cache の no-flag 実測（各 run の `run.log` に完全なコマンドと
 `effective-config: ... next_image_policy: Auto` を保存）は次の通り。
@@ -466,3 +466,226 @@ release build、および `sh scripts/check.sh` と `git diff --check` である
 Windows-only gate は Linux host のため未実行である。未コミットの既存
 SfM/SIFT/BA/CLI/docs 差分は保持し、repo 内に feature/db/log/temp/secret は
 追加していない。
+
+## 14. Office milestone 2 connectivity audit (2026-08-31)
+
+対象は固定した同一 cache
+`/media/sasaki/aiueo1/visloc-rs/eth3d/nonregression_20260830/runs/office-authoritative-venv/features`
+と、全画像共通の PINHOLE `6221x4146, fx=3437.84, fy=3435.95,
+cx=3127.19, cy=2066.98` である。Auto no-flag の完全な未登録画像は
+`DSC_0236, DSC_0237, DSC_0238, DSC_0239, DSC_0240, DSC_0241,
+DSC_0253, DSC_0254`。初期 Visibility/Count はともに 17/26 で、Count
+選択後の clean post pass は `DSC_0223` を 52 correspondences / 13 PnP
+inliers で追加し、18/26、1,082 tracks / 3,037 observations、1.512 px
+となった。再実行でも同じ結果を得た。
+
+### Verified-graph upper-bound evidence
+
+全探索 `.8` + cross-check の診断は 325 candidate pairs、92 verified pairs、
+5,686 accepted inliers。検証済みグラフは 23-image component と孤立した
+`DSC_0238`–`DSC_0240` で、後者は raw matches が各 24/40/30 ある一方
+accepted inliers はすべて 0。従って `.8` の安全な verifier/track graph
+だけでは 26/26 を支える幾何辺が存在しない。`.9` + cross-check は
+`DSC_0238` を `DSC_0237` 経由で 15 inliers まで増やし、21/26 の実再構成
+になったが、`DSC_0239` と `DSC_0240` はなお孤立（安全上の上限は 24-image
+connectivity）。`.95` no-cross-check は全26画像を接続したものの、relaxed
+bridges の同一画像 conflict が増え、rescue 実測は 18/26・967 tracks /
+2,619 observations・1.492 px に悪化したため採用しない。
+
+### A/B and implementation disposition
+
+detached baseline `2a36d44`、current Count、Visibility、Auto、全探索 `.8`
+recovery/post、`.9` control の入力 artifacts は同一である。候補 coverage
+だけを増やしても `DSC_0238`–`DSC_0240` の verifier failure は解消せず、
+track/PnP 側だけで 26/26 を作るのは GT-free では安全でない。今回の最小
+実装は Auto post の clean-candidate 採用条件のみであり、Count/Visibility
+および `IncrementalSfmConfig::default()`、PnP 閾値、cross-check semantics
+は変更していない。`next_image_auto_post_candidate_is_better` の focused
+unit tests は、登録増分・finite error・非悪化を確認する。
+
+実測コマンドと durable run paths は CHANGELOG の Office entry と
+`docs/nonregression_20260830.md` に残し、`.8` safe graph での次の候補は
+検証失敗理由を改善する descriptor/geometry parity の診断である。false
+pose を追加する一般緩和は停止条件とした。
+
+## 15. Office milestone 2 high-density frontend rescue (2026-08-31)
+
+### Genuine official COLMAP CPU control
+
+固定 cache の上限を結論にしないため、公式の full-resolution Office 26画像
+（各 `6221x4146`）を新規 DB へ再抽出した。mapping へ渡したのは supplied
+ calibration の PINHOLE intrinsics (`fx=3437.84, fy=3435.95,
+ cx=3127.19, cy=2066.98`) だけで、extrinsics/laser GT は入力していない。
+使用コンテナは `colmap/colmap:latest`、`COLMAP 4.2.0.dev0 (Commit Unknown
+ on Unknown with CUDA)` だが、全工程で GPU を無効化した。
+
+再現コマンド（`$IMG` は source image directory、`$OUT` は空の新規 directory）:
+
+```sh
+docker run --rm -v "$IMG:/input:ro" -v "$OUT:/output" \
+  colmap/colmap:latest colmap feature_extractor \
+  --database_path /output/database.db --image_path /input \
+  --ImageReader.camera_model PINHOLE --ImageReader.single_camera 1 \
+  --ImageReader.camera_params 3437.84,3435.95,3127.19,2066.98 \
+  --FeatureExtraction.use_gpu 0 --SiftExtraction.max_num_features 8192 \
+  --SiftExtraction.first_octave -1 --SiftExtraction.num_octaves 4 \
+  --SiftExtraction.octave_resolution 3 --SiftExtraction.peak_threshold 0.00667 \
+  --SiftExtraction.edge_threshold 10 --SiftExtraction.max_num_orientations 2
+docker run --rm -v "$IMG:/input:ro" -v "$OUT:/output" \
+  colmap/colmap:latest colmap exhaustive_matcher \
+  --database_path /output/database.db --FeatureMatching.use_gpu 0 \
+  --SiftMatching.max_ratio 0.8 --SiftMatching.cross_check 1 \
+  --FeatureMatching.guided_matching 1
+mkdir -p "$OUT/sparse"
+docker run --rm -v "$IMG:/input:ro" -v "$OUT:/output" \
+  colmap/colmap:latest colmap mapper \
+  --database_path /output/database.db --image_path /input \
+  --output_path /output/sparse --Mapper.min_num_matches 15 \
+  --Mapper.multiple_models 1 --Mapper.max_num_models 50 \
+  --Mapper.num_threads 4 --Mapper.ba_use_gpu 0
+```
+
+実測は `167,891` keypoint/descriptor rows、`325/325` raw pairs、
+`173` non-empty verified pairs、`83,438` accepted inliers だった。画像ごとの
+全対 raw/verified graph support は次の通りで、従来の8欠落画像にも安全な
+geometry edge が存在する。
+
+| image | raw matches | verified degree | verified inliers |
+|---|---:|---:|---:|
+| `DSC_0236` | 11,696 | 11 | 14,686 |
+| `DSC_0237` | 11,060 | 7 | 15,392 |
+| `DSC_0238` | 7,310 | 5 | 10,590 |
+| `DSC_0239` | 5,164 | 5 | 6,775 |
+| `DSC_0240` | 6,177 | 5 | 8,993 |
+| `DSC_0241` | 10,231 | 11 | 14,736 |
+| `DSC_0253` | 1,702 | 16 | 4,194 |
+| `DSC_0254` | 1,336 | 15 | 3,014 |
+
+公式 COLMAP mapper は **26/26** を登録し、`13,425` points / `44,979`
+observations を出力した。supplied calibration extrinsics との診断 score は
+center RMSE **0.50 cm**（median `0.25 cm`, max `1.94 cm`）である。これは
+公式 mapper の feasibility control であり、extrinsics/GT を mapping に
+注入した結果ではない。
+
+### Same official features through visloc
+
+COLMAP DB の keypoint/uint8 descriptor rows を text feature files へ変換し、
+同じ入力を visloc の `NN + ratio .8 + exhaustive + full verifier`、per-image
+calibration、`pnp100k/min8 + geometry-guided-conflict-recovery +
+post-refinement-registration + final-iterative-refinement + Auto` へ渡した。
+DB export は外部の検証済み converter で行った。
+
+```sh
+python3 /media/sasaki/aiueo1/visloc-rs/scripts/export_colmap_sift_features.py \
+  --database "$OUT/database.db" --out-dir "$FEATURES"
+target/release/examples/unordered_sfm_demo \
+  --feature-extractor files --features-dir "$FEATURES" \
+  --feature-suffix _features.txt --image-suffix .JPG \
+  --images-dir "$IMG" --input-colmap-calibration "$CAL" \
+  --exhaustive --min-matches 30 --match-ratio 0.8 \
+  --verification-mode full --mapper incremental \
+  --pnp-max-iterations 100000 --min-pnp-inliers 8 \
+  --geometry-guided-conflict-recovery --post-refinement-registration \
+  --final-iterative-refinement --next-image-policy auto \
+  --out-colmap "$VISLOC_OUT/colmap"
+```
+
+ここで `$IMG` は source image directory、`$CAL` は per-image calibration
+directory、`$OUT` は official COLMAP run、`$FEATURES` は text export、
+`$VISLOC_OUT` は空の新規 output directory である。
+この run は **121/325 verified**、`45,285` verifier inlier correspondences、
+初期 track build `18,704` tracks を経て、最終 **26/26**、`17,772` tracks /
+`47,503` observations、mean reprojection **0.380 px**、calibration-reference
+center RMSE **0.34 cm**（median `0.22 cm`, max `0.67 cm`）となった。欠落8画像の
+PnP は次の通りで、raw support だけでなく登録可能な 2D--3D support も得ている。
+
+| image | PnP correspondences | PnP inliers | ratio |
+|---|---:|---:|---:|
+| `DSC_0236` | 54 | 50 | 0.926 |
+| `DSC_0237` | 2,014 | 1,962 | 0.974 |
+| `DSC_0238` | 1,581 | 1,562 | 0.988 |
+| `DSC_0239` | 1,577 | 1,572 | 0.997 |
+| `DSC_0240` | 1,667 | 1,656 | 0.993 |
+| `DSC_0241` | 47 | 36 | 0.766 |
+| `DSC_0253` | 121 | 75 | 0.620 |
+| `DSC_0254` | 118 | 78 | 0.661 |
+
+従って、凍結 SuperPoint cache の no-flag `17/26 -> post 18/26`、bounded
+LightGlue supplement の `21/26` に対し、公式 SIFT は frontend 起因の
+observability gap を埋めて `26/26` にする。ただし official SIFT は現行の
+SuperPoint/LightGlue extractor の単なる sparse rematch ではなく別 frontend
+である。LightGlue の 31 bounded candidate supplement は `88/325` verified /
+`7,641` inliers、最終 `21/26` で、`DSC_0238`--`DSC_0240` は raw support 不足
+のままだった。
+
+### Artifact and implementation disposition
+
+全成果物（公式 DB、text features、公式/visloc text models、LightGlue
+supplement、logs、SHA-256）は次に隔離保存した。
+
+```text
+/media/sasaki/aiueo1/visloc-rs/eth3d/nonregression_20260830/
+  runs/office-colmap-sift8192-20260831/
+```
+
+主要 hash は DB `f904a0dc3cb22e1e019e4dafcd74d77a9b4a9f18daa19c3ab2eeed710135fbde`、
+公式 `sparse_txt/images.txt` `9d98833d40ea3d3bc9a0f257c2a764f19dde336db917d999f4c8658c43796702`、
+visloc `colmap/images.txt` `93e7262792016c8a3877d26ded38d2892b458cb42067151bd34114460910e8d4`
+である。既存の `--import-matches-supplement-file` と file-feature input は、
+candidate を限定した高密度 artifact を deterministic に追加する再利用可能な
+merge path であり、今回の LightGlue run でも使用した。一方、公式 SIFT の成功は
+別 extractor の置換結果であり、未登録画像だけを自動再抽出して選択する品質保証
+（同じ row/provenance を保ったまま全 suite で候補を比較する仕組み）はまだない。
+したがって今回は Auto の暗黙 trigger や dataset-specific rescue を追加せず、
+公式 SIFT result を frontend feasibility ceiling として記録する。次の実装候補は
+この既存 supplement interface に、validated feature-manifest/provenance と bounded
+per-image rematch selection を一般化して加えることだが、現データだけで既定動作を
+変更する根拠にはしない。
+
+## 16. Milestone 3 bounded candidate scheduling (2026-08-31)
+
+候補生成をmatch/verifier前に限定するM3実装を追加した。`PairSource` の
+`vlad-mutual` と、numeric stemのlocal windowとVLAD retrievalを決定的に併合して
+budgetで切る `vlad-union` を追加し、`visloc_candidate_manifest_v1`（画像名・順序を
+束縛したpair-only manifest、重複/範囲検証、同一ディレクトリのatomic rename）を
+`--export-candidate-manifest` / `--candidate-manifest` で再利用できるようにした。
+通常のpair source/defaultは変更していない。
+
+候補選択は画像順/filename stemと事前VLADだけを使う。凍結したraw match importは
+候補選択後のverification replayにのみ使い、GT、official extrinsics、raw/inlier数を
+候補順位付けへ渡していない。`scripts/benchmark_courtyard.py` はconfigの名前付き
+schedule、manifest hash/row validation、`--allow-incomplete` negative A/B、候補数・
+verified/inlier数・tracks/observations・reprojection・mapping elapsedとJSON gateを
+提供する。exhaustive 703-pair controlは引き続き既定である。
+
+### Frozen courtyard A/B
+
+共通条件はofficial high-resolution SIFT features、per-image calibration、ratio .8、
+cross-check/full verifier、geometry recovery、post/final incremental mapperである。
+
+| schedule | candidates | verified / inliers | registration | tracks / observations | reprojection | centre RMSE |
+|---|---:|---:|---:|---:|---:|---:|
+| exhaustive control | 703 | 366 / 261,724 | 38/38 | 43,852 / 152,432 | 0.579 px | 0.5379 cm |
+| local stem≤3 + VLAD top-8, budget 200 | 200 | 172 / 199,871 | 38/38 | 45,016 / 148,192 | 0.537 px | 0.66 cm |
+| VLAD top-8, non-mutual | 188 | 158 / 187,191 | 38/38 | 44,800 / 135,485 | 0.502 px | 14.17 cm |
+| VLAD top-8, mutual | 116 | 112 / 156,140 | 13/38 | 16,646 / 50,278 | 0.478 px | 33.97 cm* |
+| sequential stem≤3 | 108 | 100 / 136,553 | 23/38 | 25,315 / 77,273 | 0.499 px | 1.08 cm* |
+| vocab-tree base top-4 | 104 | 89 / 129,766 | 38/38 | 44,002 / 121,742 | 0.425 px | exploratory |
+
+`*` は登録済みsubsetだけの診断scoreであり、full gateではない。200-pair unionは
+703から503 pair（71.6%）を削減しながら38/38・1cm以下を維持したが、最小RMSEの
+exhaustive championではない。manifest replay runのhashは
+`2d654b9ed124ec1732d65f4f3829dfadba5e3e978b085844b59c1ee5e5ed32c1` である。候補
+生成31.4秒、manifestからのmapping57.3秒（RAYON_NUM_THREADS=1）をJSONへ保存した。
+このM3結果をOffice/South/terrace/EuRoCの品質主張へ流用せず、各suiteのfrontend/cache
+比較は従来の記録を使う。
+
+## 17. Milestone 4 large-scale unordered-SfM plan (2026-08-31)
+
+大規模化はまだ実行せず、候補データセット、公式一次情報、段階的なresource/runbook、
+候補budget・shard・atomic resume・component recovery・評価ゲートを
+[`docs/large_scale_unordered_sfm_plan.md`](large_scale_unordered_sfm_plan.md) に整理した。
+最初の対象は公式ETH3D low-res many-view `electro`（300画像probe → 1,200画像）で、
+10k級へ進む前に候補recall・登録率・再現hash・RSS/disk上限を確認する。
+この計画はdownload/large runを含まず、courtyard exhaustive 703-pair / 38/38 /
+0.005379 m gateとM3 200-pair A/Bを変更しない。

--- a/docs/courtyard_benchmark.md
+++ b/docs/courtyard_benchmark.md
@@ -1,0 +1,194 @@
+# Reproducible courtyard benchmark
+
+`benchmarks/courtyard/exhaustive_control.json` pins the high-resolution ETH3D
+courtyard control used by the README. The 38 source images, six-column
+COLMAP-SIFT files, all-pairs raw matches, calibration, and completed model
+outputs remain in the external artifact directory; none are checked into this
+repository.
+
+The one-command entry point is:
+
+```bash
+scripts/benchmark_courtyard.sh --verify-only
+```
+
+The default artifact root is the path recorded in the manifest. On another
+machine, pass the durable copy explicitly (or set
+`COURTYARD_ARTIFACT_ROOT`). The source images and calibration model are
+licensed external inputs and are pinned as absolute paths in this checkout;
+when they live elsewhere, pass both overrides as well. Their files are still
+checked against the hashes in the manifest:
+
+```bash
+scripts/benchmark_courtyard.sh \
+  --artifact-root /media/sasaki/aiueo1/visloc-rs/eth3d/courtyard/artifacts/colmap_highres_exhaustive_allpairs_20260830 \
+  --images-dir /path/to/dslr_images_undistorted \
+  --calibration-model /path/to/dslr_calibration_undistorted \
+  --verify-only
+```
+
+## Modes and gates
+
+`--verify-only` is the fast, read-only mode and is the default when neither
+mode flag is supplied. It checks:
+
+- the artifact checksum manifest, all 38 feature-file hashes and row counts
+  (439,481 rows total), all 38 source-image hashes, and the complete 703-pair
+  / 306,324-correspondence raw-match stream;
+- the three calibration files and the durable visloc and official COLMAP text
+  models, including their exact hashes and registered/track/observation
+  counts; and
+- the tracked README PNG/GIF hashes, dimensions, frame count, and central
+  claim/table references.
+
+It also validates the stored visloc score: 38/38 cameras and centre RMSE
+`0.005379 m`, below the default `0.01 m` gate. `--max-rmse-m` can make the
+threshold stricter, but a looser threshold should be used only for a clearly
+labelled exploratory run.
+
+`--full` first repeats those input checks, builds the image-IO example, runs
+the normal mapping command, scores the newly written model against the
+calibration model, and writes logs plus a deterministic `summary.json` under
+`--output-dir`. A fresh output directory is required; `--force` removes only
+the explicitly named output directory. The mapping command receives features,
+raw matches, source images, and per-image calibration only. The calibration
+model is opened again for centre scoring after mapping and is never supplied
+as mapping ground truth.
+
+```bash
+scripts/benchmark_courtyard.sh --full \
+  --output-dir /media/sasaki/aiueo1/visloc-rs/eth3d/courtyard/runs/benchmark_courtyard_$(date +%Y%m%d) \
+  --colmap-control validate --visuals check
+```
+
+The effective visloc configuration is pinned in the JSON manifest: exhaustive
+703-pair import, ratio 0.8, full verification, per-image PINHOLE calibration,
+plain incremental mapping, 100,000 PnP iterations, eight minimum PnP inliers,
+geometry-guided recovery, post-registration refinement, final iterative
+refinement, and the recorded `visibility` next-image policy. Output paths are
+not part of the input hashes, so a rerun can use any fresh external output
+directory. Use `--no-build` only when the release example was built with
+`--features image-io` from the same source revision.
+
+The final stdout document is sorted, indented JSON. By default it is also
+atomically written to `target/benchmark_courtyard/verify-summary.json` in
+verify-only mode or `summary.json` in the full output directory. Use
+`--summary-json PATH`, or `--summary-json -` to make stdout the only summary
+channel. Child output is captured in named log files; a failed command prints
+the command and its last log lines with a remediation hint.
+
+## Pre-match candidate schedules
+
+The exhaustive control is still the accuracy control: it proposes all
+`38 * 37 / 2 = 703` unordered image pairs. Optional `--candidate-strategy`
+schedules select image pairs before local matching and verification, using only
+image names/order and cheap VLAD retrieval. In this frozen-artifact benchmark,
+the raw match stream is replayed after selection, so no descriptor or local
+match recomputation is claimed by the reduced-run timing.
+
+The bounded schedule that currently meets the full gate is:
+
+```bash
+scripts/benchmark_courtyard.sh --full --no-build \
+  --candidate-strategy local-vlad-union-3-8-200 \
+  --write-candidate-manifest /path/to/runs/courtyard-union/candidates.txt \
+  --output-dir /path/to/runs/courtyard-union \
+  --colmap-control validate --visuals skip
+```
+
+The manifest is image-name bound and versioned (`visloc_candidate_manifest_v1`)
+with atomic write, duplicate/order checks, and a SHA-256 summary. A later run
+can skip candidate generation and replay it directly with
+`--candidate-manifest PATH`. `--allow-incomplete` returns negative A/B
+registration and score results as JSON instead of turning incompleteness into
+a process failure. Summaries include candidate count, verified pairs/inliers,
+mapping elapsed time, tracks/observations, reprojection, score, and a
+machine-readable `gate_passed` field.
+
+Measured on the frozen high-resolution artifact (ratio 0.8, cross-check/full
+verifier, imported raw matches, same recovery/post/final mapper):
+
+| pre-match schedule | candidates | verified / inliers | registered | tracks / observations | reproj. | centre RMSE |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| exhaustive control | 703 | 366 / 261,724 | 38/38 | 43,852 / 152,432 | 0.579 px | 0.5379 cm |
+| local stem ≤3 + VLAD top-8, budget 200 | 200 | 172 / 199,871 | 38/38 | 45,016 / 148,192 | 0.537 px | 0.66 cm |
+| VLAD top-8 (non-mutual) | 188 | 158 / 187,191 | 38/38 | 44,800 / 135,485 | 0.502 px | 14.17 cm |
+| VLAD top-8 (mutual) | 116 | 112 / 156,140 | 13/38 | 16,646 / 50,278 | 0.478 px | 33.97 cm* |
+| VLAD top-4 (non-mutual) | 99 | 93 / 138,421 | 13/38 | 16,725 / 47,915 | 0.456 px | 25.20 cm* |
+| sequential stem ≤3 | 108 | 100 / 136,553 | 23/38 | 25,315 / 77,273 | 0.499 px | 1.08 cm* |
+| vocab-tree base, top-4 | 104 | 89 / 129,766 | 38/38 | 44,002 / 121,742 | 0.425 px | exploratory |
+
+An asterisk marks a partial-reconstruction score over its registered subset.
+The 200-pair schedule removes 503 of 703 candidates (71.6%) while retaining
+38/38 and the ≤1 cm gate. Its reproducibility-run manifest hash is
+`2d654b9ed124ec1732d65f4f3829dfadba5e3e978b085844b59c1ee5e5ed32c1`.
+Candidate selection contains no ground-truth, official-extrinsic, raw-match,
+or inlier-count input; imported raw matches are used only after selection for
+verification replay. The exhaustive model remains the durable README/champion
+artifact.
+
+## COLMAP and README controls
+
+`--colmap-control validate` (the default) checks the durable official
+COLMAP CPU-SIFT model: 38/38, 38,422 points, 169,590 observations, and the
+recorded 1.6166 cm calibration-proxy centre RMSE. `--colmap-control skip`
+omits this control when only the visloc artifact is available. In a full run,
+`--colmap-control run` additionally requires the `colmap` executable and runs
+it against the durable calibrated database into a new output subdirectory;
+its result is scored for comparison but is not subjected to the visloc 1 cm
+gate.
+
+`--visuals check` verifies the committed PNG/GIF and README references without
+plotting dependencies. In a full run, `--visuals regenerate` invokes
+[`generate_courtyard_readme_visuals.py`](../scripts/generate_courtyard_readme_visuals.py)
+in a fresh output directory and requires byte-identical hashes and dimensions
+for the committed assets. This makes plotting-library drift an explicit,
+actionable failure rather than silently rewriting tracked visuals.
+
+## Artifact provenance and CI policy
+
+The default durable artifact root is approximately 465 MiB and contains
+licensed dataset-derived data and runtime outputs. The manifest records exact
+SHA-256 values for those inputs and the source-image files; copy it outside
+the repository and pass `--artifact-root` on a different host. Do not commit
+the datasets, databases, feature files, logs, or generated models.
+The checked `SHA256SUMS` file itself is pinned as
+`12e91cd3a2e595625ef167d8cd8a2af6310d3ea3cd1e3b1a0c2f8264004fa96e`.
+
+Hosted CI intentionally does not run the full benchmark: the dataset size,
+external artifact storage, and licensing/provenance requirements make a
+public runner invocation misleading. The normal CI suite runs the
+dependency-free parser/hash/threshold tests and shell-syntax smoke check.
+For a self-hosted or scheduled run, provision the durable artifact and use:
+
+```bash
+COURTYARD_ARTIFACT_ROOT=/path/to/colmap_highres_exhaustive_allpairs_20260830 \
+  scripts/benchmark_courtyard.sh \
+    --images-dir /path/to/dslr_images_undistorted \
+    --calibration-model /path/to/dslr_calibration_undistorted \
+    --verify-only
+COURTYARD_ARTIFACT_ROOT=/path/to/colmap_highres_exhaustive_allpairs_20260830 \
+  scripts/benchmark_courtyard.sh --full \
+    --images-dir /path/to/dslr_images_undistorted \
+    --calibration-model /path/to/dslr_calibration_undistorted \
+    --output-dir /path/to/benchmark-runs/courtyard-$(date +%Y%m%d) \
+    --colmap-control validate --visuals regenerate
+```
+
+The JSON summary is suitable for a self-hosted nightly wrapper to archive and
+compare. There is no hosted workflow claiming a result without the external
+artifact.
+
+The manifest retains `future_scale.feature_shards` for a future large-scale
+runner and records the versioned candidate-manifest format used by the
+optional schedules above. Feature sharding remains reserved; candidate
+reduction is explicit and does not replace the exhaustive control.
+
+## Large-scale follow-up plan
+
+The next validation milestone is documented in
+[`docs/large_scale_unordered_sfm_plan.md`](large_scale_unordered_sfm_plan.md).
+It starts with a 300-image ETH3D low-res `electro` probe, then a 1,200-image
+run, and defines the resource, candidate-recall, shard-integrity, and
+reproducibility gates before any 10k+ experiment. This M4 document is
+planning-only; it does not download data or alter this courtyard control.

--- a/docs/large_scale_unordered_sfm_plan.md
+++ b/docs/large_scale_unordered_sfm_plan.md
@@ -1,0 +1,237 @@
+# Large-scale unordered-SfM validation plan
+
+**Milestone 4 — planning only (2026-08-31).** This document defines the next
+validation stages; it does not download data, run a large reconstruction, or
+change the production default. The current 38-image courtyard result and the
+M3 reduced-candidate result remain the acceptance controls.
+
+## 1. Objective and rules
+
+The objective is to establish whether unordered SfM remains reproducible as
+the image count grows from hundreds to 10k+ images, while keeping candidate
+generation, matching, and mapping bounded. Every run must be independently
+restartable and must record the exact input/config/tool hashes.
+
+The following rules are non-negotiable:
+
+- Candidate selection before local matching may use only image metadata/order,
+  cheap global retrieval descriptors, and calibration metadata. It must not use
+  raw matches, verified inliers, ground truth, or supplied extrinsics.
+- Reference poses/geometry are used only after mapping for scoring. A COLMAP
+  run is a control, not an input to visloc.
+- A scene/sequence is a unit of reconstruction. Do not connect unrelated
+  scenes merely to increase the image count.
+- No `N × N` pair list, descriptor matrix, or all-image feature resident set is
+  allowed beyond the small courtyard control. Pair generation is `O(NK)` and
+  pair/feature work is streamed or sharded.
+- An interrupted run may resume only from hash-validated complete artifacts;
+  file size alone is never sufficient. Temporary outputs are atomically
+  renamed into the manifest.
+
+## 2. Dataset selection and authoritative candidates
+
+Selection criteria are: an official download/terms page, a stable scene or
+sequence identity, calibration and a reference trajectory/structure when
+available, a declared license or access agreement, and a manifest from which
+image counts and checksums can be frozen. Current availability and terms must
+be rechecked immediately before any download.
+
+| Scale | Official candidate and source | What is known before download | Use and caveat |
+| --- | --- | --- | --- |
+| Control / hundreds | [ETH3D high-res multi-view datasets](https://www.eth3d.net/datasets) | The official table lists 13 training scenes totaling 454 DSLR images; all undistorted training images are listed as 5.5 GB and each scene has calibration/scan evaluation data. | First cross-scene-capable validation after the 38-image control. Run one scene at a time; never treat the aggregate as one connected map. |
+| Recommended first large target | [ETH3D low-res many-view, official table](https://www.eth3d.net/datasets) | `electro` is listed as **4×300 images** and its undistorted image archive as about **0.3 GB**, with calibration and scan evaluation data. | Start with a deterministic 300-image shard for resource calibration, then the complete 1,200-image `electro` scene. It is the closest scalable control with explicit calibration/GT and manageable storage. |
+| Thousands | [EuRoC MAV](https://projects.asl.ethz.ch/datasets/euroc-mav/) and [KITTI raw data](https://www.cvlibs.net/datasets/kitti/raw_data.php) | EuRoC provides stereo, synchronized IMU, calibration, and motion/structure ground truth. KITTI provides rectified/ unrectified stereo, timestamps, calibration, and GPS/IMU; raw downloads require account access. | Use EuRoC for a known-trajectory sequential sanity check, not as the sole unordered benchmark. Use one KITTI sequence at a time and derive counts from the official files rather than assuming a frame count. KITTI data is CC BY-NC-SA 3.0 per its [official license notice](https://www.cvlibs.net/datasets/kitti/). |
+| 10k+ | ETH3D low-res many-view aggregate, still sourced from the [official dataset table](https://www.eth3d.net/datasets) | The listed training scenes sum to 4,796 images (`4×237 + 4×300 + 4×257 + 4×240 + 4×165`); the listed test scenes sum to 5,212 (`4×266 + 4×278 + 4×199 + 4×208 + 4×352`), or 10,008 across separate scenes. | This is a batch of independently scored scenes, not a single 10,008-image graph. It is the preferred 10k validation after `electro`; process one scene/rig shard at a time and aggregate resource/quality statistics. |
+| 10k–100k | [Tanks and Temples download page](https://tanksandtemples.org/download/) | The official site supplies per-scene high-resolution videos and sampled image sets, recommends its MD5-checking downloader, and provides training geometry for selected scenes. Intrinsics are not explicitly supplied; the site gives an initialization heuristic. | Useful for real large-scene stress tests after ETH3D. Freeze the selected scene/image manifest and accept the [non-commercial terms](https://tanksandtemples.org/license/). Do not infer a total image count from the site; record the downloaded manifest. |
+| 100k+ (static, very large) | [DTU Point Feature Data Set](https://roboimagedata.compute.dtu.dk/?page_id=24) | The official page states 60 scenes × 119 positions × 19 illuminations = **135,660 images**, 1200×1600, with calibration and structured-light surfaces; full-resolution data is listed as about **730 GB**. | Strong controlled feature/repeatability stress test, but illumination repeats and fixed robot views are not representative of a driving sequence. Start with one 6-scene archive; do not reserve 730 GB until the shard protocol is proven. |
+| Optional 100k+ (long-term/dynamic) | [Oxford RobotCar datasets](https://robotcar-dataset.robots.ox.ac.uk/datasets/) and [downloads/terms](https://robotcar-dataset.robots.ox.ac.uk/downloads/) | The official site describes more than 100 repetitions of an Oxford route, supplies calibration/ground truth tooling, and lists individual downloads from roughly 10 GB to 244 GB. Download registration is required and the license is CC BY-NC-SA 4.0. | A realistic long-term retrieval/mapping stress test after the controlled tiers. Weather, traffic, construction, and very large I/O make it unsuitable as the first large run. |
+| Optional 1M+ (RGB-D/synthetic alternatives) | [ScanNet official repository](https://github.com/ScanNet/ScanNet), [TartanAir documentation](https://tartanair.org/), and [CO3Dv2 official tools](https://github.com/facebookresearch/co3d) | ScanNet reports 2.5M views in more than 1,500 scans but requires an institutional Terms of Use agreement. TartanAir V2 documents 65 environments and CC BY 4.0; its V1 paper reports over 1M simulated frames, which must not be conflated with V2 counts. CO3Dv2 lists 5.5 TB for all archives and 8.9 GB for its single-sequence subset, under CC BY-NC 4.0. | Use only when the required terms and modality conversion are explicitly frozen. These are supplementary scale tests, not substitutes for calibrated real-photo SfM. |
+
+The recommended order is therefore: current courtyard → one ETH3D
+high-res scene → ETH3D `electro` (300 probe, then 1,200 full) → all ETH3D
+low-res many-view scenes (10,008 images in separate maps) → selected DTU or
+Oxford shards. No data is downloaded as part of this milestone.
+
+## 3. Staged runbook and resource budgets
+
+Budgets below are safety ceilings for planning, not measured performance
+claims. Tier A must calibrate the ceilings before Tier B is started.
+
+| Stage | Images per mapping job | Candidate ceiling | Working RAM ceiling | Working disk ceiling | Go condition |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Courtyard control | 38 | 703 exhaustive or 200 reduced | existing control | existing external artifact | Exact durable control remains valid. |
+| Tier A | 100–454 | `min(N(N-1)/2, 32N)` | 8 GB | 20 GB | Two identical runs, complete manifests, and no loss against an exhaustive scene control. |
+| Tier B probe | 300 | `min(N(N-1)/2, 32N)` | 16 GB | 50 GB | One-at-a-time extraction and bounded matching stay within ceilings; all files validate after restart. |
+| Tier B full | 1,200 | `min(N(N-1)/2, 32N)` | 32 GB | 150 GB | Full registration or a documented observability ceiling, with candidate recall and COLMAP comparison recorded. |
+| Tier C | 10k aggregate, scene-sharded | `≤32N` per scene/job | 32 GB per worker | 250 GB per worker | No process materializes all pairs; shard merge is hash-validated and component results are reproducible. |
+| Tier D | 100k+ shards | `≤64N` per shard, unless a measured recall audit justifies another bound | 64 GB per worker | 2 TB per shard host | Only after Tier C passes; network/disk high-water and retry behavior are recorded. |
+
+The initial retrieval profile is a fixed, documented top-`K` policy (start with
+`K=32` for new tiers) plus a small local/sequence reserve where timestamps or
+official frame order is part of the input. The effective budget is a manifest
+field, not an implicit loop limit. `K` and any reserve may be changed only in
+a new A/B manifest; they are not selected from verified-match counts.
+
+### Per-run procedure
+
+1. Freeze the source revision, tool/container versions, dataset terms, image
+   manifest, calibration manifest, and output root outside the repository.
+2. Decode a small image sample and run a feature smoke test. Record dimensions,
+   feature rows, descriptor schema, peak RSS, and elapsed time.
+3. Stream feature extraction one image at a time. Write per-image feature and
+   locus shards to temporary files, validate row counts/hashes, then rename
+   atomically. A manifest records config hash, source-image hash, row count,
+   and schema version.
+4. Build cheap global descriptors/retrieval index in `O(NK)` query work. Emit
+   an image-name-bound candidate manifest before local matching. Validate pair
+   bounds, duplicates, image order, budget, config hash, and checksum.
+5. Match and verify candidate shards with bounded workers. Store exact pair
+   order, raw/accepted counts, verifier configuration/outcome, and checksum.
+   A retry must replace only an invalid temporary shard.
+6. Map from streamed/sharded correspondences. Keep connected-component state
+   bounded; run adaptive expansion only for an unregistered/low-degree image or
+   component after the initial schedule, with its additions recorded as a new
+   manifest revision. Never use GT to decide an expansion.
+7. Run the same frozen visloc and official COLMAP controls where feasible. Do
+   not compare a reduced visloc graph to an exhaustive COLMAP graph without
+   labelling the difference.
+8. Score after mapping, archive logs/JSON/hashes, and repeat the complete run
+   or a deterministic shard subset. A restart must reuse only complete,
+   hash-valid artifacts.
+
+## 4. Required measurements and acceptance rules
+
+Every result JSON must include:
+
+- image count, registered count/fraction, connected-component count and sizes;
+- proposed, matched, verified, and accepted-inlier pair counts; per-image
+  degree/support; candidate recall against an exhaustive reference when that
+  reference is available (diagnostic only, never a selection input);
+- track count, observation count, track-length histogram, same-image conflicts,
+  triangulation/parallax summaries, mean/median/p95 reprojection, and rejected
+  observations;
+- extraction, retrieval, matching, verification, mapping, BA, and total wall
+  time; peak RSS; feature/match/model bytes; disk high-water; network bytes and
+  retry/cache-hit counts when applicable;
+- source/config/tool/container hashes, ordered and unordered manifest hashes,
+  restart outcome, and byte hashes for each durable model artifact;
+- centre/pose accuracy only after alignment when a reference exists (RMSE,
+  median, p95, max, scale, and per-image outliers), plus ATE/RPE for trajectory
+  datasets. Reprojection settings and “tracks” versus “points” terminology
+  must remain explicit.
+
+Use the following predeclared decisions:
+
+- **Courtyard safety gate:** before and after any scheduler change,
+  `scripts/benchmark_courtyard.sh --verify-only` must pass; the exhaustive
+  model must remain 38/38 and ≤0.01 m centre RMSE. The current 703-pair
+  champion is the accuracy control; the 200-pair union is a successful bounded
+  A/B, not a replacement or a new champion.
+- **Structural gate:** on a scene with a complete reference/control, a reduced
+  candidate run must not lose more than one percentage point of registered
+  fraction or introduce an extra disconnected component. A failure stops the
+  reduction and triggers candidate-recall/component diagnostics.
+- **Accuracy gate:** when a same-input COLMAP/control score exists, require
+  centre/pose RMSE no worse than the frozen control tolerance declared in that
+  dataset manifest, and reprojection no worse than 1.10× the control unless
+  the metric definition differs. If no reference exists, report structure and
+  reprojection but classify accuracy as inconclusive.
+- **Candidate gate:** Tier A/B must retain at least 99% of the exhaustive
+  verified-pair recall on the bounded calibration scene and preserve every
+  component bridge needed by the control. For larger tiers, report recall per
+  shard/component; a low global average cannot hide an isolated component.
+- **Reproducibility gate:** a repeated run must have identical input,
+  candidate, feature/match-shard, and model hashes, or a documented
+  nondeterministic dependency with a bounded numeric tolerance. Partial,
+  corrupt, or silently skipped artifacts are a stop condition.
+- **Resource gate:** exceed any RAM/disk/network ceiling, or materialize an
+  `N²` object, and stop before increasing the tier. First reduce worker count or
+  shard size; do not silently drop images/pairs.
+
+## 5. Scale requirements for the implementation
+
+The current M3 flat manifest is sufficient for the courtyard A/B but is not a
+claim that the mapper is already 100k-image ready. The next implementation
+work, only after a Tier A/B resource probe, should preserve these contracts:
+
+### Retrieval and candidate manifests
+
+- Keep global-descriptor retrieval at `O(NK)` with deterministic total ordering,
+  stable image IDs, and a bounded local/bridge reserve.
+- Keep `visloc_candidate_manifest_v1` image-name-bound and replayable. A future
+  `v2` should add dataset/config hash, retrieval-model hash, shard ID, pair
+  range, source/score metadata, row count, and checksum while retaining a clear
+  v1 reader.
+- Shard candidate manifests by stable image ranges or connected retrieval
+  buckets. A top-level index must list every shard and its checksum; merging
+  shards must reject overlap, omission, reversed duplicates, and mismatched
+  image order.
+
+### Feature, match, and track storage
+
+- Feature extraction and local matching must be streaming, resumable, and
+  atomic. Existing files are skipped only after schema/config/source hashes
+  validate.
+- Pair shards must preserve exact input order and verifier metadata so a fresh
+  reconstruction can replay without recomputing descriptors or matches.
+- Track construction must process connected components or bounded windows from
+  disk-backed correspondence state. It must not retain every image's
+  descriptors, every pair's matches, and every landmark simultaneously.
+- Component recovery may add a bounded, explicitly logged shard after a
+  registration stall. It must not use a reference model, GT, or hidden
+  full-match statistics.
+
+### Observability and failure handling
+
+- Log the first missing bridge/component, candidate degree, shard state, and
+  reason for every registration rejection. Distinguish “not proposed”, “raw
+  match absent”, “verification rejected”, “track unavailable”, and “PnP/BA
+  rejected”.
+- Keep a deterministic state machine (`planned → running → complete` or
+  `failed`) for every shard. A failed shard is retried into a new temporary
+  path; a partial final file is never treated as complete.
+- Keep mapping defaults and snapshot replay semantics unchanged. New streaming
+  or adaptive behavior must be opt-in until the courtyard exhaustive and 200
+  pair gates plus the applicable cross-suite controls pass.
+
+## 6. Future artifact/runbook shape
+
+Each external run root should contain at least:
+
+```text
+run.json                    # schema, source/config/tool hashes, terms
+images.manifest             # ordered names, dimensions, source hashes
+calibration.manifest        # camera IDs/params and checksum
+features/index.json         # shard paths, rows, schema/config/source hashes
+features/shards/*.part      # atomically completed per-image files
+candidates/index.json       # v1/v2 manifests and budget/retrieval metadata
+candidates/shards/*.part   # deterministic pair ranges
+matches/index.json          # verifier config/outcome and pair-shard hashes
+mapping/summary.json        # counters, timings, RSS, components, metrics
+mapping/logs/*
+models/*                    # cameras/images/points + hashes
+```
+
+The top-level run manifest must identify the exact source revision and must
+never embed licensed images, databases, descriptors, or generated models in
+the repository. A later benchmark helper can accept `--artifact-root`,
+`--verify-only`, `--resume`, and `--shard` without changing the current
+courtyard command.
+
+## 7. Milestone-4 stop/go checklist
+
+Before starting the first download, confirm:
+
+- [ ] official URL, license/terms, archive size, and current availability were
+      rechecked and recorded;
+- [ ] external storage and network quotas meet the selected tier;
+- [ ] a 300-image ETH3D `electro` probe has a complete atomic manifest and a
+      second-run hash check;
+- [ ] courtyard exhaustive verify-only and the 200-pair manifest replay pass;
+- [ ] the proposed candidate budget and shard layout are fixed before matching;
+- [ ] the run can stop cleanly at a component/shard boundary and resume;
+- [ ] no GT/extrinsics/reference model is available to candidate selection or
+      mapping decisions.
+
+This plan intentionally leaves the first large download and all 10k+/100k+
+measurements for a subsequent execution request.

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -12,6 +12,11 @@
 //!    - `vlad`: a VLAD vocabulary over all descriptors gives each image a
 //!      global descriptor; the top-K most similar images per image become
 //!      candidate pairs.
+//!    - `vlad-union`: a deterministic union of a numeric-stem local-overlap
+//!      schedule (`--local-stem-window`) and the VLAD retrieval pairs.  The
+//!      optional `--candidate-budget` retains local pairs first, then the
+//!      highest-scoring retrieval pairs.  It is an explicit, bounded M3
+//!      schedule and never consults raw matches or verification outcomes.
 //!    - `vocab-tree`: `visloc_rs::vision::vocab_tree`'s hierarchical-k-means
 //!      vocabulary + TF-IDF/Hamming-embedding inverted-file retrieval
 //!      (COLMAP's `VocabTreePairGenerator`-equivalent, M3 in
@@ -168,6 +173,14 @@
 //! stem, only pairs whose numeric stem difference is at most `N` are matched
 //! and verified.  It applies to imported verified pairs and all opt-in pair
 //! expansion paths as well; omitted means the historical candidate set.
+//!
+//! `--candidate-manifest PATH` imports a versioned, image-name-bound list of
+//! candidate pairs and bypasses pair generation.  `--export-candidate-manifest
+//! PATH` writes the generated list atomically and exits before matching.  The
+//! manifest is deliberately small and hashable, so a benchmark can cache the
+//! cheap retrieval result while validating that it still belongs to the same
+//! image order.  Candidate manifests contain no descriptors, raw matches, or
+//! ground-truth information.
 //!
 //! `--initial-poses MODEL/images.txt` is an explicit, default-off staged
 //! incremental seed.  The model's image names are matched by stem and its
@@ -466,6 +479,11 @@ impl std::str::FromStr for VerificationMode {
 enum PairSource {
     /// Flat-VLAD top-K cosine retrieval (pre-M3 behaviour, unchanged).
     Vlad,
+    /// VLAD top-K pairs retained only when retrieval is mutual.
+    VladMutual,
+    /// Union of a bounded numeric-stem local schedule and flat-VLAD
+    /// retrieval.  Local edges are retained first when a budget is applied.
+    VladUnion,
     /// Hierarchical-k-means vocab-tree retrieval (M3).
     VocabTree,
     /// COLMAP's `TransitivePairGenerator` port: propose pairs through the
@@ -481,10 +499,12 @@ impl std::str::FromStr for PairSource {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "vlad" => Ok(Self::Vlad),
+            "vlad-mutual" => Ok(Self::VladMutual),
+            "vlad-union" => Ok(Self::VladUnion),
             "vocab-tree" => Ok(Self::VocabTree),
             "transitive" => Ok(Self::Transitive),
             other => Err(format!(
-                "unknown --pair-source {other:?} (expected vlad|vocab-tree|transitive)"
+                "unknown --pair-source {other:?} (expected vlad|vlad-mutual|vlad-union|vocab-tree|transitive)"
             )),
         }
     }
@@ -2324,9 +2344,17 @@ struct Args {
     /// with the guarded geometry-guided recovery pass. Default off.
     geometry_guided_conflict_recovery: bool,
     /// M3 A/B switch: which candidate-pair source feeds verification — flat
-    /// VLAD top-K (default) or the hierarchical vocab-tree
+    /// VLAD top-K (default), a bounded local+VLAD union, or the hierarchical vocab-tree
     /// (`docs/colmap_port_plan.md`'s M3 milestone).
     pair_source: PairSource,
+    /// Numeric-stem local overlap window for `--pair-source vlad-union`.
+    /// This schedule is cheap and is evaluated before any pair matching.
+    local_stem_window: Option<u64>,
+    /// Optional upper bound on generated candidate pairs.  Under
+    /// `vlad-union`, local pairs have priority, then retrieval pairs by
+    /// descending similarity and stable pair key.  `None` preserves the full
+    /// generated set.
+    candidate_budget: Option<usize>,
     /// Vocab-tree hierarchical-k-means branching factor (M3; ignored under
     /// `--pair-source vlad`). See `vocab_tree::hkm::HkmBuildOptions`.
     vocab_tree_branching: usize,
@@ -2338,6 +2366,11 @@ struct Args {
     /// (`VocabTreePairingOptions::num_images`). Ignored under
     /// `--pair-source vlad`.
     vocab_tree_num_images: usize,
+    /// Import a validated, image-name-bound candidate manifest and bypass
+    /// candidate generation.  Matching/verification still run for its pairs.
+    candidate_manifest: Option<PathBuf>,
+    /// Export the generated candidate manifest and exit before matching.
+    export_candidate_manifest: Option<PathBuf>,
     /// M5 (`docs/colmap_port_plan.md`): run the opt-in rescue-bridging pass
     /// after initial verification (see the file header's step 4).
     rescue_bridging: bool,
@@ -3001,6 +3034,181 @@ fn filter_pairs_by_stem_window(
         .collect()
 }
 
+const CANDIDATE_MANIFEST_MAGIC: &str = "visloc_candidate_manifest_v1";
+
+/// Parse a small, image-name-bound candidate-pair manifest.  The format is
+/// intentionally line-oriented so it can be inspected, hashed, and generated
+/// without a JSON dependency in the Rust example:
+///
+/// visloc_candidate_manifest_v1
+/// images 2
+/// image 0 first.JPG
+/// image 1 second.JPG
+/// pairs 1
+/// pair 0 1
+///
+/// Pair order is preserved, while duplicate/reversed pairs are rejected.  A
+/// manifest is a candidate schedule only; it contains no raw matches or
+/// verification outcomes.
+fn parse_candidate_manifest(
+    path: &Path,
+    image_names: &[String],
+) -> Result<Vec<(usize, usize)>, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|error| format!("cannot read candidate manifest {path:?}: {error}"))?;
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect();
+    let mut cursor = 0usize;
+    let next = |cursor: &mut usize, label: &str| -> Result<&str, String> {
+        let line = lines.get(*cursor).copied().ok_or_else(|| {
+            format!("candidate manifest {path:?} is truncated while reading {label}")
+        })?;
+        *cursor += 1;
+        Ok(line)
+    };
+    if next(&mut cursor, "header")? != CANDIDATE_MANIFEST_MAGIC {
+        return Err(format!(
+            "candidate manifest {path:?} has unsupported header (expected {CANDIDATE_MANIFEST_MAGIC})"
+        ));
+    }
+    let image_header = next(&mut cursor, "image count")?;
+    let image_fields: Vec<&str> = image_header.split_whitespace().collect();
+    if image_fields.len() != 2 || image_fields[0] != "images" {
+        return Err(format!(
+            "candidate manifest {path:?} image count must be images N"
+        ));
+    }
+    let image_count: usize = image_fields[1].parse().map_err(|error| {
+        format!("candidate manifest {path:?} image count is not numeric: {error}")
+    })?;
+    if image_count != image_names.len() {
+        return Err(format!(
+            "candidate manifest {path:?} image count {} differs from loaded {}",
+            image_count,
+            image_names.len()
+        ));
+    }
+    for expected_index in 0..image_count {
+        let line = next(&mut cursor, "image entry")?;
+        let mut fields = line.splitn(3, char::is_whitespace);
+        let kind = fields.next().unwrap_or_default();
+        let index = fields.next().unwrap_or_default();
+        let name = fields.next().unwrap_or_default().trim();
+        if kind != "image" || name.is_empty() {
+            return Err(format!(
+                "candidate manifest {path:?} image entry must be image INDEX NAME"
+            ));
+        }
+        let index: usize = index.parse().map_err(|error| {
+            format!("candidate manifest {path:?} image index is not numeric: {error}")
+        })?;
+        if index != expected_index || name != image_names[index] {
+            return Err(format!(
+                "candidate manifest {path:?} image entry {expected_index} does not match loaded image order"
+            ));
+        }
+    }
+    let pair_header = next(&mut cursor, "pair count")?;
+    let pair_fields: Vec<&str> = pair_header.split_whitespace().collect();
+    if pair_fields.len() != 2 || pair_fields[0] != "pairs" {
+        return Err(format!(
+            "candidate manifest {path:?} pair count must be pairs N"
+        ));
+    }
+    let pair_count: usize = pair_fields[1].parse().map_err(|error| {
+        format!("candidate manifest {path:?} pair count is not numeric: {error}")
+    })?;
+    let mut pairs = Vec::with_capacity(pair_count);
+    let mut seen = HashSet::with_capacity(pair_count);
+    for pair_number in 0..pair_count {
+        let line = next(&mut cursor, "pair entry")?;
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 3 || fields[0] != "pair" {
+            return Err(format!(
+                "candidate manifest {path:?} pair {pair_number} must be pair I J"
+            ));
+        }
+        let i: usize = fields[1].parse().map_err(|error| {
+            format!("candidate manifest {path:?} pair {pair_number} first index is not numeric: {error}")
+        })?;
+        let j: usize = fields[2].parse().map_err(|error| {
+            format!("candidate manifest {path:?} pair {pair_number} second index is not numeric: {error}")
+        })?;
+        if i >= image_names.len() || j >= image_names.len() || i >= j {
+            return Err(format!(
+                "candidate manifest {path:?} pair {pair_number} must satisfy 0 <= I < J < {}",
+                image_names.len()
+            ));
+        }
+        if !seen.insert((i, j)) {
+            return Err(format!(
+                "candidate manifest {path:?} repeats pair ({i},{j})"
+            ));
+        }
+        pairs.push((i, j));
+    }
+    if cursor != lines.len() {
+        return Err(format!(
+            "candidate manifest {path:?} has unexpected trailing data"
+        ));
+    }
+    Ok(pairs)
+}
+
+/// Write a candidate manifest through a same-directory temporary file and
+/// rename.  This keeps an interrupted cheap retrieval pass from leaving a
+/// file that a later benchmark could mistake for a complete schedule.
+fn write_candidate_manifest(
+    path: &Path,
+    image_names: &[String],
+    pairs: &[(usize, usize)],
+) -> Result<(), String> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!("cannot create candidate manifest directory {parent:?}: {error}")
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| format!("candidate manifest path has no valid filename: {path:?}"))?;
+    let temporary = parent.join(format!(".{file_name}.tmp"));
+    let mut text = String::new();
+    text.push_str(CANDIDATE_MANIFEST_MAGIC);
+    text.push('\n');
+    text.push_str(&format!("images {}\n", image_names.len()));
+    for (index, name) in image_names.iter().enumerate() {
+        if name.chars().any(char::is_whitespace) {
+            return Err(format!(
+                "candidate manifest cannot encode whitespace in image name {name:?}"
+            ));
+        }
+        text.push_str(&format!("image {index} {name}\n"));
+    }
+    text.push_str(&format!("pairs {}\n", pairs.len()));
+    let mut seen = HashSet::with_capacity(pairs.len());
+    for &(i, j) in pairs {
+        if i >= image_names.len() || j >= image_names.len() || i >= j {
+            return Err(format!(
+                "candidate pair ({i},{j}) is outside canonical image order"
+            ));
+        }
+        if !seen.insert((i, j)) {
+            return Err(format!("candidate pair ({i},{j}) is duplicated"));
+        }
+        text.push_str(&format!("pair {i} {j}\n"));
+    }
+    std::fs::write(&temporary, text).map_err(|error| {
+        format!("cannot write temporary candidate manifest {temporary:?}: {error}")
+    })?;
+    std::fs::rename(&temporary, path).map_err(|error| {
+        format!("cannot atomically install candidate manifest {path:?}: {error}")
+    })?;
+    Ok(())
+}
+
 /// Add the numeric-consecutive edges required by the opt-in sequence
 /// relative-pose fallback.  Retrieval remains the normal source for every
 /// other edge; only missing consecutive pairs are appended, so the flag does
@@ -3151,6 +3359,8 @@ where
     let mut seed_trials = 12usize;
     let mut seed_pair: Option<(usize, usize)> = None;
     let mut pair_stem_window: Option<u64> = None;
+    let mut local_stem_window: Option<u64> = None;
+    let mut candidate_budget: Option<usize> = None;
     let mut refine_intrinsics = false;
     let mut refine_distortion = false;
     let mut colmap_style = false;
@@ -3268,6 +3478,8 @@ where
     let mut import_verified_pairs_file: Option<PathBuf> = None;
     let mut export_verified_pairs_snapshot: Option<PathBuf> = None;
     let mut import_verified_pairs_snapshot: Option<PathBuf> = None;
+    let mut candidate_manifest: Option<PathBuf> = None;
+    let mut export_candidate_manifest: Option<PathBuf> = None;
     let mut snapshot_coordinate_override_dir: Option<PathBuf> = None;
     let mut diagnose_ba_oracle_poses_file: Option<PathBuf> = None;
     let mut diagnose_fixed_rotation_ba: Option<String> = None;
@@ -3472,6 +3684,34 @@ where
                 }
                 a.remove(i + 1);
                 pair_stem_window = Some(window);
+            }
+            "--local-stem-window" => {
+                let raw = a
+                    .get(i + 1)
+                    .ok_or("--local-stem-window requires a positive integer N")?
+                    .clone();
+                let window: u64 = raw.parse().map_err(|error| {
+                    format!("--local-stem-window must be a positive integer: {error}")
+                })?;
+                if window == 0 {
+                    return Err("--local-stem-window must be at least 1".into());
+                }
+                a.remove(i + 1);
+                local_stem_window = Some(window);
+            }
+            "--candidate-budget" => {
+                let raw = a
+                    .get(i + 1)
+                    .ok_or("--candidate-budget requires a positive integer")?
+                    .clone();
+                let budget: usize = raw.parse().map_err(|error| {
+                    format!("--candidate-budget must be a positive integer: {error}")
+                })?;
+                if budget == 0 {
+                    return Err("--candidate-budget must be at least 1".into());
+                }
+                a.remove(i + 1);
+                candidate_budget = Some(budget);
             }
             "--match-ratio" => match_ratio = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
             "--min-matches" => min_matches = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
@@ -3899,6 +4139,28 @@ where
                 a.remove(i + 1);
                 import_verified_pairs_snapshot = Some(PathBuf::from(raw));
             }
+            "--candidate-manifest" => {
+                let raw = a
+                    .get(i + 1)
+                    .ok_or("--candidate-manifest requires PATH")?
+                    .clone();
+                if raw.trim().is_empty() {
+                    return Err("--candidate-manifest requires a non-empty PATH".into());
+                }
+                a.remove(i + 1);
+                candidate_manifest = Some(PathBuf::from(raw));
+            }
+            "--export-candidate-manifest" => {
+                let raw = a
+                    .get(i + 1)
+                    .ok_or("--export-candidate-manifest requires PATH")?
+                    .clone();
+                if raw.trim().is_empty() {
+                    return Err("--export-candidate-manifest requires a non-empty PATH".into());
+                }
+                a.remove(i + 1);
+                export_candidate_manifest = Some(PathBuf::from(raw));
+            }
             "--snapshot-coordinate-override-dir" => {
                 let raw = a
                     .get(i + 1)
@@ -4100,6 +4362,49 @@ where
         return Err(
             "--sift-stream-export requires --export-features-only so extracted banks are not retained in memory"
                 .into(),
+        );
+    }
+    if candidate_manifest.is_some() && export_candidate_manifest.is_some() {
+        return Err(
+            "--candidate-manifest and --export-candidate-manifest are mutually exclusive".into(),
+        );
+    }
+    if local_stem_window.is_some() && pair_source != PairSource::VladUnion {
+        return Err("--local-stem-window requires --pair-source vlad-union".into());
+    }
+    if pair_source == PairSource::VladUnion && local_stem_window.is_none() {
+        return Err("--pair-source vlad-union requires --local-stem-window N".into());
+    }
+    if pair_source == PairSource::VladUnion && exhaustive {
+        return Err("--pair-source vlad-union cannot be combined with --exhaustive".into());
+    }
+    if candidate_budget.is_some() && pair_source != PairSource::VladUnion {
+        return Err("--candidate-budget currently requires --pair-source vlad-union".into());
+    }
+    if pair_source == PairSource::VladUnion && pair_stem_window.is_some() {
+        return Err(
+            "--pair-source vlad-union uses --local-stem-window; do not combine it with --pair-stem-window".into(),
+        );
+    }
+    if candidate_manifest.is_some()
+        && (exhaustive
+            || local_stem_window.is_some()
+            || candidate_budget.is_some()
+            || pair_stem_window.is_some()
+            || pair_source == PairSource::Transitive)
+    {
+        return Err(
+            "--candidate-manifest cannot be combined with generated candidate filters or transitive expansion".into(),
+        );
+    }
+    if export_candidate_manifest.is_some()
+        && (import_matches_file.is_some()
+            || import_matches_supplement_file.is_some()
+            || import_verified_pairs_file.is_some()
+            || import_verified_pairs_snapshot.is_some())
+    {
+        return Err(
+            "--export-candidate-manifest cannot be combined with imported pair streams".into(),
         );
     }
     if diagnose_colmap_track_membership.is_some() && mapper != MapperKind::Incremental {
@@ -4307,9 +4612,15 @@ where
                 "--import-verified-pairs-snapshot cannot be combined with raw match imports".into(),
             );
         }
-        if pair_stem_window.is_some() || pair_source == PairSource::Transitive {
+        if pair_stem_window.is_some()
+            || local_stem_window.is_some()
+            || candidate_budget.is_some()
+            || candidate_manifest.is_some()
+            || export_candidate_manifest.is_some()
+            || pair_source == PairSource::Transitive
+        {
             return Err(
-                "--import-verified-pairs-snapshot cannot filter or transitively expand pairs"
+                "--import-verified-pairs-snapshot cannot generate, filter, or transitively expand pairs"
                     .into(),
             );
         }
@@ -4375,6 +4686,8 @@ where
         retrieval_topk,
         exhaustive,
         pair_stem_window,
+        local_stem_window,
+        candidate_budget,
         match_ratio,
         min_matches,
         min_pnp_inliers,
@@ -4494,6 +4807,8 @@ where
         pose_guided_track_merging,
         pose_guided_merge_max_reproj,
         pair_source,
+        candidate_manifest,
+        export_candidate_manifest,
         vocab_tree_branching,
         vocab_tree_depth,
         vocab_tree_num_images,
@@ -7208,39 +7523,130 @@ fn all_pairs(n: usize) -> Vec<(usize, usize)> {
 /// Candidate image pairs `(i, j)` with `i < j` from flat-VLAD top-K cosine
 /// retrieval (or all pairs when `exhaustive`) — the pre-M3 pair source,
 /// unchanged.
-fn candidate_pairs_vlad(
+fn candidate_pairs_vlad_scored(
     features: &[FeatureSet],
     vocab_size: usize,
     topk: usize,
     exhaustive: bool,
-) -> Vec<(usize, usize)> {
+    mutual: bool,
+) -> Vec<((usize, usize), f32)> {
     let n = features.len();
     if exhaustive || n <= topk + 1 {
-        return all_pairs(n);
+        return all_pairs(n).into_iter().map(|pair| (pair, 0.0)).collect();
     }
 
     let sample = sampled_training_descriptors(features);
     let Some(vocab) = Vocabulary::build(&sample, vocab_size, 10, 0) else {
         // Fall back to exhaustive if the vocabulary cannot be built.
-        return all_pairs(n);
+        return all_pairs(n).into_iter().map(|pair| (pair, 0.0)).collect();
     };
     let globals: Vec<Vec<f32>> = features
         .iter()
         .map(|f| vlad(&f.descriptors, &vocab))
         .collect();
 
-    let mut set: std::collections::BTreeSet<(usize, usize)> = std::collections::BTreeSet::new();
+    let mut scores = std::collections::BTreeMap::<(usize, usize), f32>::new();
+    let mut neighbors = vec![HashSet::<usize>::new(); n];
     for i in 0..n {
         let mut sims: Vec<(usize, f32)> = (0..n)
             .filter(|&j| j != i)
             .map(|j| (j, cosine_similarity(&globals[i], &globals[j])))
             .collect();
-        sims.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        for &(j, _) in sims.iter().take(topk) {
-            set.insert((i.min(j), i.max(j)));
+        sims.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        for &(j, score) in sims.iter().take(topk) {
+            neighbors[i].insert(j);
+            let pair = (i.min(j), i.max(j));
+            if !mutual || neighbors[j].contains(&i) {
+                scores
+                    .entry(pair)
+                    .and_modify(|best| *best = best.max(score))
+                    .or_insert(score);
+            }
         }
     }
-    set.into_iter().collect()
+    if mutual {
+        // The first pass can see only one side of a pair.  Rebuild the score
+        // map from the completed neighbour sets so pair admission is exactly
+        // symmetric and independent of image traversal order.
+        scores.clear();
+        for i in 0..n {
+            let mut sims: Vec<(usize, f32)> = (0..n)
+                .filter(|&j| j != i && neighbors[i].contains(&j) && neighbors[j].contains(&i))
+                .map(|j| (j, cosine_similarity(&globals[i], &globals[j])))
+                .collect();
+            sims.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            for (j, score) in sims {
+                let pair = (i.min(j), i.max(j));
+                scores
+                    .entry(pair)
+                    .and_modify(|best| *best = best.max(score))
+                    .or_insert(score);
+            }
+        }
+    }
+    scores.into_iter().collect()
+}
+
+fn candidate_pairs_vlad(
+    features: &[FeatureSet],
+    vocab_size: usize,
+    topk: usize,
+    exhaustive: bool,
+) -> Vec<(usize, usize)> {
+    candidate_pairs_vlad_scored(features, vocab_size, topk, exhaustive, false)
+        .into_iter()
+        .map(|(pair, _)| pair)
+        .collect()
+}
+
+fn candidate_pairs_vlad_mutual(
+    features: &[FeatureSet],
+    vocab_size: usize,
+    topk: usize,
+    exhaustive: bool,
+) -> Vec<(usize, usize)> {
+    candidate_pairs_vlad_scored(features, vocab_size, topk, exhaustive, true)
+        .into_iter()
+        .map(|(pair, _)| pair)
+        .collect()
+}
+
+/// Candidate pairs from a bounded union of local numeric-stem overlap and
+/// VLAD retrieval. Local edges are selected before retrieval edges under a
+/// budget, then retrieval-only edges are ranked by pre-match VLAD score.
+fn candidate_pairs_vlad_union(
+    features: &[FeatureSet],
+    image_names: &[String],
+    vocab_size: usize,
+    topk: usize,
+    local_window: u64,
+    budget: Option<usize>,
+) -> Result<Vec<(usize, usize)>, String> {
+    let local =
+        filter_pairs_by_stem_window(all_pairs(features.len()), image_names, Some(local_window))?;
+    let retrieval = candidate_pairs_vlad_scored(features, vocab_size, topk, false, false);
+    let local_set: HashSet<(usize, usize)> = local.iter().copied().collect();
+    let mut ranked: Vec<((usize, usize), bool, f32)> = retrieval
+        .into_iter()
+        .map(|(pair, score)| (pair, local_set.contains(&pair), score))
+        .collect();
+    let mut seen: HashSet<(usize, usize)> = ranked.iter().map(|(pair, _, _)| *pair).collect();
+    for pair in local {
+        if seen.insert(pair) {
+            ranked.push((pair, true, f32::NEG_INFINITY));
+        }
+    }
+    ranked.sort_by(|lhs, rhs| {
+        rhs.1
+            .cmp(&lhs.1)
+            .then_with(|| rhs.2.total_cmp(&lhs.2))
+            .then_with(|| lhs.0.cmp(&rhs.0))
+    });
+    if let Some(budget) = budget {
+        ranked.truncate(budget);
+    }
+    ranked.sort_unstable_by_key(|(pair, _, _)| *pair);
+    Ok(ranked.into_iter().map(|(pair, _, _)| pair).collect())
 }
 
 /// Candidate image pairs `(i, j)` with `i < j` from the M3 hierarchical
@@ -7317,21 +7723,40 @@ const TRANSITIVE_ROUNDS: usize = 2;
 /// the transitive expansion happens in [`expand_transitive`] after those
 /// base pairs are verified, mirroring COLMAP's generator running against
 /// an existing match table.
-fn candidate_pairs(features: &[FeatureSet], args: &Args) -> Vec<(usize, usize)> {
+fn candidate_pairs(
+    features: &[FeatureSet],
+    image_names: &[String],
+    args: &Args,
+) -> Result<Vec<(usize, usize)>, String> {
     match args.pair_source {
-        PairSource::Vlad => candidate_pairs_vlad(
+        PairSource::Vlad => Ok(candidate_pairs_vlad(
             features,
             args.vocab_size,
             args.retrieval_topk,
             args.exhaustive,
+        )),
+        PairSource::VladMutual => Ok(candidate_pairs_vlad_mutual(
+            features,
+            args.vocab_size,
+            args.retrieval_topk,
+            args.exhaustive,
+        )),
+        PairSource::VladUnion => candidate_pairs_vlad_union(
+            features,
+            image_names,
+            args.vocab_size,
+            args.retrieval_topk,
+            args.local_stem_window
+                .expect("validated vlad-union local window"),
+            args.candidate_budget,
         ),
-        PairSource::VocabTree | PairSource::Transitive => candidate_pairs_vocab_tree(
+        PairSource::VocabTree | PairSource::Transitive => Ok(candidate_pairs_vocab_tree(
             features,
             args.vocab_tree_branching,
             args.vocab_tree_depth,
             args.vocab_tree_num_images,
             args.exhaustive,
-        ),
+        )),
     }
 }
 
@@ -11812,11 +12237,12 @@ fn diagnose_pairs_for_csv(
     args: &Args,
 ) -> Result<Vec<(usize, usize)>, String> {
     if args.diagnose_pair_stems.is_empty() {
-        return filter_pairs_by_stem_window(
-            candidate_pairs(features, args),
-            image_names,
-            args.pair_stem_window,
-        );
+        let generated = if let Some(path) = args.candidate_manifest.as_deref() {
+            parse_candidate_manifest(path, image_names)?
+        } else {
+            candidate_pairs(features, image_names, args)?
+        };
+        return filter_pairs_by_stem_window(generated, image_names, args.pair_stem_window);
     }
     filter_pairs_by_stem_window(
         all_pairs(features.len())
@@ -12739,10 +13165,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
+    if let Some(path) = args.export_candidate_manifest.as_deref() {
+        let generated = candidate_pairs(&features, &image_names, &args)?;
+        let generated =
+            filter_pairs_by_stem_window(generated, &image_names, args.pair_stem_window)?;
+        write_candidate_manifest(path, &image_names, &generated)?;
+        println!(
+            "candidate manifest: exported {} pairs for {} images to {}",
+            generated.len(),
+            image_names.len(),
+            path.display()
+        );
+        return Ok(());
+    }
     let mut all_candidates = if imported_snapshot.is_some() {
         Vec::new()
+    } else if let Some(path) = args.candidate_manifest.as_deref() {
+        parse_candidate_manifest(path, &image_names)?
     } else {
-        candidate_pairs(&features, &args)
+        candidate_pairs(&features, &image_names, &args)?
     };
     if imported_snapshot.is_none() && args.sequence_relative_pose_fallback {
         let before = all_candidates.len();
@@ -12770,7 +13211,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "view graph: {} candidate pairs ({})",
         candidates.len(),
-        if args.exhaustive {
+        if args.candidate_manifest.is_some() {
+            "candidate manifest"
+        } else if args.exhaustive {
             if args.pair_stem_window.is_some() {
                 "exhaustive + stem window"
             } else {
@@ -12779,6 +13222,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             match args.pair_source {
                 PairSource::Vlad => "VLAD top-k",
+                PairSource::VladMutual => "VLAD mutual top-k",
+                PairSource::VladUnion => "local stem + VLAD union",
                 PairSource::VocabTree => "vocab-tree",
                 PairSource::Transitive => "transitive (vocab-tree base)",
             }
@@ -14064,18 +14509,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod diagnose_cli_tests {
     use super::{
         apply_snapshot_coordinate_override, apply_union_traversal_order,
-        apply_union_traversal_order_with_features, canonicalize_feature_order,
-        canonicalize_pairwise_loci, colmap_guided_geometry, colmap_guided_matches,
-        descriptor_squared_distance, effective_config_hash, effective_config_snapshot,
-        filter_imported_verified_pairs_by_stem_window, filter_pairs_by_stem_window,
-        imported_reference_quality_is_strong, initial_poses_from_colmap_images_txt,
+        apply_union_traversal_order_with_features, candidate_pairs_vlad_union,
+        canonicalize_feature_order, canonicalize_pairwise_loci, colmap_guided_geometry,
+        colmap_guided_matches, descriptor_squared_distance, effective_config_hash,
+        effective_config_snapshot, filter_imported_verified_pairs_by_stem_window,
+        filter_pairs_by_stem_window, imported_reference_quality_is_strong,
+        initial_poses_from_colmap_images_txt,
         initial_poses_from_colmap_images_txt_with_expected_cameras, load_input_colmap_calibration,
         match_candidate_cmp, model_cross_validation_is_held_out,
         model_cross_validation_is_held_out_for_pixels, model_cross_validation_selection_score,
-        parse_args_from, parse_colmap_image_camera_assignments, parse_colmap_track_membership,
-        parse_diagnose_stems, robust_huber_mean, summarize_model_cross_validation_bucket,
-        translation_direction_delta_deg, unordered_pairwise_edge_hash, validate_diagnose_options,
-        verified_pair_oracle_map, Camera, ColmapTrackMembership, ConfigurationType,
+        parse_args_from, parse_candidate_manifest, parse_colmap_image_camera_assignments,
+        parse_colmap_track_membership, parse_diagnose_stems, robust_huber_mean,
+        summarize_model_cross_validation_bucket, translation_direction_delta_deg,
+        unordered_pairwise_edge_hash, validate_diagnose_options, verified_pair_oracle_map,
+        write_candidate_manifest, Camera, ColmapTrackMembership, ConfigurationType,
         EssentialPairQuality, FeatureLocusMetadata, ImportedVerifiedPair, IncrementalSfmConfig,
         ModelCrossValidationBucket, ModelCrossValidationSummary, NextImagePolicy, PairwiseMatches,
         RobustKernel, TwoViewGeometryReport, UnionTraversalOrder,
@@ -14147,6 +14594,79 @@ mod diagnose_cli_tests {
         assert_eq!(snapshot_auto.next_image_policy, NextImagePolicy::Auto);
         assert!(parse_args_from(minimal_args(&["--next-image-policy", "pyramid"])).is_err());
         assert!(parse_args_from(minimal_args(&["--next-image-policy"])).is_err());
+    }
+
+    #[test]
+    fn candidate_manifest_round_trip_binds_image_order_and_rejects_duplicates() {
+        let root =
+            std::env::temp_dir().join(format!("visloc_candidate_manifest_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("pairs.txt");
+        let names = vec![
+            "DSC_0001.JPG".to_owned(),
+            "DSC_0002.JPG".to_owned(),
+            "DSC_0003.JPG".to_owned(),
+        ];
+        let pairs = vec![(0, 2), (0, 1)];
+        write_candidate_manifest(&path, &names, &pairs).unwrap();
+        assert_eq!(parse_candidate_manifest(&path, &names).unwrap(), pairs);
+
+        let mut wrong_names = names.clone();
+        wrong_names.swap(0, 1);
+        assert!(parse_candidate_manifest(&path, &wrong_names)
+            .unwrap_err()
+            .contains("image entry"));
+
+        std::fs::write(
+            &path,
+            "visloc_candidate_manifest_v1\nimages 3\n\
+             image 0 DSC_0001.JPG\nimage 1 DSC_0002.JPG\nimage 2 DSC_0003.JPG\n\
+             pairs 2\npair 0 1\npair 1 0\n",
+        )
+        .unwrap();
+        assert!(parse_candidate_manifest(&path, &names)
+            .unwrap_err()
+            .contains("must satisfy"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn candidate_schedule_flags_are_explicit_and_validated() {
+        let union = parse_args_from(minimal_args(&[
+            "--pair-source",
+            "vlad-union",
+            "--local-stem-window",
+            "3",
+            "--candidate-budget",
+            "200",
+        ]))
+        .unwrap();
+        assert!(matches!(union.pair_source, super::PairSource::VladUnion));
+        assert_eq!(union.local_stem_window, Some(3));
+        assert_eq!(union.candidate_budget, Some(200));
+        assert!(parse_args_from(minimal_args(&["--pair-source", "vlad-union",])).is_err());
+        assert!(parse_args_from(minimal_args(&["--local-stem-window", "3",])).is_err());
+        assert!(parse_args_from(minimal_args(&["--candidate-budget", "0",])).is_err());
+    }
+
+    #[test]
+    fn bounded_local_vlad_schedule_is_deterministic_and_respects_budget() {
+        let features: Vec<FeatureSet> = (0..5)
+            .map(|index| {
+                FeatureSet::new(
+                    vec![Point2::new(index as f64, 0.0)],
+                    vec![vec![1.0, index as f32 + 1.0]],
+                )
+                .unwrap()
+            })
+            .collect();
+        let names: Vec<String> = (0..5).map(|index| format!("DSC_{index:04}.JPG")).collect();
+        let first = candidate_pairs_vlad_union(&features, &names, 4, 12, 1, Some(3)).unwrap();
+        let second = candidate_pairs_vlad_union(&features, &names, 4, 12, 1, Some(3)).unwrap();
+        assert_eq!(first, second);
+        assert!(first.len() <= 3);
+        assert!(first.iter().all(|&(i, j)| i < j && j < features.len()));
     }
 
     #[test]

--- a/pipelines/slam/src/incremental_sfm.rs
+++ b/pipelines/slam/src/incremental_sfm.rs
@@ -1604,7 +1604,7 @@ fn incremental_sfm_with_initial_poses_and_track_membership_and_sequence_override
                 Ok(post) => {
                     if sfm_debug_enabled() {
                         eprintln!(
-                            "sfm-auto: post completion rejected policy={selected_policy:?} registered={}/{} -> {}/{} (strict increase required) elapsed={:.3}s total={:.3}s",
+                            "sfm-auto: post completion rejected policy={selected_policy:?} registered={}/{} -> {}/{} (strict increase and non-increasing finite reprojection required) elapsed={:.3}s total={:.3}s",
                             selected.registered_images,
                             features.len(),
                             post.registered_images,
@@ -10175,14 +10175,24 @@ fn next_image_auto_post_candidate_is_needed(registered_images: usize, total_imag
 }
 
 /// Post-refinement completion is a registration-only fallback.  A candidate
-/// is adopted only when it strictly adds registered images; equal-support
-/// results retain the untouched pre-post candidate, including its tracks,
-/// poses, and BA state.
+/// is adopted only when it strictly adds registered images without worsening
+/// the finite mean reprojection error.  Equal-support results retain the
+/// untouched pre-post candidate, including its tracks, poses, and BA state.
 fn next_image_auto_post_candidate_is_better(
     candidate: &IncrementalSfmResult,
     incumbent: &IncrementalSfmResult,
 ) -> bool {
-    candidate.registered_images > incumbent.registered_images
+    if candidate.registered_images <= incumbent.registered_images {
+        return false;
+    }
+
+    let candidate_error = candidate.mean_reprojection_px;
+    if !candidate_error.is_finite() {
+        return false;
+    }
+
+    let incumbent_error = incumbent.mean_reprojection_px;
+    !incumbent_error.is_finite() || candidate_error <= incumbent_error
 }
 
 /// Compare two completed Auto candidates in the documented lexicographic
@@ -15845,6 +15855,17 @@ mod tests {
             &candidate, &baseline
         ));
 
+        // A registration gain must not be allowed to replace a materially
+        // cleaner incumbent with a finite but much worse post candidate.
+        candidate.mean_reprojection_px = 100.0;
+        assert!(!next_image_auto_post_candidate_is_better(
+            &candidate, &baseline
+        ));
+        candidate.mean_reprojection_px = 1.0;
+        assert!(next_image_auto_post_candidate_is_better(
+            &candidate, &baseline
+        ));
+
         // A post pass may improve reprojection or change tracks while leaving
         // registration unchanged. Auto must retain the untouched candidate in
         // that case, so the primary model's bytes/trajectory are stable.
@@ -15856,6 +15877,20 @@ mod tests {
 
         candidate.registered_images = baseline.registered_images.saturating_sub(1);
         assert!(!next_image_auto_post_candidate_is_better(
+            &candidate, &baseline
+        ));
+        candidate.registered_images = baseline.registered_images + 1;
+        candidate.mean_reprojection_px = f64::NAN;
+        assert!(!next_image_auto_post_candidate_is_better(
+            &candidate, &baseline
+        ));
+
+        // A finite post candidate can repair an incumbent whose aggregate
+        // reprojection metric is unavailable, while a non-finite candidate
+        // can never be adopted.
+        baseline.mean_reprojection_px = f64::NAN;
+        candidate.mean_reprojection_px = 0.5;
+        assert!(next_image_auto_post_candidate_is_better(
             &candidate, &baseline
         ));
         baseline.registered_images = 0;

--- a/scripts/benchmark_courtyard.py
+++ b/scripts/benchmark_courtyard.py
@@ -1,0 +1,1346 @@
+#!/usr/bin/env python3
+"""Validate or rerun the reproducible high-resolution courtyard control.
+
+The benchmark's large inputs and model outputs intentionally live outside the
+repository.  This runner validates their manifests before doing any work,
+then optionally runs the normal visloc mapper and scores its *completed*
+model against the supplied calibration model.  The calibration model is a
+score reference only; it is never passed to the mapper as ground truth.
+
+The default is the fast, read-only ``--verify-only`` mode.  Use ``--full``
+for a fresh mapping run.  Progress and child-process output go to stderr/log
+files, while the final stdout value is deterministic JSON suitable for CI or
+another program.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import struct
+import subprocess
+import sys
+import time
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = REPO_ROOT / "benchmarks" / "courtyard" / "exhaustive_control.json"
+DEFAULT_ARTIFACT_ROOT_ENV = "COURTYARD_ARTIFACT_ROOT"
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+SCORE_MATCH_RE = re.compile(r"matched=(\d+)/(\d+)\s+est_registered=(\d+)")
+SCORE_RMSE_RE = re.compile(r"^rmse_m=([0-9eE+.-]+)", re.MULTILINE)
+CANDIDATE_MANIFEST_MAGIC = "visloc_candidate_manifest_v1"
+VIEW_GRAPH_RE = re.compile(r"view graph:\s+(\d+)\s+candidate pairs")
+VERIFIED_RE = re.compile(r"verified\s+(\d+)\s*/\s*(\d+)\s+pairs,\s+(\d+)\s+inlier correspondences")
+RECONSTRUCTION_RE = re.compile(
+    r"reconstruction .*?:\s+(\d+)\s*/\s*(\d+)\s+images registered,\s+(\d+)\s+tracks,\s+mean reproj\s+([0-9eE+.-]+)\s+px"
+)
+WRITTEN_MODEL_RE = re.compile(
+    r"wrote COLMAP model to\s+(.+?)\s+\((\d+)\s+images,\s+(\d+)\s+points,\s+(\d+)\s+observations\)"
+)
+TRANSITIVE_RE = re.compile(r"transitive expansion:\s+(\d+)\s+new pairs")
+RUNTIME_RE = re.compile(r"^elapsed=([0-9eE+.-]+)\s+maxrss=([0-9]+)", re.MULTILINE)
+
+
+class ValidationError(RuntimeError):
+    """An input or result failed a reproducibility gate."""
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of *path* without loading it all in memory."""
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ValidationError(f"cannot read {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def _required_sha(value: Any, label: str) -> str:
+    if not isinstance(value, str) or SHA256_RE.fullmatch(value) is None:
+        raise ValidationError(f"{label} must be a 64-character hexadecimal SHA-256")
+    return value.lower()
+
+
+def validate_hashed_file(path: Path, expected_sha256: str, label: str) -> str:
+    """Check existence and exact digest, returning the verified digest."""
+
+    if not path.is_file():
+        raise ValidationError(f"{label} is missing: {path}; provide the durable artifact or override its root")
+    expected = _required_sha(expected_sha256, f"{label} expected hash")
+    actual = sha256_file(path)
+    if actual != expected:
+        raise ValidationError(
+            f"{label} hash mismatch for {path}: expected {expected}, got {actual}; "
+            "use the artifact version recorded by the benchmark manifest"
+        )
+    return actual
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    """Load and minimally validate a benchmark manifest."""
+
+    if not path.is_file():
+        raise ValidationError(f"benchmark config not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot parse benchmark config {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValidationError(f"benchmark config must contain a JSON object: {path}")
+    if data.get("schema_version") != 1:
+        raise ValidationError(f"unsupported benchmark config schema_version: {data.get('schema_version')!r}")
+    if not isinstance(data.get("benchmark"), dict) or not data["benchmark"].get("id"):
+        raise ValidationError("benchmark config is missing benchmark.id")
+    for section in ("inputs", "models", "mapping", "visuals"):
+        if not isinstance(data.get(section), dict):
+            raise ValidationError(f"benchmark config is missing object section {section!r}")
+    return data
+
+
+def resolve_artifact_root(config: dict[str, Any], override: Path | None) -> Path:
+    configured = config.get("artifact_root")
+    value: str | Path | None = override
+    if value is None:
+        value = os.environ.get(DEFAULT_ARTIFACT_ROOT_ENV) or configured
+    if value is None:
+        raise ValidationError(
+            f"no artifact root configured; pass --artifact-root or set {DEFAULT_ARTIFACT_ROOT_ENV}"
+        )
+    root = Path(value).expanduser().resolve()
+    if not root.is_dir():
+        raise ValidationError(
+            f"artifact root does not exist: {root}; pass --artifact-root pointing at the durable courtyard artifact"
+        )
+    return root
+
+
+def resolve_path(root: Path, value: str | Path, *, label: str) -> Path:
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path.resolve()
+    # Relative paths in the manifest are rooted at the external artifact.
+    return (root / path).resolve()
+
+
+def _safe_manifest_relative(value: str, label: str) -> Path:
+    path = Path(value)
+    if path.is_absolute() or not value or any(part in ("", ".", "..") for part in path.parts):
+        raise ValidationError(f"{label} must be a simple relative path, got {value!r}")
+    return path
+
+
+def _noncomment_lines(path: Path) -> list[str]:
+    try:
+        return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip() and not line.lstrip().startswith("#")]
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read text file {path}: {exc}") from exc
+
+
+def parse_feature_manifest(path: Path) -> list[dict[str, Any]]:
+    """Parse a ``file rows sha256`` feature manifest."""
+
+    if not path.is_file():
+        raise ValidationError(f"feature manifest is missing: {path}")
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read feature manifest {path}: {exc}") from exc
+    for line_number, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        if len(fields) != 3:
+            raise ValidationError(f"feature manifest {path}:{line_number} must contain file, rows, sha256")
+        relative = _safe_manifest_relative(fields[0], f"feature manifest {path}:{line_number} path")
+        name = relative.as_posix()
+        if name in seen:
+            raise ValidationError(f"feature manifest repeats {name!r} at {path}:{line_number}")
+        seen.add(name)
+        try:
+            rows = int(fields[1])
+        except ValueError as exc:
+            raise ValidationError(f"feature manifest {path}:{line_number} has non-integer row count") from exc
+        if rows < 0:
+            raise ValidationError(f"feature manifest {path}:{line_number} has negative row count")
+        entries.append({"path": relative, "rows": rows, "sha256": _required_sha(fields[2], f"feature manifest {path}:{line_number}")})
+    if not entries:
+        raise ValidationError(f"feature manifest is empty: {path}")
+    return entries
+
+
+def _count_data_rows(path: Path) -> int:
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            return sum(1 for line in stream if line.strip() and not line.lstrip().startswith("#"))
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot count rows in {path}: {exc}") from exc
+
+
+def validate_features(root: Path, spec: dict[str, Any]) -> tuple[list[str], dict[str, Any]]:
+    manifest_spec = spec.get("manifest")
+    if not isinstance(manifest_spec, dict) or not isinstance(manifest_spec.get("path"), str):
+        raise ValidationError("inputs.features.manifest.path is required")
+    manifest_path = resolve_path(root, manifest_spec["path"], label="feature manifest")
+    validate_hashed_file(manifest_path, manifest_spec.get("sha256"), "feature manifest")
+    entries = parse_feature_manifest(manifest_path)
+    expected_count = spec.get("file_count")
+    if expected_count is not None and len(entries) != expected_count:
+        raise ValidationError(f"feature file count mismatch: expected {expected_count}, got {len(entries)}")
+    expected_total = spec.get("total_rows")
+    total_rows = 0
+    row_counts: dict[int, int] = {}
+    feature_names: list[str] = []
+    suffix = "_features.txt"
+    for entry in entries:
+        path = (manifest_path.parent / entry["path"]).resolve()
+        try:
+            path.relative_to(root.resolve())
+        except ValueError as exc:
+            raise ValidationError(f"feature manifest entry escapes artifact root: {entry['path']}") from exc
+        label = f"feature file {entry['path']}"
+        validate_hashed_file(path, entry["sha256"], label)
+        rows = _count_data_rows(path)
+        if rows != entry["rows"]:
+            raise ValidationError(f"{label} row count mismatch: manifest {entry['rows']}, actual {rows}")
+        total_rows += rows
+        row_counts[len(feature_names)] = rows
+        filename = Path(entry["path"]).name
+        if not filename.endswith(suffix):
+            raise ValidationError(f"feature file does not use {suffix!r}: {filename}")
+        feature_names.append(filename[: -len(suffix)])
+    if expected_total is not None and total_rows != expected_total:
+        raise ValidationError(f"feature row total mismatch: expected {expected_total}, got {total_rows}")
+    return feature_names, {"file_count": len(entries), "total_rows": total_rows, "manifest_sha256": manifest_spec["sha256"], "row_counts": row_counts}
+
+
+def _expected_image_names(feature_stems: Iterable[str], image_suffix: str) -> list[str]:
+    return [f"{stem}{image_suffix}" for stem in feature_stems]
+
+
+def validate_images(directory: Path, spec: dict[str, Any], expected_names: list[str]) -> dict[str, Any]:
+    if not directory.is_dir():
+        raise ValidationError(f"image directory is missing: {directory}; pass --images-dir to the official source images")
+    suffix = spec.get("suffix", ".JPG")
+    hashes = spec.get("sha256")
+    if not isinstance(hashes, dict):
+        raise ValidationError("inputs.images.sha256 must map exact image names to hashes")
+    expected_set = set(hashes)
+    if set(expected_names) != expected_set:
+        raise ValidationError("feature manifest image names do not match the configured image hash manifest")
+    actual_names = {path.name for path in directory.iterdir() if path.is_file() and path.name.endswith(suffix)}
+    if actual_names != expected_set:
+        missing = sorted(expected_set - actual_names)
+        extra = sorted(actual_names - expected_set)
+        raise ValidationError(f"image set mismatch in {directory}: missing={missing[:5]} extra={extra[:5]}")
+    for name in expected_names:
+        validate_hashed_file(directory / name, hashes[name], f"source image {name}")
+    expected_count = spec.get("file_count")
+    if expected_count is not None and len(actual_names) != expected_count:
+        raise ValidationError(f"source image count mismatch: expected {expected_count}, got {len(actual_names)}")
+    return {"directory": str(directory), "file_count": len(actual_names), "suffix": suffix}
+
+
+def _next_nonempty(lines: Iterable[str], label: str) -> str:
+    for raw in lines:
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            return line
+    raise ValidationError(f"{label} is truncated")
+
+
+def validate_matches(path: Path, spec: dict[str, Any], feature_stems: list[str], image_suffix: str, row_counts: dict[int, int] | None = None) -> dict[str, Any]:
+    expected_sha = spec.get("sha256")
+    validate_hashed_file(path, expected_sha, "raw match import")
+    try:
+        stream = path.open("r", encoding="utf-8")
+    except OSError as exc:
+        raise ValidationError(f"cannot open raw match import {path}: {exc}") from exc
+    with stream:
+        lines = (line for line in stream)
+        try:
+            image_count = int(_next_nonempty(lines, "raw match import image count"))
+        except ValueError as exc:
+            raise ValidationError("raw match import image count is not an integer") from exc
+        names = [_next_nonempty(lines, "raw match import image names") for _ in range(image_count)]
+        expected_names = _expected_image_names(feature_stems, image_suffix)
+        if names != expected_names:
+            raise ValidationError("raw match import image names/order differ from the feature manifest")
+        try:
+            pair_count = int(_next_nonempty(lines, "raw match import pair count"))
+        except ValueError as exc:
+            raise ValidationError("raw match import pair count is not an integer") from exc
+        seen_pairs: set[tuple[int, int]] = set()
+        raw_matches = 0
+        for pair_number in range(pair_count):
+            header = _next_nonempty(lines, f"raw match import pair {pair_number} header").split()
+            if len(header) != 3:
+                raise ValidationError(f"raw match import pair {pair_number} header must be i j count")
+            try:
+                first, second, count = (int(value) for value in header)
+            except ValueError as exc:
+                raise ValidationError(f"raw match import pair {pair_number} header is not numeric") from exc
+            if not (0 <= first < image_count and 0 <= second < image_count) or first == second:
+                raise ValidationError(f"raw match import pair {pair_number} has invalid image indices")
+            pair = tuple(sorted((first, second)))
+            if pair in seen_pairs:
+                raise ValidationError(f"raw match import repeats pair {pair}")
+            seen_pairs.add(pair)
+            if count < 0:
+                raise ValidationError(f"raw match import pair {pair} has negative match count")
+            for match_number in range(count):
+                fields = _next_nonempty(lines, f"raw match import pair {pair} match {match_number}").split()
+                if len(fields) != 2:
+                    raise ValidationError(f"raw match import pair {pair} contains a malformed correspondence")
+                try:
+                    first_index = int(fields[0])
+                    second_index = int(fields[1])
+                except ValueError as exc:
+                    raise ValidationError(f"raw match import pair {pair} contains a non-numeric correspondence") from exc
+                if row_counts is not None:
+                    if first not in row_counts or second not in row_counts:
+                        raise ValidationError(f"raw match import pair {pair} has no matching feature row-count entry")
+                    if not 0 <= first_index < row_counts[first] or not 0 <= second_index < row_counts[second]:
+                        raise ValidationError(f"raw match import pair {pair} contains a feature index outside its manifest row count")
+            raw_matches += count
+        trailing = [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
+        if trailing:
+            raise ValidationError(f"raw match import has unexpected trailing data after {pair_count} pairs")
+    expected_pairs = spec.get("pair_count")
+    if expected_pairs is not None and pair_count != expected_pairs:
+        raise ValidationError(f"raw match pair count mismatch: expected {expected_pairs}, got {pair_count}")
+    expected_raw = spec.get("raw_match_count")
+    if expected_raw is not None and raw_matches != expected_raw:
+        raise ValidationError(f"raw match correspondence count mismatch: expected {expected_raw}, got {raw_matches}")
+    if spec.get("candidate_semantics", "").startswith("all unordered"):
+        expected_set = set(combinations(range(image_count), 2))
+        if seen_pairs != expected_set:
+            raise ValidationError("raw match import is not the complete unordered candidate set")
+    return {"pair_count": pair_count, "raw_match_count": raw_matches, "sha256": expected_sha}
+
+
+def parse_candidate_manifest(path: Path, expected_names: list[str]) -> dict[str, Any]:
+    """Parse the image-name-bound candidate schedule emitted by the Rust demo.
+
+    Candidate manifests deliberately contain no matches or verification data;
+    they are safe to select before the expensive local matcher runs.  Keep this
+    parser structurally identical to the Rust reader so a manifest can be
+    validated in a cheap Python-only job before it is handed to the mapper.
+    """
+
+    lines = _noncomment_lines(path)
+    cursor = 0
+
+    def next_line(label: str) -> str:
+        nonlocal cursor
+        if cursor >= len(lines):
+            raise ValidationError(f"candidate manifest {path} is truncated while reading {label}")
+        line = lines[cursor]
+        cursor += 1
+        return line
+
+    if next_line("header") != CANDIDATE_MANIFEST_MAGIC:
+        raise ValidationError(f"candidate manifest {path} has unsupported header")
+    image_header = next_line("image count").split()
+    if len(image_header) != 2 or image_header[0] != "images":
+        raise ValidationError(f"candidate manifest {path} image count must be images N")
+    try:
+        image_count = int(image_header[1])
+    except ValueError as exc:
+        raise ValidationError(f"candidate manifest {path} image count is not numeric") from exc
+    if image_count != len(expected_names):
+        raise ValidationError(
+            f"candidate manifest {path} image count {image_count} differs from loaded {len(expected_names)}"
+        )
+    for expected_index, expected_name in enumerate(expected_names):
+        fields = next_line("image entry").split(maxsplit=2)
+        if len(fields) != 3 or fields[0] != "image":
+            raise ValidationError(f"candidate manifest {path} image entry must be image INDEX NAME")
+        try:
+            index = int(fields[1])
+        except ValueError as exc:
+            raise ValidationError(f"candidate manifest {path} image index is not numeric") from exc
+        if index != expected_index or fields[2] != expected_name:
+            raise ValidationError(
+                f"candidate manifest {path} image entry {expected_index} does not match loaded image order"
+            )
+
+    pair_header = next_line("pair count").split()
+    if len(pair_header) != 2 or pair_header[0] != "pairs":
+        raise ValidationError(f"candidate manifest {path} pair count must be pairs N")
+    try:
+        pair_count = int(pair_header[1])
+    except ValueError as exc:
+        raise ValidationError(f"candidate manifest {path} pair count is not numeric") from exc
+    if pair_count < 0:
+        raise ValidationError(f"candidate manifest {path} has a negative pair count")
+    pairs: list[tuple[int, int]] = []
+    seen: set[tuple[int, int]] = set()
+    for pair_number in range(pair_count):
+        fields = next_line("pair entry").split()
+        if len(fields) != 3 or fields[0] != "pair":
+            raise ValidationError(f"candidate manifest {path} pair {pair_number} must be pair I J")
+        try:
+            first, second = int(fields[1]), int(fields[2])
+        except ValueError as exc:
+            raise ValidationError(f"candidate manifest {path} pair {pair_number} is not numeric") from exc
+        if not (0 <= first < second < image_count):
+            raise ValidationError(
+                f"candidate manifest {path} pair {pair_number} must satisfy 0 <= I < J < {image_count}"
+            )
+        pair = (first, second)
+        if pair in seen:
+            raise ValidationError(f"candidate manifest {path} repeats pair {pair}")
+        seen.add(pair)
+        pairs.append(pair)
+    if cursor != len(lines):
+        raise ValidationError(f"candidate manifest {path} has unexpected trailing data")
+    return {"path": str(path), "pair_count": pair_count, "pairs": pairs, "sha256": sha256_file(path)}
+
+
+def validate_candidate_manifest(
+    path: Path,
+    expected_names: list[str],
+    expected_pair_count: int | None = None,
+    expected_sha256: str | None = None,
+) -> dict[str, Any]:
+    if expected_sha256 is not None:
+        validate_hashed_file(path, expected_sha256, "candidate manifest")
+    result = parse_candidate_manifest(path, expected_names)
+    if expected_pair_count is not None and result["pair_count"] != expected_pair_count:
+        raise ValidationError(
+            f"candidate manifest pair count mismatch: expected {expected_pair_count}, got {result['pair_count']}"
+        )
+    # Do not expose the full pair list in the benchmark summary; its digest and
+    # count are sufficient for an independently reproducible schedule.
+    return {key: value for key, value in result.items() if key != "pairs"}
+
+
+def parse_mapping_log(path: Path) -> dict[str, Any]:
+    """Extract machine-readable candidate/verification/mapping counters."""
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ValidationError(f"cannot read mapping log {path}: {exc}") from exc
+    graph = VIEW_GRAPH_RE.findall(text)
+    verified = VERIFIED_RE.findall(text)
+    recon = RECONSTRUCTION_RE.findall(text)
+    written = WRITTEN_MODEL_RE.findall(text)
+    expansions = [int(value) for value in TRANSITIVE_RE.findall(text)]
+    runtime = RUNTIME_RE.findall(text)
+    if not graph:
+        raise ValidationError(f"mapping log has no candidate-pair summary: {path}")
+    result: dict[str, Any] = {
+        "candidate_pairs": int(graph[-1]),
+        "candidate_pairs_base": int(graph[-1]),
+        "adaptive_expansion_pairs": sum(expansions),
+    }
+    if expansions:
+        result["candidate_pairs_total"] = int(graph[-1]) + sum(expansions)
+    if verified:
+        matched, attempted, inliers = verified[-1]
+        result.update(
+            {
+                "verified_pairs": int(matched),
+                "verification_pairs": int(attempted),
+                "inlier_correspondences": int(inliers),
+            }
+        )
+    if recon:
+        registered, total, tracks, reprojection = recon[-1]
+        result.update(
+            {
+                "registered": int(registered),
+                "total_images": int(total),
+                "tracks": int(tracks),
+                "reprojection_px": float(reprojection),
+            }
+        )
+    if written:
+        model_path, images, points, observations = written[-1]
+        result["written_model"] = {
+            "path": model_path,
+            "images": int(images),
+            "points": int(points),
+            "observations": int(observations),
+        }
+    if runtime:
+        elapsed, maxrss = runtime[-1]
+        result["process_elapsed_s"] = float(elapsed)
+        result["peak_rss_kb"] = int(maxrss)
+    return result
+
+
+def parse_colmap_image_names(path: Path) -> list[str]:
+    try:
+        lines = [line.rstrip("\r\n") for line in path.read_text(encoding="utf-8").splitlines(keepends=True) if not line.lstrip().startswith("#")]
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read COLMAP images.txt {path}: {exc}") from exc
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    if len(lines) % 2:
+        raise ValidationError(f"COLMAP images.txt has an unmatched pose/points2D row: {path}")
+    names: list[str] = []
+    for row_number in range(0, len(lines), 2):
+        fields = lines[row_number].split()
+        if len(fields) < 10:
+            raise ValidationError(f"COLMAP images.txt pose row {row_number + 1} is malformed: {path}")
+        try:
+            int(fields[0])
+            [float(value) for value in fields[1:8]]
+        except ValueError as exc:
+            raise ValidationError(f"COLMAP images.txt pose row {row_number + 1} is not numeric: {path}") from exc
+        names.append(fields[9])
+    if len(set(names)) != len(names):
+        raise ValidationError(f"COLMAP images.txt contains duplicate image names: {path}")
+    return names
+
+
+def parse_colmap_point_stats(path: Path) -> tuple[int, int]:
+    points = _noncomment_lines(path)
+    observations = 0
+    for row_number, line in enumerate(points, 1):
+        fields = line.split()
+        if len(fields) < 8:
+            raise ValidationError(f"COLMAP points3D.txt row {row_number} is malformed: {path}")
+        try:
+            [float(value) for value in fields[1:8]]
+        except ValueError as exc:
+            raise ValidationError(f"COLMAP points3D.txt row {row_number} is not numeric: {path}") from exc
+        if (len(fields) - 8) % 2:
+            raise ValidationError(f"COLMAP points3D.txt row {row_number} has an incomplete track: {path}")
+        observations += (len(fields) - 8) // 2
+    return len(points), observations
+
+
+def validate_model(root: Path, spec: dict[str, Any], label: str, *, expected_files: bool = True) -> dict[str, Any]:
+    if not isinstance(spec, dict) or not isinstance(spec.get("path"), str):
+        raise ValidationError(f"models.{label}.path is required")
+    model_dir = resolve_path(root, spec["path"], label=f"{label} model")
+    if not model_dir.is_dir():
+        raise ValidationError(f"{label} model directory is missing: {model_dir}")
+    files = spec.get("files", {})
+    if expected_files:
+        if not isinstance(files, dict):
+            raise ValidationError(f"models.{label}.files must be an object")
+        for filename, expected_sha in files.items():
+            validate_hashed_file(model_dir / filename, expected_sha, f"{label} model {filename}")
+    image_path = model_dir / "images.txt"
+    point_path = model_dir / "points3D.txt"
+    names = parse_colmap_image_names(image_path)
+    points, observations = parse_colmap_point_stats(point_path)
+    expected_registered = spec.get("registered")
+    if expected_registered is not None and len(names) != expected_registered:
+        raise ValidationError(f"{label} registered-camera count mismatch: expected {expected_registered}, got {len(names)}")
+    for key, actual in (("tracks", points), ("points", points), ("observations", observations)):
+        if key in spec and spec[key] != actual:
+            raise ValidationError(f"{label} {key} mismatch: expected {spec[key]}, got {actual}")
+    result: dict[str, Any] = {
+        "path": str(model_dir),
+        "registered": len(names),
+        "points": points,
+        "observations": observations,
+    }
+    if "tracks" in spec:
+        result["tracks"] = points
+    if "reprojection_px" in spec:
+        result["reprojection_px"] = spec["reprojection_px"]
+    if files:
+        result["file_hashes"] = dict(sorted((str(key), str(value).lower()) for key, value in files.items()))
+    return result
+
+
+def parse_score_file(path: Path) -> dict[str, float | int]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read visloc score file {path}: {exc}") from exc
+    match = SCORE_MATCH_RE.search(text)
+    rmse = SCORE_RMSE_RE.search(text)
+    if match is None or rmse is None:
+        raise ValidationError(f"visloc score file has an unsupported format: {path}")
+    return {
+        "matched": int(match.group(1)),
+        "reference_registered": int(match.group(2)),
+        "registered": int(match.group(3)),
+        "rmse_m": float(rmse.group(1)),
+    }
+
+
+def validate_score_file(root: Path, spec: dict[str, Any], model_spec: dict[str, Any], max_rmse_m: float) -> dict[str, Any]:
+    score_spec = model_spec.get("score_file")
+    if not isinstance(score_spec, dict):
+        raise ValidationError("models.visloc.score_file is required for verify-only mode")
+    path = resolve_path(root, score_spec.get("path"), label="visloc score")
+    validate_hashed_file(path, score_spec.get("sha256"), "visloc score file")
+    score = parse_score_file(path)
+    expected_registered = int(model_spec.get("registered", 0))
+    if score["registered"] != expected_registered or score["matched"] != expected_registered:
+        raise ValidationError(
+            f"stored visloc score is incomplete: expected {expected_registered}/{expected_registered}, "
+            f"got {score['matched']}/{score['reference_registered']} and registered={score['registered']}"
+        )
+    expected_rmse = model_spec.get("score_rmse_m")
+    if expected_rmse is not None and abs(float(score["rmse_m"]) - float(expected_rmse)) > 1e-12:
+        raise ValidationError(f"stored visloc RMSE differs from manifest: expected {expected_rmse}, got {score['rmse_m']}")
+    if float(score["rmse_m"]) > max_rmse_m:
+        raise ValidationError(f"visloc centre RMSE {score['rmse_m']:.6f} m exceeds threshold {max_rmse_m:.6f} m")
+    return {**score, "score_file": str(path), "sha256": score_spec["sha256"]}
+
+
+def _png_dimensions(path: Path) -> tuple[int, int]:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise ValidationError(f"cannot read PNG asset {path}: {exc}") from exc
+    if len(data) < 24 or data[:8] != b"\x89PNG\r\n\x1a\n" or data[12:16] != b"IHDR":
+        raise ValidationError(f"invalid PNG signature/header: {path}")
+    return struct.unpack(">II", data[16:24])
+
+
+def _gif_dimensions_and_frames(path: Path) -> tuple[int, int, int]:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise ValidationError(f"cannot read GIF asset {path}: {exc}") from exc
+    if len(data) < 13 or data[:6] not in (b"GIF87a", b"GIF89a"):
+        raise ValidationError(f"invalid GIF header: {path}")
+    width, height = struct.unpack_from("<HH", data, 6)
+    packed = data[10]
+    offset = 13
+    if packed & 0x80:
+        offset += 3 * (1 << ((packed & 0x07) + 1))
+    frames = 0
+    while offset < len(data):
+        introducer = data[offset]
+        offset += 1
+        if introducer == 0x3B:
+            break
+        if introducer == 0x2C:
+            if offset + 9 > len(data):
+                raise ValidationError(f"truncated GIF image descriptor: {path}")
+            local_packed = data[offset + 8]
+            offset += 9
+            if local_packed & 0x80:
+                offset += 3 * (1 << ((local_packed & 0x07) + 1))
+            if offset >= len(data):
+                raise ValidationError(f"truncated GIF LZW header: {path}")
+            offset += 1
+            while True:
+                if offset >= len(data):
+                    raise ValidationError(f"truncated GIF image data: {path}")
+                size = data[offset]
+                offset += 1
+                if size == 0:
+                    break
+                offset += size
+                if offset > len(data):
+                    raise ValidationError(f"truncated GIF sub-block: {path}")
+            frames += 1
+            continue
+        if introducer == 0x21:
+            if offset >= len(data):
+                raise ValidationError(f"truncated GIF extension: {path}")
+            offset += 1  # extension label
+            while True:
+                if offset >= len(data):
+                    raise ValidationError(f"truncated GIF extension data: {path}")
+                size = data[offset]
+                offset += 1
+                if size == 0:
+                    break
+                offset += size
+                if offset > len(data):
+                    raise ValidationError(f"truncated GIF extension sub-block: {path}")
+            continue
+        raise ValidationError(f"unknown GIF block 0x{introducer:02x}: {path}")
+    return width, height, frames
+
+
+def validate_visuals(repo_root: Path, spec: dict[str, Any]) -> dict[str, Any]:
+    readme_value = spec.get("readme", "README.md")
+    readme = (repo_root / readme_value).resolve()
+    if not readme.is_file():
+        raise ValidationError(f"README for benchmark visual validation is missing: {readme}")
+    readme_text = readme.read_text(encoding="utf-8")
+    for needle in spec.get("readme_needles", []):
+        if needle not in readme_text:
+            raise ValidationError(f"README is missing the measured courtyard claim/reference: {needle!r}")
+    assets_result: dict[str, Any] = {}
+    assets = spec.get("assets")
+    if not isinstance(assets, dict):
+        raise ValidationError("visuals.assets must be an object")
+    for name, asset in sorted(assets.items()):
+        if not isinstance(asset, dict) or not isinstance(asset.get("path"), str):
+            raise ValidationError(f"visuals.assets.{name}.path is required")
+        path = (repo_root / asset["path"]).resolve()
+        validate_hashed_file(path, asset.get("sha256"), f"README {name} asset")
+        if name == "png":
+            width, height = _png_dimensions(path)
+            frames = None
+        elif name == "gif":
+            width, height, frames = _gif_dimensions_and_frames(path)
+        else:
+            raise ValidationError(f"unsupported visual asset kind {name!r}")
+        if (width, height) != (asset.get("width"), asset.get("height")):
+            raise ValidationError(f"README {name} dimensions differ: expected {(asset.get('width'), asset.get('height'))}, got {(width, height)}")
+        if frames is not None and asset.get("frames") is not None and frames != asset["frames"]:
+            raise ValidationError(f"README GIF frame count differs: expected {asset['frames']}, got {frames}")
+        assets_result[name] = {"path": str(path), "sha256": asset["sha256"], "width": width, "height": height, **({"frames": frames} if frames is not None else {})}
+    return {"readme": str(readme), "assets": assets_result}
+
+
+def validate_artifact_root_manifest(root: Path, config: dict[str, Any]) -> None:
+    manifest_spec = config.get("artifact_manifest")
+    if isinstance(manifest_spec, dict):
+        path = resolve_path(root, manifest_spec.get("path"), label="artifact checksum manifest")
+        validate_hashed_file(path, manifest_spec.get("sha256"), "artifact checksum manifest")
+
+
+def validate_inputs(config: dict[str, Any], root: Path, *, images_override: Path | None, calibration_override: Path | None, max_rmse_m: float, include_colmap: bool = True) -> dict[str, Any]:
+    validate_artifact_root_manifest(root, config)
+    inputs = config["inputs"]
+    mapping = config["mapping"]
+    image_suffix = str(mapping.get("image_suffix", ".JPG"))
+    feature_stems, feature_stats = validate_features(root, inputs["features"])
+    images_spec = inputs.get("images")
+    images_summary: dict[str, Any] | None = None
+    if isinstance(images_spec, dict):
+        configured_dir = Path(images_spec.get("directory", "")) if images_spec.get("directory") else None
+        image_dir = (images_override or configured_dir)
+        if image_dir is None:
+            raise ValidationError("source image directory is required; pass --images-dir or configure inputs.images.directory")
+        images_summary = validate_images(image_dir.expanduser().resolve(), images_spec, _expected_image_names(feature_stems, image_suffix))
+    matches_spec = inputs["matches"]
+    matches_path = resolve_path(root, matches_spec.get("path"), label="raw matches")
+    matches_summary = validate_matches(matches_path, matches_spec, feature_stems, image_suffix, feature_stats.get("row_counts"))
+
+    calibration_spec = inputs.get("calibration")
+    calibration_summary: dict[str, Any] | None = None
+    calibration_dir: Path | None = None
+    if isinstance(calibration_spec, dict):
+        configured_calibration = Path(calibration_spec.get("model_dir", "")) if calibration_spec.get("model_dir") else None
+        calibration_dir = (calibration_override or configured_calibration)
+        if calibration_dir is None:
+            raise ValidationError("calibration model is required; pass --calibration-model or configure inputs.calibration.model_dir")
+        calibration_dir = calibration_dir.expanduser().resolve()
+        if not calibration_dir.is_dir():
+            raise ValidationError(f"calibration model directory is missing: {calibration_dir}")
+        for filename, expected_sha in calibration_spec.get("files", {}).items():
+            validate_hashed_file(calibration_dir / filename, expected_sha, f"calibration {filename}")
+        calibration_names = parse_colmap_image_names(calibration_dir / "images.txt")
+        expected_registered = calibration_spec.get("registered")
+        if expected_registered is not None and len(calibration_names) != expected_registered:
+            raise ValidationError(f"calibration registered-camera count mismatch: expected {expected_registered}, got {len(calibration_names)}")
+        calibration_summary = {"path": str(calibration_dir), "registered": len(calibration_names), "file_hashes": dict(sorted(calibration_spec.get("files", {}).items()))}
+
+    model_summary: dict[str, Any] = {}
+    visloc_spec = config["models"].get("visloc")
+    if not isinstance(visloc_spec, dict):
+        raise ValidationError("models.visloc is required")
+    model_summary["visloc"] = validate_model(root, visloc_spec, "visloc")
+    if include_colmap:
+        colmap_spec = config["models"].get("colmap")
+        if not isinstance(colmap_spec, dict):
+            raise ValidationError("models.colmap is required when --colmap-control is validate or run")
+        model_summary["colmap"] = validate_model(root, colmap_spec, "COLMAP")
+    result = {
+        "artifact_root": str(root),
+        "features": {key: value for key, value in feature_stats.items() if key != "row_counts"},
+        "feature_names": feature_stems,
+        "matches": matches_summary,
+        "images": images_summary,
+        "calibration": calibration_summary,
+        "models": model_summary,
+        "calibration_dir": str(calibration_dir) if calibration_dir is not None else None,
+        "matches_path": str(matches_path),
+        "features_dir": str((resolve_path(root, inputs["features"]["manifest"]["path"], label="feature manifest")).parent),
+    }
+    return result
+
+
+def _tail(path: Path, lines: int = 30) -> str:
+    try:
+        values = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return "(log unavailable)"
+    return "\n".join(values[-lines:])
+
+
+def run_command(command: list[str], *, cwd: Path, log_path: Path, env: dict[str, str] | None = None) -> float:
+    started = time.monotonic()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"$ {shlex.join(command)}", file=sys.stderr)
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    try:
+        with log_path.open("w", encoding="utf-8") as log:
+            result = subprocess.run(command, cwd=cwd, env=merged_env, stdout=log, stderr=subprocess.STDOUT, check=False)
+    except OSError as exc:
+        raise ValidationError(f"cannot execute {command[0]!r}: {exc}; see intended command above") from exc
+    if result.returncode != 0:
+        raise ValidationError(f"command failed with exit code {result.returncode}: {shlex.join(command)}\nlast log lines:\n{_tail(log_path)}")
+    return time.monotonic() - started
+
+
+def _prepare_output(path: Path, force: bool) -> None:
+    if path.exists():
+        if not force:
+            raise ValidationError(f"output directory already exists: {path}; choose a new --output-dir or pass --force")
+        if not path.is_dir():
+            raise ValidationError(f"--output-dir exists but is not a directory: {path}")
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=False)
+
+
+def resolve_candidate_schedule(config: dict[str, Any], name: str) -> dict[str, Any]:
+    """Resolve a named, pre-match candidate schedule from the benchmark config."""
+
+    schedules = config.get("candidate_schedules", {})
+    if not isinstance(schedules, dict):
+        raise ValidationError("candidate_schedules must be an object")
+    value = schedules.get(name)
+    if value is None:
+        # Explicit strategy names are useful for a one-off local run while
+        # named entries keep the published benchmark reproducible.
+        value = {"strategy": name}
+    if not isinstance(value, dict):
+        raise ValidationError(f"candidate schedule {name!r} must be an object")
+    schedule = dict(value)
+    strategy = schedule.get("strategy")
+    if strategy not in {"exhaustive", "sequential", "vlad", "vlad-mutual", "vlad-union", "adaptive", "manifest"}:
+        raise ValidationError(
+            f"candidate schedule {name!r} has unsupported strategy {strategy!r}; "
+            "expected exhaustive|sequential|vlad|vlad-mutual|vlad-union|adaptive|manifest"
+        )
+    schedule["name"] = name
+    if strategy in {"vlad", "vlad-mutual", "vlad-union"}:
+        topk = schedule.get("retrieval_topk")
+        if not isinstance(topk, int) or topk <= 0:
+            raise ValidationError(f"candidate schedule {name!r} retrieval_topk must be a positive integer")
+    if strategy == "sequential":
+        window = schedule.get("stem_window")
+        if not isinstance(window, int) or window <= 0:
+            raise ValidationError(f"candidate schedule {name!r} stem_window must be a positive integer")
+    if strategy == "vlad-union":
+        window = schedule.get("local_stem_window")
+        if not isinstance(window, int) or window <= 0:
+            raise ValidationError(f"candidate schedule {name!r} local_stem_window must be a positive integer")
+    if strategy == "adaptive":
+        count = schedule.get("vocab_tree_num_images")
+        if not isinstance(count, int) or count <= 0:
+            raise ValidationError(f"candidate schedule {name!r} vocab_tree_num_images must be a positive integer")
+    budget = schedule.get("candidate_budget")
+    if budget is not None and (not isinstance(budget, int) or budget <= 0):
+        raise ValidationError(f"candidate schedule {name!r} candidate_budget must be a positive integer")
+    if "candidate_count" in schedule and (not isinstance(schedule["candidate_count"], int) or schedule["candidate_count"] <= 0):
+        raise ValidationError(f"candidate schedule {name!r} candidate_count must be a positive integer")
+    return schedule
+
+
+def resolve_schedule_manifest(root: Path, schedule: dict[str, Any]) -> tuple[Path, str | None] | None:
+    """Resolve an optional pre-generated manifest referenced by a schedule."""
+
+    value = schedule.get("candidate_manifest")
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return resolve_path(root, value, label="candidate manifest"), None
+    if not isinstance(value, dict) or not isinstance(value.get("path"), str):
+        raise ValidationError("candidate schedule candidate_manifest must be a path or {path, sha256}")
+    return resolve_path(root, value["path"], label="candidate manifest"), value.get("sha256")
+
+
+def build_mapping_command(
+    config: dict[str, Any],
+    *,
+    binary: Path,
+    features_dir: Path,
+    images_dir: Path | None,
+    calibration_dir: Path,
+    matches_path: Path,
+    output_model: Path,
+    candidate_schedule: dict[str, Any] | None = None,
+    candidate_manifest: Path | None = None,
+    include_match_import: bool = True,
+) -> list[str]:
+    mapping = config["mapping"]
+    command = [str(binary), "--feature-extractor", "files", "--features-dir", str(features_dir)]
+    command.extend(["--feature-suffix", str(mapping.get("feature_suffix", "_features.txt")), "--image-suffix", str(mapping.get("image_suffix", ".JPG"))])
+    if images_dir is not None:
+        command.extend(["--images-dir", str(images_dir)])
+    command.extend(["--input-colmap-calibration", str(calibration_dir)])
+    if include_match_import:
+        command.extend(["--import-matches-file", str(matches_path)])
+    schedule = candidate_schedule or {"strategy": "exhaustive", "name": "exhaustive"}
+    strategy = schedule["strategy"]
+    if candidate_manifest is not None:
+        command.extend(["--candidate-manifest", str(candidate_manifest)])
+    elif strategy == "exhaustive":
+        command.append("--exhaustive")
+    elif strategy == "sequential":
+        command.extend(["--exhaustive", "--pair-stem-window", str(schedule["stem_window"])])
+    elif strategy in {"vlad", "vlad-mutual"}:
+        command.extend(["--pair-source", strategy, "--retrieval-topk", str(schedule["retrieval_topk"])])
+    elif strategy == "vlad-union":
+        command.extend(
+            [
+                "--pair-source",
+                "vlad-union",
+                "--local-stem-window",
+                str(schedule["local_stem_window"]),
+                "--retrieval-topk",
+                str(schedule["retrieval_topk"]),
+            ]
+        )
+    elif strategy == "adaptive":
+        command.extend(
+            [
+                "--pair-source",
+                "transitive",
+                "--vocab-tree-num-images",
+                str(schedule["vocab_tree_num_images"]),
+            ]
+        )
+    elif strategy == "manifest":
+        raise ValidationError("candidate strategy 'manifest' requires --candidate-manifest or a manifest path in the schedule")
+    else:  # pragma: no cover - resolve_candidate_schedule validates this
+        raise ValidationError(f"unsupported candidate strategy {strategy!r}")
+    if candidate_manifest is None and schedule.get("candidate_budget") is not None:
+        if strategy != "vlad-union":
+            raise ValidationError("candidate_budget is currently supported only by vlad-union")
+        command.extend(["--candidate-budget", str(schedule["candidate_budget"])])
+    command.extend([
+        "--min-matches", str(mapping.get("min_matches", 20)),
+        "--match-ratio", str(mapping.get("match_ratio", 0.8)),
+        "--verification-mode", str(mapping.get("verification_mode", "full")),
+        "--mapper", str(mapping.get("mapper", "incremental")),
+        "--pnp-max-iterations", str(mapping.get("pnp_max_iterations", 100000)),
+        "--min-pnp-inliers", str(mapping.get("min_pnp_inliers", 8)),
+    ])
+    for key, flag in (("geometry_guided_conflict_recovery", "--geometry-guided-conflict-recovery"), ("post_refinement_registration", "--post-refinement-registration"), ("final_iterative_refinement", "--final-iterative-refinement")):
+        if mapping.get(key, False):
+            command.append(flag)
+    if mapping.get("next_image_policy"):
+        command.extend(["--next-image-policy", str(mapping["next_image_policy"])])
+    command.extend(["--out-colmap", str(output_model)])
+    return command
+
+
+def score_model(query_model: Path, reference_model: Path) -> dict[str, Any]:
+    try:
+        import numpy as np
+        import compare_sfm_sim3
+    except ImportError as exc:
+        raise ValidationError(f"full score requires numpy and scripts/compare_sfm_sim3.py: {exc}") from exc
+    try:
+        reference = compare_sfm_sim3.load_centers(str(reference_model / "images.txt"))
+        query = compare_sfm_sim3.load_centers(str(query_model / "images.txt"))
+    except (OSError, ValueError, ZeroDivisionError) as exc:
+        raise ValidationError(f"cannot parse COLMAP model for Sim(3) score: {exc}") from exc
+    common = sorted(set(reference) & set(query))
+    if len(common) < 3:
+        raise ValidationError(f"cannot score model: only {len(common)} common camera names")
+    source = np.asarray([query[index] for index in common], dtype=float)
+    destination = np.asarray([reference[index] for index in common], dtype=float)
+    scale, rotation, translation = compare_sfm_sim3.umeyama(source, destination)
+    aligned = (scale * (rotation @ source.T).T) + translation
+    errors = np.linalg.norm(aligned - destination, axis=1)
+    return {
+        "registered": len(query),
+        "reference_registered": len(reference),
+        "common": len(common),
+        "scale": float(scale),
+        "rmse_m": float(np.sqrt(np.mean(errors**2))),
+        "median_m": float(np.median(errors)),
+        "max_m": float(np.max(errors)),
+    }
+
+
+def run_colmap_control(config: dict[str, Any], root: Path, images_dir: Path, output_dir: Path, calibration_dir: Path) -> dict[str, Any]:
+    control = config.get("colmap_control", {})
+    database_spec = control.get("database", "exhaustive/database_calibrated.db")
+    database = resolve_path(root, database_spec, label="COLMAP database")
+    if not database.is_file():
+        raise ValidationError(f"COLMAP control database is missing: {database}")
+    model_dir = output_dir / "colmap_model"
+    command = ["colmap", "mapper", "--database_path", str(database), "--image_path", str(images_dir), "--output_path", str(model_dir)]
+    run_command(command, cwd=REPO_ROOT, log_path=output_dir / "colmap_mapper.log")
+    candidates = sorted(path for path in model_dir.rglob("images.txt") if path.is_file())
+    if not candidates:
+        raise ValidationError(f"COLMAP mapper completed but wrote no images.txt under {model_dir}")
+    selected = candidates[0].parent
+    model = validate_model(root, {"path": str(selected), "registered": None}, "generated COLMAP", expected_files=False)
+    score = score_model(selected, calibration_dir)
+    return {"command": command, "model": model, "score": score}
+
+
+def regenerate_visuals(config: dict[str, Any], root: Path, output_dir: Path, calibration_dir: Path) -> dict[str, Any]:
+    static_visloc = resolve_path(root, config["models"]["visloc"]["path"], label="visloc model")
+    generated_visloc = output_dir / "visloc_model"
+    visloc_model = generated_visloc if (generated_visloc / "images.txt").is_file() else static_visloc
+    static_colmap = resolve_path(root, config["models"]["colmap"]["path"], label="COLMAP model")
+    visual_dir = output_dir / "visuals"
+    visual_dir.mkdir(parents=True, exist_ok=False)
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "generate_courtyard_readme_visuals.py"),
+        "--visloc-model", str(visloc_model),
+        "--colmap-model", str(static_colmap),
+        "--reference-model", str(calibration_dir),
+        "--output-dir", str(visual_dir),
+    ]
+    run_command(command, cwd=REPO_ROOT, log_path=output_dir / "visuals.log")
+    generated_spec = {
+        "readme": "README.md",
+        "readme_needles": [],
+        "assets": config["visuals"]["assets"],
+    }
+    # The generator's output is in a temporary directory, so validate its
+    # dimensions and deterministic hashes without requiring those files to be
+    # copied into tracked docs/assets.
+    result: dict[str, Any] = {"command": command, "output_dir": str(visual_dir), "assets": {}}
+    for name, asset in sorted(config["visuals"]["assets"].items()):
+        generated = visual_dir / Path(asset["path"]).name
+        if not generated.is_file():
+            raise ValidationError(f"visual generator did not produce {generated}")
+        actual = sha256_file(generated)
+        if actual != asset["sha256"]:
+            raise ValidationError(f"regenerated README {name} hash differs: expected {asset['sha256']}, got {actual}; check plotting dependency versions")
+        if name == "png":
+            width, height = _png_dimensions(generated)
+            frames = None
+        else:
+            width, height, frames = _gif_dimensions_and_frames(generated)
+        if (width, height) != (asset["width"], asset["height"]):
+            raise ValidationError(f"regenerated README {name} dimensions differ")
+        if frames is not None and frames != asset.get("frames"):
+            raise ValidationError(f"regenerated README GIF frame count differs")
+        result["assets"][name] = {"path": str(generated), "sha256": actual, "width": width, "height": height, **({"frames": frames} if frames is not None else {})}
+    del generated_spec
+    return result
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if path.exists() and path.is_dir():
+        raise ValidationError(f"summary path is a directory: {path}")
+    temporary = path.with_name(path.name + ".tmp")
+    try:
+        temporary.write_text(text, encoding="utf-8")
+        temporary.replace(path)
+    except OSError as exc:
+        raise ValidationError(f"cannot write summary JSON {path}: {exc}") from exc
+
+
+def default_summary_path(args: argparse.Namespace) -> Path:
+    if args.summary_json is not None:
+        return Path(args.summary_json).expanduser()
+    if args.full:
+        return Path(args.output_dir).expanduser().resolve() / "summary.json"
+    return (REPO_ROOT / "target" / "benchmark_courtyard" / "verify-summary.json").resolve()
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--verify-only", action="store_true", help="validate hashes/models/README without building or mapping (default)")
+    mode.add_argument("--full", action="store_true", help="run the visloc mapper, score the output, and write logs/artifacts")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help=f"benchmark JSON manifest (default: {DEFAULT_CONFIG})")
+    parser.add_argument("--artifact-root", type=Path, help=f"external artifact root (or {DEFAULT_ARTIFACT_ROOT_ENV})")
+    parser.add_argument("--images-dir", type=Path, help="override the exact source image directory")
+    parser.add_argument("--calibration-model", type=Path, help="override the calibration model directory (hashes must still match)")
+    parser.add_argument("--output-dir", type=Path, default=REPO_ROOT / "target" / "benchmark_courtyard", help="fresh full-run output directory")
+    parser.add_argument("--summary-json", type=str, help="summary path; use '-' to print only to stdout (default writes target/.../summary.json)")
+    parser.add_argument("--force", action="store_true", help="remove only an existing --output-dir before a full run")
+    parser.add_argument("--no-build", action="store_true", help="full mode: do not run cargo build before mapping")
+    parser.add_argument("--colmap-control", choices=("validate", "run", "skip"), default="validate", help="validate the durable COLMAP model, run COLMAP, or skip the control")
+    parser.add_argument("--visuals", choices=("check", "regenerate", "skip"), default="check", help="check tracked README assets, regenerate into the full output, or skip")
+    parser.add_argument("--max-rmse-m", type=float, help="maximum accepted visloc centre RMSE in metres (default: manifest threshold)")
+    parser.add_argument(
+        "--candidate-strategy",
+        default="exhaustive",
+        help="named pre-match candidate schedule from the config (default: exhaustive)",
+    )
+    parser.add_argument(
+        "--candidate-manifest",
+        type=Path,
+        help="use an image-name-bound candidate manifest instead of generating candidates",
+    )
+    parser.add_argument(
+        "--write-candidate-manifest",
+        type=Path,
+        help="full mode: generate the selected pre-match schedule and atomically export its manifest before mapping",
+    )
+    parser.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="full mode: report a reduced schedule even when it does not register every reference image",
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    config_path = args.config.expanduser().resolve()
+    config = load_config(config_path)
+    root = resolve_artifact_root(config, args.artifact_root)
+    schedule = resolve_candidate_schedule(config, args.candidate_strategy)
+    configured_manifest = resolve_schedule_manifest(root, schedule)
+    cli_manifest = args.candidate_manifest.expanduser().resolve() if args.candidate_manifest is not None else None
+    if cli_manifest is not None and configured_manifest is not None and cli_manifest != configured_manifest[0]:
+        raise ValidationError("--candidate-manifest differs from the manifest configured by the candidate schedule")
+    selected_manifest = cli_manifest or (configured_manifest[0] if configured_manifest is not None else None)
+    selected_manifest_sha = configured_manifest[1] if configured_manifest is not None else None
+    # A CLI manifest is an explicit replay override.  In particular, the
+    # documented `--candidate-strategy exhaustive --candidate-manifest ...`
+    # form must not insist that the replayed file contain 703 pairs.
+    manifest_expected_pairs = schedule.get("candidate_count")
+    if cli_manifest is not None and schedule["strategy"] == "exhaustive":
+        manifest_expected_pairs = None
+    expected_max = config.get("expected", {}).get("max_rmse_m", config["models"]["visloc"].get("score_rmse_m", 0.01))
+    max_rmse_m = float(args.max_rmse_m if args.max_rmse_m is not None else expected_max)
+    if max_rmse_m <= 0:
+        raise ValidationError("--max-rmse-m must be positive")
+    full = bool(args.full)
+    if not full and (args.colmap_control == "run" or args.visuals == "regenerate"):
+        raise ValidationError("--colmap-control run and --visuals regenerate require --full")
+    if args.force and not full:
+        raise ValidationError("--force is only valid with --full")
+    if args.no_build and not full:
+        raise ValidationError("--no-build is only valid with --full")
+    if args.allow_incomplete and not full:
+        raise ValidationError("--allow-incomplete is only valid with --full")
+    if args.candidate_manifest is not None and args.write_candidate_manifest is not None:
+        raise ValidationError("--candidate-manifest and --write-candidate-manifest are mutually exclusive")
+    if args.write_candidate_manifest is not None and schedule["strategy"] == "manifest":
+        raise ValidationError("candidate strategy 'manifest' cannot generate a new candidate manifest")
+    if selected_manifest is None and schedule["strategy"] == "manifest":
+        raise ValidationError("candidate strategy 'manifest' requires --candidate-manifest or a configured manifest")
+    inputs = validate_inputs(
+        config,
+        root,
+        images_override=args.images_dir,
+        calibration_override=args.calibration_model,
+        max_rmse_m=max_rmse_m,
+        include_colmap=args.colmap_control != "skip",
+    )
+    candidate_manifest_summary: dict[str, Any] | None = None
+    if selected_manifest is not None and args.write_candidate_manifest is None:
+        candidate_manifest_summary = validate_candidate_manifest(
+            selected_manifest,
+            _expected_image_names(inputs["feature_names"], config["mapping"].get("image_suffix", ".JPG")),
+            manifest_expected_pairs,
+            selected_manifest_sha,
+        )
+    visual_summary: dict[str, Any] | None = None
+    if args.visuals == "check":
+        visual_summary = validate_visuals(REPO_ROOT, config["visuals"])
+    elif args.visuals == "skip":
+        visual_summary = {"status": "skipped"}
+
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "benchmark": config["benchmark"],
+        "config": {"path": str(config_path), "sha256": sha256_file(config_path)},
+        "mode": "full" if full else "verify-only",
+        "artifact_root": str(root),
+        "mapping": {"performed": False, "ground_truth_used": False, "reference_used_only_for_score": True},
+        "inputs": {key: value for key, value in inputs.items() if key not in {"calibration_dir", "matches_path", "features_dir"}},
+        "candidate_schedule": {key: value for key, value in schedule.items() if key != "name"},
+        "candidate_manifest": candidate_manifest_summary,
+        "future_scale": config.get("future_scale", {}),
+        "visuals": visual_summary,
+    }
+    if not full:
+        score = validate_score_file(root, config.get("expected", {}), config["models"]["visloc"], max_rmse_m)
+        summary["models"] = {"visloc": inputs["models"]["visloc"], "visloc_score": score}
+        if args.colmap_control == "skip":
+            summary["colmap_control"] = {"status": "skipped"}
+        else:
+            summary["colmap_control"] = {"status": "validated", "model": inputs["models"].get("colmap")}
+        return summary
+
+    output_dir = args.output_dir.expanduser().resolve()
+    _prepare_output(output_dir, args.force)
+    features_dir = Path(inputs["features_dir"])
+    images_dir = Path(inputs["images"]["directory"]) if inputs.get("images") else None
+    calibration_dir = Path(inputs["calibration_dir"]) if inputs.get("calibration_dir") else None
+    if calibration_dir is None:
+        raise ValidationError("full mode requires a calibration model")
+    binary = REPO_ROOT / "target" / "release" / "examples" / "unordered_sfm_demo"
+    if not args.no_build:
+        run_command(["cargo", "build", "--release", "--example", "unordered_sfm_demo", "--features", "image-io"], cwd=REPO_ROOT, log_path=output_dir / "cargo_build.log")
+    if not binary.is_file():
+        raise ValidationError(f"visloc example binary is missing: {binary}; remove --no-build or build it with --features image-io")
+    export_elapsed: float | None = None
+    if args.write_candidate_manifest is not None:
+        selected_manifest = args.write_candidate_manifest.expanduser().resolve()
+        if selected_manifest.exists() and not args.force:
+            raise ValidationError(
+                f"candidate manifest already exists: {selected_manifest}; choose a new path or pass --force"
+            )
+        export_command = build_mapping_command(
+            config,
+            binary=binary,
+            features_dir=features_dir,
+            images_dir=images_dir,
+            calibration_dir=calibration_dir,
+            matches_path=Path(inputs["matches_path"]),
+            output_model=output_dir / "candidate_export_unused",
+            candidate_schedule=schedule,
+            include_match_import=False,
+        )
+        export_command.extend(["--export-candidate-manifest", str(selected_manifest)])
+        export_elapsed = run_command(
+            export_command,
+            cwd=REPO_ROOT,
+            log_path=output_dir / "candidate_manifest.log",
+            env={"RAYON_NUM_THREADS": str(config.get("runtime", {}).get("rayon_threads", "1"))},
+        )
+        candidate_manifest_summary = validate_candidate_manifest(
+            selected_manifest,
+            _expected_image_names(inputs["feature_names"], config["mapping"].get("image_suffix", ".JPG")),
+            manifest_expected_pairs,
+        )
+        summary["candidate_manifest"] = {
+            **candidate_manifest_summary,
+            "generated": True,
+            "generation_command": export_command,
+            "generation_elapsed_s": export_elapsed,
+        }
+    output_model = output_dir / "visloc_model"
+    mapping_command = build_mapping_command(
+        config,
+        binary=binary,
+        features_dir=features_dir,
+        images_dir=images_dir,
+        calibration_dir=calibration_dir,
+        matches_path=Path(inputs["matches_path"]),
+        output_model=output_model,
+        candidate_schedule=schedule,
+        candidate_manifest=selected_manifest,
+    )
+    mapping_elapsed = run_command(
+        mapping_command,
+        cwd=REPO_ROOT,
+        log_path=output_dir / "visloc_mapper.log",
+        env={"RAYON_NUM_THREADS": str(config.get("runtime", {}).get("rayon_threads", "1"))},
+    )
+    diagnostics = parse_mapping_log(output_dir / "visloc_mapper.log")
+    expected_candidates = manifest_expected_pairs
+    if expected_candidates is not None and diagnostics["candidate_pairs"] != expected_candidates:
+        raise ValidationError(
+            f"candidate schedule {schedule['name']!r} produced {diagnostics['candidate_pairs']} pairs, "
+            f"manifest expects {expected_candidates}"
+        )
+    expected_registered = config["models"]["visloc"].get("registered")
+    generated = validate_model(
+        root,
+        {"path": str(output_model), "registered": None if args.allow_incomplete else expected_registered},
+        "generated visloc",
+        expected_files=False,
+    )
+    score: dict[str, Any] | None
+    score_error: str | None = None
+    try:
+        score = score_model(output_model, calibration_dir)
+    except ValidationError as exc:
+        if not args.allow_incomplete:
+            raise
+        score = None
+        score_error = str(exc)
+    if score is None:
+        gate_reasons = [score_error or "model could not be scored"]
+    else:
+        gate_reasons: list[str] = []
+        if score["registered"] != expected_registered or score["common"] != expected_registered:
+            gate_reasons.append(
+                f"registered/common={score['registered']}/{score['common']} expected {expected_registered}/{expected_registered}"
+            )
+        if score["rmse_m"] > max_rmse_m:
+            gate_reasons.append(f"centre RMSE {score['rmse_m']:.6f} m exceeds {max_rmse_m:.6f} m")
+    gate_passed = not gate_reasons
+    if not gate_passed and not args.allow_incomplete:
+        raise ValidationError("candidate schedule failed benchmark gate: " + "; ".join(gate_reasons))
+    summary["mapping"] = {
+        "performed": True,
+        "ground_truth_used": False,
+        "reference_used_only_for_score": True,
+        "matching_mode": "imported raw matches; local matching was not recomputed",
+        "command": mapping_command,
+        "elapsed_s": mapping_elapsed,
+        "candidate_generation_elapsed_s": export_elapsed,
+        "diagnostics": diagnostics,
+        "model": generated,
+        "score": score,
+        "gate_passed": gate_passed,
+        "gate_reasons": gate_reasons,
+    }
+    if args.colmap_control == "skip":
+        summary["colmap_control"] = {"status": "skipped"}
+    elif args.colmap_control == "validate":
+        summary["colmap_control"] = {"status": "validated", "model": inputs["models"].get("colmap")}
+    else:
+        if images_dir is None:
+            raise ValidationError("--colmap-control run requires --images-dir or inputs.images.directory")
+        summary["colmap_control"] = run_colmap_control(config, root, images_dir, output_dir, calibration_dir)
+    if args.visuals == "regenerate":
+        summary["visuals"] = regenerate_visuals(config, root, output_dir, calibration_dir)
+    summary["output_dir"] = str(output_dir)
+    return summary
+
+
+def _summary_path_for_failure(args: argparse.Namespace) -> Path | None:
+    if args.summary_json == "-":
+        return None
+    try:
+        return default_summary_path(args)
+    except (AttributeError, TypeError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = make_parser()
+    args = parser.parse_args(argv)
+    try:
+        summary = run(args)
+        rendered = json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        if args.summary_json == "-":
+            print(rendered, end="")
+        else:
+            path = default_summary_path(args)
+            _write_json(path, summary)
+            print(rendered, end="")
+            print(f"summary: {path}", file=sys.stderr)
+        return 0
+    except ValidationError as exc:
+        failure = {"schema_version": 1, "status": "failed", "error": str(exc)}
+        path = _summary_path_for_failure(args)
+        if path is not None:
+            try:
+                _write_json(path, failure)
+            except ValidationError:
+                pass
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark_courtyard.sh
+++ b/scripts/benchmark_courtyard.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# One-command entry point for the externally stored courtyard control.
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec python3 "$script_dir/benchmark_courtyard.py" "$@"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -17,6 +17,7 @@ if [ -z "${PYTHON:-}" ]; then
 fi
 
 cargo fmt --all -- --check
+sh -n scripts/benchmark_courtyard.sh
 sh scripts/check_msrv.sh
 sh scripts/check_feature_matrix.sh
 cargo clippy --workspace --all-targets -- -D warnings

--- a/tests/test_benchmark_courtyard.py
+++ b/tests/test_benchmark_courtyard.py
@@ -1,0 +1,257 @@
+"""Focused, dependency-free tests for the courtyard benchmark runner."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_courtyard", ROOT / "scripts" / "benchmark_courtyard.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(benchmark)
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class CourtyardBenchmarkTests(unittest.TestCase):
+    def test_manifest_rejects_duplicate_and_traversal_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            duplicate = root / "duplicate.tsv"
+            duplicate.write_text(
+                "a_features.txt 1 " + "0" * 64 + "\n"
+                "a_features.txt 1 " + "0" * 64 + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(benchmark.ValidationError, "repeats"):
+                benchmark.parse_feature_manifest(duplicate)
+
+            traversal = root / "traversal.tsv"
+            traversal.write_text("../outside.txt 1 " + "0" * 64 + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "simple relative path"):
+                benchmark.parse_feature_manifest(traversal)
+
+    def test_feature_hash_and_row_mismatch_are_actionable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            features = root / "features"
+            features.mkdir()
+            feature = features / "a_features.txt"
+            feature.write_text("0 0\n1 1\n", encoding="utf-8")
+            manifest = features / "MANIFEST.tsv"
+            manifest.write_text(f"a_features.txt 2 {digest(feature)}\n", encoding="utf-8")
+            names, stats = benchmark.validate_features(
+                root,
+                {
+                    "manifest": {
+                        "path": "features/MANIFEST.tsv",
+                        "sha256": digest(manifest),
+                    },
+                    "file_count": 1,
+                    "total_rows": 2,
+                },
+            )
+            self.assertEqual(names, ["a"])
+            self.assertEqual(stats["total_rows"], 2)
+
+            feature.write_text("changed\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_features(
+                    root,
+                    {
+                        "manifest": {
+                            "path": "features/MANIFEST.tsv",
+                            "sha256": digest(manifest),
+                        },
+                        "file_count": 1,
+                        "total_rows": 2,
+                    },
+                )
+
+    def test_raw_match_parser_checks_indices_and_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            matches = root / "matches.txt"
+            matches.write_text("2\na.JPG\nb.JPG\n1\n0 1 1\n0 1\n", encoding="utf-8")
+            spec = {
+                "sha256": digest(matches),
+                "pair_count": 1,
+                "raw_match_count": 1,
+                "candidate_semantics": "all unordered pairs",
+            }
+            result = benchmark.validate_matches(matches, spec, ["a", "b"], ".JPG", {0: 2, 1: 2})
+            self.assertEqual(result["pair_count"], 1)
+            self.assertEqual(result["raw_match_count"], 1)
+
+            matches.write_text("2\na.JPG\nb.JPG\n1\n0 1 1\n2 1\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "outside"):
+                benchmark.validate_matches(
+                    matches,
+                    {**spec, "sha256": digest(matches)},
+                    ["a", "b"],
+                    ".JPG",
+                    {0: 2, 1: 2},
+                )
+
+    def test_candidate_manifest_round_trip_and_structural_rejections(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "candidates.txt"
+            manifest.write_text(
+                "visloc_candidate_manifest_v1\n"
+                "images 3\n"
+                "image 0 a.JPG\n"
+                "image 1 b.JPG\n"
+                "image 2 c.JPG\n"
+                "pairs 2\n"
+                "pair 0 2\n"
+                "pair 1 2\n",
+                encoding="utf-8",
+            )
+            parsed = benchmark.parse_candidate_manifest(manifest, ["a.JPG", "b.JPG", "c.JPG"])
+            self.assertEqual(parsed["pair_count"], 2)
+            self.assertEqual(parsed["pairs"], [(0, 2), (1, 2)])
+            self.assertEqual(benchmark.validate_candidate_manifest(manifest, ["a.JPG", "b.JPG", "c.JPG"], 2)["sha256"], digest(manifest))
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_candidate_manifest(
+                    manifest,
+                    ["a.JPG", "b.JPG", "c.JPG"],
+                    expected_sha256="0" * 64,
+                )
+
+            duplicate = root / "duplicate.txt"
+            duplicate.write_text(manifest.read_text(encoding="utf-8").replace("pair 1 2", "pair 0 2"), encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "repeats"):
+                benchmark.parse_candidate_manifest(duplicate, ["a.JPG", "b.JPG", "c.JPG"])
+
+            reversed_pair = root / "reversed.txt"
+            reversed_pair.write_text(manifest.read_text(encoding="utf-8").replace("pair 0 2", "pair 2 0"), encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "0 <= I < J"):
+                benchmark.parse_candidate_manifest(reversed_pair, ["a.JPG", "b.JPG", "c.JPG"])
+
+    def test_candidate_schedule_validation_and_mapping_command(self) -> None:
+        config = benchmark.load_config(ROOT / "benchmarks" / "courtyard" / "exhaustive_control.json")
+        schedule = benchmark.resolve_candidate_schedule(config, "local-vlad-union-3-8-200")
+        command = benchmark.build_mapping_command(
+            config,
+            binary=Path("/bin/visloc-demo"),
+            features_dir=Path("/external/features"),
+            images_dir=Path("/external/images"),
+            calibration_dir=Path("/external/calibration"),
+            matches_path=Path("/external/matches_import.txt"),
+            output_model=Path("/external/out"),
+            candidate_schedule=schedule,
+        )
+        self.assertIn("--pair-source", command)
+        self.assertIn("vlad-union", command)
+        self.assertIn("--local-stem-window", command)
+        self.assertIn("--candidate-budget", command)
+        self.assertNotIn("--exhaustive", command)
+        replay = benchmark.build_mapping_command(
+            config,
+            binary=Path("/bin/visloc-demo"),
+            features_dir=Path("/external/features"),
+            images_dir=Path("/external/images"),
+            calibration_dir=Path("/external/calibration"),
+            matches_path=Path("/external/matches_import.txt"),
+            output_model=Path("/external/out"),
+            candidate_manifest=Path("/external/candidates.txt"),
+        )
+        self.assertIn("--candidate-manifest", replay)
+        self.assertNotIn("--exhaustive", replay)
+        with self.assertRaisesRegex(benchmark.ValidationError, "unsupported strategy"):
+            benchmark.resolve_candidate_schedule(config, "not-a-schedule")
+        bad_config = {**config, "candidate_schedules": {"bad": {"strategy": "vlad"}}}
+        with self.assertRaisesRegex(benchmark.ValidationError, "retrieval_topk"):
+            benchmark.resolve_candidate_schedule(bad_config, "bad")
+
+    def test_mapping_log_parser_extracts_candidate_and_result_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mapper.log"
+            path.write_text(
+                "view graph: 200 candidate pairs (local stem + VLAD union)\n"
+                "verified 172 / 200 pairs, 199871 inlier correspondences\n"
+                "reconstruction (track-source=union-find): 38 / 38 images registered, 45016 tracks, mean reproj 0.537 px\n"
+                "wrote COLMAP model to /tmp/model (38 images, 45016 points, 148192 observations)\n"
+                "elapsed=57.35 maxrss=1068548\n",
+                encoding="utf-8",
+            )
+            parsed = benchmark.parse_mapping_log(path)
+            self.assertEqual(parsed["candidate_pairs"], 200)
+            self.assertEqual(parsed["verified_pairs"], 172)
+            self.assertEqual(parsed["inlier_correspondences"], 199871)
+            self.assertEqual(parsed["registered"], 38)
+            self.assertEqual(parsed["tracks"], 45016)
+            self.assertAlmostEqual(parsed["reprojection_px"], 0.537)
+            self.assertEqual(parsed["written_model"]["observations"], 148192)
+            self.assertAlmostEqual(parsed["process_elapsed_s"], 57.35)
+            self.assertEqual(parsed["peak_rss_kb"], 1068548)
+
+    def test_score_threshold_and_hash_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            score = root / "score.txt"
+            score.write_text(
+                "matched=38/38 est_registered=38\n"
+                "sim3_scale=1.0\n"
+                "rmse_m=0.020000 rmse_cm=2.00\n",
+                encoding="utf-8",
+            )
+            model_spec = {
+                "registered": 38,
+                "score_file": {"path": "score.txt", "sha256": digest(score)},
+                "score_rmse_m": 0.020000,
+            }
+            with self.assertRaisesRegex(benchmark.ValidationError, "exceeds threshold"):
+                benchmark.validate_score_file(root, {}, model_spec, 0.01)
+
+            score.write_text(score.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_score_file(root, {}, model_spec, 0.1)
+
+    def test_visual_asset_parser_and_config_schema(self) -> None:
+        width, height = benchmark._png_dimensions(ROOT / "docs" / "assets" / "courtyard_sfm_comparison.png")
+        self.assertEqual((width, height), (1458, 883))
+        width, height, frames = benchmark._gif_dimensions_and_frames(ROOT / "docs" / "assets" / "courtyard_sfm_comparison.gif")
+        self.assertEqual((width, height, frames), (772, 432, 24))
+        config = benchmark.load_config(ROOT / "benchmarks" / "courtyard" / "exhaustive_control.json")
+        self.assertEqual(config["benchmark"]["id"], "courtyard-colmap-exhaustive-v1")
+        self.assertEqual(config["expected"]["max_rmse_m"], 0.01)
+
+    def test_mapping_command_contains_only_mapping_inputs(self) -> None:
+        config = benchmark.load_config(ROOT / "benchmarks" / "courtyard" / "exhaustive_control.json")
+        command = benchmark.build_mapping_command(
+            config,
+            binary=Path("/bin/visloc-demo"),
+            features_dir=Path("/external/features"),
+            images_dir=Path("/external/images"),
+            calibration_dir=Path("/external/calibration"),
+            matches_path=Path("/external/matches_import.txt"),
+            output_model=Path("/external/out"),
+        )
+        self.assertIn("--import-matches-file", command)
+        self.assertIn("--input-colmap-calibration", command)
+        self.assertIn("--next-image-policy", command)
+        self.assertNotIn("--gt", command)
+        self.assertNotIn("points3D.txt", command)
+
+    def test_config_rejects_unknown_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.json"
+            path.write_text(json.dumps({"schema_version": 99}), encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "unsupported"):
+                benchmark.load_config(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a hash-checked, deterministic Courtyard benchmark entry point with verify-only/full modes, explicit artifact/image/calibration overrides, JSON summaries, candidate manifests, and a lightweight parser/hash test suite.
- Add the M2 Office high-density SIFT result and Auto/post quality guard while preserving the library Count default and verified-pair snapshot replay semantics.
- Add the M3 bounded pre-match candidate scheduler: 200/703 proposed pairs, 38/38 registration, 0.66 cm centre RMSE (exhaustive control remains 703/703 at 0.5379 cm).
- Add the M4 large-scale unordered-SfM validation plan with official dataset/licensing/resource caveats; it is planning-only and does not download data.
- Put a prominent README “Run the SfM demo” quickstart beside the courtyard comparison, including the in-process SIFT command and Courtyard verify/full commands with explicit overrides.

## Measured results

- Courtyard exhaustive official high-resolution SIFT control: visloc 38/38, 0.5379 cm centre RMSE, 43,852 tracks / 152,432 observations, 0.579 px; official COLMAP control 38/38, 1.6166 cm, 38,422 points / 169,590 observations.
- Courtyard reduced candidate schedule: 200/703 pairs, 38/38, 0.66 cm.
- Office high-density diagnostic: visloc 26/26, 0.34 cm versus official COLMAP 26/26, 0.50 cm. The frozen lower-density cache remains documented separately.
- The README and benchmark docs keep external datasets/models out of git and label historical-cache comparisons as caveats.

## Validation

- `cargo fmt --all -- --check`
- `sh scripts/check.sh`
- `sh scripts/check_docs_links.sh`
- `python3 -m unittest discover -s tests -p 'test_*.py'` (253 passed, 8 skipped)
- `cargo test --release --example unordered_sfm_demo --features image-io diagnose_cli_tests -- --nocapture` (28 passed)
- `scripts/benchmark_courtyard.sh --help`
- `scripts/benchmark_courtyard.sh --verify-only --artifact-root ... --images-dir ... --calibration-model ... --colmap-control validate --visuals check` (durable artifact validated; 38/38 and 0.005379 m)
- One-image SIFT CLI smoke parsed the README flags and stopped at the expected “need ≥2 images” guard.
- `git diff --check`

Hosted CI intentionally does not run the licensed, external Courtyard artifact; the self-hosted/full command is documented. The Windows-only gate was not run locally.
