### PR TITLE
feat(benchmark): add resumable electro controls

### DIFF
--- a/benchmarks/electro/colmap_1200_v1.json
+++ b/benchmarks/electro/colmap_1200_v1.json
@@ -1,0 +1,71 @@
+{
+  "schema": "visloc_electro_colmap_control_config_v1",
+  "benchmark": {
+    "id": "eth3d-electro-colmap-candidate-12000-v1",
+    "scene": "electro",
+    "description": "Official COLMAP CPU-SIFT control using exactly the frozen 12000-pair visloc candidate list."
+  },
+  "protocol": {
+    "image_count": 1200,
+    "camera_count": 4,
+    "candidate_budget": 12000,
+    "candidate_policy": "temporal-pyramid-v1",
+    "candidate_source": "validated candidates/index.json; no reference poses or points",
+    "pair_schedule": "matches_importer match_type=pairs; one pair per line; candidate order preserved",
+    "ground_truth_used_for_selection_or_mapping": false
+  },
+  "colmap": {
+    "version": "3.9.1",
+    "feature_extractor": {
+      "algorithm": "SIFT",
+      "use_gpu": false,
+      "threads": 8,
+      "max_num_features": 2048,
+      "max_image_size": 5000,
+      "first_octave": -1,
+      "peak_threshold": 0.0066666667,
+      "max_num_orientations": 2,
+      "camera_model": "PINHOLE",
+      "intrinsics": "official undistorted cameras.txt, one feature_extractor invocation per camera"
+    },
+    "matching": {
+      "command": "matches_importer",
+      "match_type": "pairs",
+      "use_gpu": false,
+      "threads": 8,
+      "max_ratio": 0.8,
+      "cross_check": true,
+      "min_num_inliers": 8,
+      "max_error_px": 4.0,
+      "multiple_models": true
+    },
+    "mapper": {
+      "command": "mapper",
+      "multiple_models": false,
+      "min_model_size": 10,
+      "threads": 8,
+      "abs_pose_min_num_inliers": 8,
+      "ba_refine_focal_length": false,
+      "ba_refine_principal_point": false,
+      "ba_refine_extra_params": false
+    }
+  },
+  "timing": {
+    "wrapper": "/usr/bin/time -v",
+    "phase_files": [
+      "timing/feature_cam4.time.txt",
+      "timing/feature_cam5.time.txt",
+      "timing/feature_cam6.time.txt",
+      "timing/feature_cam7.time.txt",
+      "timing/matches_importer.time.txt",
+      "timing/mapper.time.txt"
+    ],
+    "comparison_rule": "sum the four feature phases; compare exact pair matching and mapper phases separately"
+  },
+  "scoring": {
+    "command": "scripts/score_electro_model.py",
+    "reference_role": "post-mapping score only",
+    "metrics": ["registered", "common", "sim3_scale", "rmse_m", "median_m", "p95_m", "max_m", "relative_rmse"],
+    "name_key": "(camera number, numeric timestamp)"
+  }
+}

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -1,0 +1,1069 @@
+#!/usr/bin/env python3
+"""Prepare and run a resumable ETH3D ``electro`` unordered-SfM benchmark.
+
+The runner keeps the expensive local matching stage in deterministic,
+image-name-bound candidate shards.  Each shard is written atomically and is
+considered complete only when its SHA-256 validates.  Matching workers emit
+the existing binary verified-pair snapshot format; the small Rust merge helper
+combines disjoint snapshots before one mapper invocation.  Ground truth and
+reference poses are intentionally absent from every candidate/mapping command;
+they can be used by a separate post-mapping scoring step.
+
+The default mode is ``--verify-only``.  ``--prepare`` creates candidate shards,
+``--match`` runs or resumes workers and merges them, ``--map`` runs the mapper,
+and ``--run`` performs all three stages.  The module is dependency-free so
+manifest checks can run on a fresh machine before Rust, NumPy, or COLMAP are
+installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_MAGIC = "visloc_candidate_manifest_v1"
+CANDIDATE_INDEX_SCHEMA = "visloc_electro_candidate_shards_v1"
+MATCH_INDEX_SCHEMA = "visloc_electro_match_shards_v1"
+FEATURE_MANIFEST_SCHEMA = "visloc_electro_feature_manifest_v1"
+SHA256_RE = set("0123456789abcdef")
+
+
+class ValidationError(RuntimeError):
+    """An electro input or resumable artifact failed validation."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ValidationError(f"cannot read {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def _sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or len(value) != 64:
+        raise ValidationError(f"{label} must be a 64-character SHA-256")
+    lowered = value.lower()
+    if any(char not in SHA256_RE for char in lowered):
+        raise ValidationError(f"{label} must be a hexadecimal SHA-256")
+    return lowered
+
+
+def _safe_relative(value: str, label: str) -> Path:
+    path = Path(value)
+    if path.is_absolute() or not value or any(part in ("", ".", "..") for part in path.parts):
+        raise ValidationError(f"{label} must be a simple relative path: {value!r}")
+    return path
+
+
+def _atomic_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.parent / f".{path.name}.tmp-{os.getpid()}"
+    try:
+        with temporary.open("wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise ValidationError(f"cannot atomically install {path}: {exc}") from exc
+
+
+def atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    _atomic_bytes(path, (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode())
+
+
+def _noncomment_lines(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read {path}: {exc}") from exc
+    return [line.strip() for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def parse_candidate_manifest(path: Path) -> tuple[list[str], list[tuple[int, int]]]:
+    """Parse the Rust demo's image-name-bound candidate manifest."""
+
+    names, pairs, _ = parse_candidate_manifest_with_metadata(path)
+    return names, pairs
+
+
+def parse_candidate_manifest_with_metadata(
+    path: Path,
+) -> tuple[list[str], list[tuple[int, int]], dict[str, str]]:
+    """Parse a candidate manifest and its optional deterministic policy block."""
+
+    lines = _noncomment_lines(path)
+    cursor = 0
+
+    def next_line(label: str) -> str:
+        nonlocal cursor
+        if cursor >= len(lines):
+            raise ValidationError(f"candidate manifest {path} is truncated while reading {label}")
+        value = lines[cursor]
+        cursor += 1
+        return value
+
+    if next_line("header") != CANDIDATE_MAGIC:
+        raise ValidationError(f"candidate manifest {path} has unsupported header")
+    image_header = next_line("image count").split()
+    if len(image_header) != 2 or image_header[0] != "images":
+        raise ValidationError(f"candidate manifest {path} image count must be images N")
+    try:
+        image_count = int(image_header[1])
+    except ValueError as exc:
+        raise ValidationError(f"candidate manifest {path} image count is not numeric") from exc
+    if image_count < 2:
+        raise ValidationError(f"candidate manifest {path} must contain at least two images")
+    names: list[str] = []
+    for expected in range(image_count):
+        fields = next_line("image entry").split(maxsplit=2)
+        if len(fields) != 3 or fields[0] != "image":
+            raise ValidationError(f"candidate manifest {path} image entry must be image INDEX NAME")
+        try:
+            index = int(fields[1])
+        except ValueError as exc:
+            raise ValidationError(f"candidate manifest {path} image index is not numeric") from exc
+        if index != expected or not fields[2] or any(char.isspace() for char in fields[2]):
+            raise ValidationError(f"candidate manifest {path} image entry {expected} is invalid")
+        names.append(fields[2])
+    metadata: dict[str, str] = {}
+    while cursor < len(lines) and lines[cursor].split(maxsplit=1)[0] == "metadata":
+        fields = lines[cursor].split()
+        if len(fields) != 3 or not fields[1] or not fields[2]:
+            raise ValidationError(
+                f"candidate manifest {path} metadata must be metadata KEY VALUE"
+            )
+        if fields[1] in metadata:
+            raise ValidationError(f"candidate manifest {path} repeats metadata key {fields[1]!r}")
+        metadata[fields[1]] = fields[2]
+        cursor += 1
+    pair_header = next_line("pair count").split()
+    if len(pair_header) != 2 or pair_header[0] != "pairs":
+        raise ValidationError(f"candidate manifest {path} pair count must be pairs N")
+    try:
+        pair_count = int(pair_header[1])
+    except ValueError as exc:
+        raise ValidationError(f"candidate manifest {path} pair count is not numeric") from exc
+    if pair_count < 0:
+        raise ValidationError(f"candidate manifest {path} has a negative pair count")
+    pairs: list[tuple[int, int]] = []
+    seen: set[tuple[int, int]] = set()
+    for pair_number in range(pair_count):
+        fields = next_line("pair entry").split()
+        if len(fields) != 3 or fields[0] != "pair":
+            raise ValidationError(f"candidate manifest {path} pair {pair_number} must be pair I J")
+        try:
+            first, second = int(fields[1]), int(fields[2])
+        except ValueError as exc:
+            raise ValidationError(f"candidate manifest {path} pair {pair_number} is not numeric") from exc
+        if not (0 <= first < second < image_count):
+            raise ValidationError(
+                f"candidate manifest {path} pair {pair_number} must satisfy 0 <= I < J < {image_count}"
+            )
+        pair = (first, second)
+        if pair in seen:
+            raise ValidationError(f"candidate manifest {path} repeats pair {pair}")
+        seen.add(pair)
+        pairs.append(pair)
+    if cursor != len(lines):
+        raise ValidationError(f"candidate manifest {path} has unexpected trailing data")
+    return names, pairs, metadata
+
+
+def write_candidate_manifest(
+    path: Path,
+    image_names: list[str],
+    pairs: Iterable[tuple[int, int]],
+    *,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    """Atomically write one canonical candidate manifest."""
+
+    pairs = list(pairs)
+    if len(image_names) < 2:
+        raise ValidationError("candidate manifest requires at least two images")
+    lines = [CANDIDATE_MAGIC, f"images {len(image_names)}"]
+    for index, name in enumerate(image_names):
+        if not name or any(char.isspace() for char in name):
+            raise ValidationError(f"candidate image name {name!r} cannot contain whitespace")
+        lines.append(f"image {index} {name}")
+    for key, value in sorted((metadata or {}).items()):
+        if not key or not value or any(char.isspace() for char in key) or any(char.isspace() for char in value):
+            raise ValidationError(f"candidate metadata must use whitespace-free KEY VALUE: {key!r}={value!r}")
+        lines.append(f"metadata {key} {value}")
+    lines.append(f"pairs {len(pairs)}")
+    seen: set[tuple[int, int]] = set()
+    for pair in pairs:
+        if len(pair) != 2:
+            raise ValidationError(f"candidate pair must contain two indices: {pair!r}")
+        first, second = pair
+        if not (0 <= first < second < len(image_names)):
+            raise ValidationError(f"candidate pair {pair!r} is outside canonical image order")
+        if pair in seen:
+            raise ValidationError(f"candidate pair {pair!r} is duplicated")
+        seen.add(pair)
+        lines.append(f"pair {first} {second}")
+    _atomic_bytes(path, ("\n".join(lines) + "\n").encode())
+
+
+def _relative_artifact(path: Path, root: Path, label: str) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError as exc:
+        raise ValidationError(f"{label} {path} must be under {root}") from exc
+
+
+def split_candidate_manifest(
+    source: Path,
+    output_dir: Path,
+    pairs_per_shard: int,
+    *,
+    resume: bool = True,
+    retrieval_topk: int | None = None,
+    local_stem_window: int | None = None,
+    candidate_budget: int | None = None,
+    local_grouping: str | None = None,
+    pair_source: str | None = None,
+    temporal_pyramid_max_offset: int | None = None,
+) -> dict[str, Any]:
+    """Create deterministic candidate shards and an image-bound index.
+
+    Existing shards are reused only after their full hash and parsed contents
+    match the expected contiguous range.  A malformed existing shard is
+    replaced with an atomic write, never accepted by size alone.
+    """
+
+    if pairs_per_shard <= 0:
+        raise ValidationError("pairs_per_shard must be positive")
+    source = source.resolve()
+    names, pairs, metadata = parse_candidate_manifest_with_metadata(source)
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_hash = sha256_file(source)
+    shards: list[dict[str, Any]] = []
+    for shard_number, start in enumerate(range(0, len(pairs), pairs_per_shard)):
+        end = min(start + pairs_per_shard, len(pairs))
+        path = output_dir / f"candidate-{shard_number:06d}.txt"
+        expected_pairs = pairs[start:end]
+        reusable = False
+        if resume and path.is_file():
+            try:
+                existing_names, existing_pairs, existing_metadata = parse_candidate_manifest_with_metadata(path)
+                reusable = (
+                    existing_names == names
+                    and existing_pairs == expected_pairs
+                    and existing_metadata == metadata
+                )
+                if reusable:
+                    # A successful parse is not enough: the index records and
+                    # later resume checks rely on this exact digest.
+                    sha256_file(path)
+            except ValidationError:
+                reusable = False
+        if not reusable:
+            write_candidate_manifest(path, names, expected_pairs, metadata=metadata)
+        digest = sha256_file(path)
+        shards.append(
+            {
+                "id": shard_number,
+                "path": path.name,
+                "start": start,
+                "end": end,
+                "pair_count": end - start,
+                "sha256": digest,
+                "status": "complete",
+            }
+        )
+    candidate_policy: dict[str, Any] = {
+        "retrieval_topk": retrieval_topk,
+        "local_stem_window": local_stem_window,
+        "candidate_budget": candidate_budget,
+    }
+    if pair_source is not None:
+        candidate_policy["pair_source"] = pair_source
+    if temporal_pyramid_max_offset is not None:
+        candidate_policy["temporal_pyramid_max_offset"] = temporal_pyramid_max_offset
+    if local_grouping is not None:
+        candidate_policy["local_grouping"] = local_grouping
+    index = {
+        "schema": CANDIDATE_INDEX_SCHEMA,
+        "source_manifest": str(source),
+        "source_manifest_sha256": source_hash,
+        "image_names": names,
+        "pair_count": len(pairs),
+        "pairs_per_shard": pairs_per_shard,
+        "candidate_policy": candidate_policy,
+        "candidate_manifest_metadata": metadata,
+        "shards": shards,
+    }
+    atomic_json(output_dir / "index.json", index)
+    return index
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot parse {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{label} {path} must contain a JSON object")
+    return value
+
+
+def validate_candidate_shards(index_path: Path) -> dict[str, Any]:
+    """Validate every candidate shard and its contiguous global coverage."""
+
+    index_path = index_path.resolve()
+    index = _load_json(index_path, "candidate index")
+    if index.get("schema") != CANDIDATE_INDEX_SCHEMA:
+        raise ValidationError(f"candidate index {index_path} has unsupported schema")
+    source_value = index.get("source_manifest")
+    if not isinstance(source_value, str) or not source_value:
+        raise ValidationError("candidate index source_manifest is missing")
+    source = Path(source_value).expanduser()
+    expected_source_hash = _sha256(
+        index.get("source_manifest_sha256"), "candidate source manifest hash"
+    )
+    actual_source_hash = sha256_file(source)
+    if actual_source_hash != expected_source_hash:
+        raise ValidationError(
+            f"candidate source manifest hash mismatch: expected {expected_source_hash}, got {actual_source_hash}"
+        )
+    names = index.get("image_names")
+    if not isinstance(names, list) or len(names) < 2 or any(not isinstance(name, str) for name in names):
+        raise ValidationError("candidate index image_names must be a non-empty string list")
+    pair_count = index.get("pair_count")
+    if not isinstance(pair_count, int) or pair_count < 0:
+        raise ValidationError("candidate index pair_count must be a non-negative integer")
+    policy = index.get("candidate_policy")
+    if policy is not None:
+        if not isinstance(policy, dict):
+            raise ValidationError("candidate index candidate_policy must be an object")
+        for key in (
+            "retrieval_topk",
+            "local_stem_window",
+            "candidate_budget",
+            "temporal_pyramid_max_offset",
+        ):
+            value = policy.get(key)
+            if value is not None and (not isinstance(value, int) or value <= 0):
+                raise ValidationError(f"candidate index candidate_policy {key} must be positive")
+        pair_source = policy.get("pair_source")
+        if pair_source is not None and pair_source not in {
+            "vlad",
+            "vlad-mutual",
+            "vlad-union",
+            "temporal-pyramid",
+            "vocab-tree",
+            "transitive",
+        }:
+            raise ValidationError(
+                f"candidate index candidate_policy pair_source is unsupported: {pair_source!r}"
+            )
+        grouping = policy.get("local_grouping")
+        if grouping is not None and grouping not in {
+            "numeric-stem-v1",
+            "rig-prefix-timestamp-v1",
+        }:
+            raise ValidationError(f"candidate index candidate_policy local_grouping is unsupported: {grouping!r}")
+    metadata = index.get("candidate_manifest_metadata", {})
+    if not isinstance(metadata, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in metadata.items()
+    ):
+        raise ValidationError("candidate index candidate_manifest_metadata must map strings to strings")
+    shards = index.get("shards")
+    if not isinstance(shards, list):
+        raise ValidationError("candidate index shards must be a list")
+    cursor = 0
+    seen: set[tuple[int, int]] = set()
+    for expected_id, shard in enumerate(shards):
+        if not isinstance(shard, dict):
+            raise ValidationError(f"candidate shard {expected_id} must be an object")
+        if shard.get("id") != expected_id:
+            raise ValidationError(f"candidate shards are not ordered at {expected_id}")
+        relative = shard.get("path")
+        if not isinstance(relative, str):
+            raise ValidationError(f"candidate shard {expected_id} path is missing")
+        path = index_path.parent / _safe_relative(relative, f"candidate shard {expected_id} path")
+        expected_hash = _sha256(shard.get("sha256"), f"candidate shard {expected_id} hash")
+        actual_hash = sha256_file(path)
+        if actual_hash != expected_hash:
+            raise ValidationError(
+                f"candidate shard {expected_id} hash mismatch: expected {expected_hash}, got {actual_hash}"
+            )
+        shard_names, shard_pairs, shard_metadata = parse_candidate_manifest_with_metadata(path)
+        if shard_names != names:
+            raise ValidationError(f"candidate shard {expected_id} image order differs from index")
+        if shard_metadata != metadata:
+            raise ValidationError(f"candidate shard {expected_id} metadata differs from index")
+        start, end = shard.get("start"), shard.get("end")
+        if not isinstance(start, int) or not isinstance(end, int) or start != cursor or end < start:
+            raise ValidationError(f"candidate shard {expected_id} has a non-contiguous range")
+        if shard.get("pair_count") != end - start or len(shard_pairs) != end - start:
+            raise ValidationError(f"candidate shard {expected_id} pair count/range disagrees")
+        for pair in shard_pairs:
+            if pair in seen:
+                raise ValidationError(f"candidate shards repeat pair {pair}")
+            seen.add(pair)
+        cursor = end
+    if cursor != pair_count or len(seen) != pair_count:
+        raise ValidationError(
+            f"candidate shards cover {cursor} pairs but index declares {pair_count}"
+        )
+    return {
+        "index": index,
+        "index_sha256": sha256_file(index_path),
+        "image_names": names,
+        "pair_count": pair_count,
+        "candidate_manifest_metadata": metadata,
+        "shards": shards,
+    }
+
+
+def feature_manifest(
+    features_dir: Path,
+    *,
+    feature_suffix: str = "_features.txt",
+    source_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Build a compact hash manifest for a flat external-feature directory."""
+
+    files = sorted(
+        path for path in features_dir.iterdir() if path.is_file() and path.name.endswith(feature_suffix)
+    )
+    if not files:
+        raise ValidationError(f"no {feature_suffix!r} files found in {features_dir}")
+    images = []
+    for path in files:
+        try:
+            with path.open(encoding="utf-8") as stream:
+                rows = sum(1 for line in stream if line.strip() and not line.lstrip().startswith("#"))
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ValidationError(f"cannot inspect feature file {path}: {exc}") from exc
+        entry: dict[str, Any] = {
+            "name": path.name[: -len(feature_suffix)] + ".png",
+            "feature": path.name,
+            "rows": rows,
+            "sha256": sha256_file(path),
+        }
+        if source_dir is not None:
+            source = source_dir / entry["name"]
+            if not source.is_file():
+                raise ValidationError(f"source image for {entry['name']} is missing: {source}")
+            entry["source_sha256"] = sha256_file(source)
+        images.append(entry)
+    return {
+        "schema": FEATURE_MANIFEST_SCHEMA,
+        "feature_suffix": feature_suffix,
+        "image_count": len(images),
+        "image_names": [entry["name"] for entry in images],
+        "images": images,
+    }
+
+
+def write_feature_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    if manifest.get("schema") != FEATURE_MANIFEST_SCHEMA:
+        raise ValidationError("feature manifest has unsupported schema")
+    atomic_json(path, manifest)
+
+
+def validate_feature_manifest(
+    path: Path, features_dir: Path, *, source_dir: Path | None = None
+) -> dict[str, Any]:
+    manifest = _load_json(path, "feature manifest")
+    if manifest.get("schema") != FEATURE_MANIFEST_SCHEMA:
+        raise ValidationError(f"feature manifest {path} has unsupported schema")
+    suffix = manifest.get("feature_suffix")
+    images = manifest.get("images")
+    if not isinstance(suffix, str) or not isinstance(images, list) or not images:
+        raise ValidationError(f"feature manifest {path} has invalid image entries")
+    if manifest.get("image_count") != len(images):
+        raise ValidationError(f"feature manifest {path} image_count disagrees")
+    seen: set[str] = set()
+    total_rows = 0
+    for entry in images:
+        if not isinstance(entry, dict) or not isinstance(entry.get("feature"), str):
+            raise ValidationError(f"feature manifest {path} has a malformed image entry")
+        filename = entry["feature"]
+        if filename in seen:
+            raise ValidationError(f"feature manifest {path} repeats {filename}")
+        seen.add(filename)
+        feature_path = features_dir / _safe_relative(filename, "feature manifest path")
+        expected = _sha256(entry.get("sha256"), f"feature {filename} hash")
+        actual = sha256_file(feature_path)
+        if actual != expected:
+            raise ValidationError(f"feature {filename} hash mismatch: expected {expected}, got {actual}")
+        try:
+            with feature_path.open(encoding="utf-8") as stream:
+                rows = sum(1 for line in stream if line.strip() and not line.lstrip().startswith("#"))
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ValidationError(f"cannot inspect feature file {feature_path}: {exc}") from exc
+        if rows != entry.get("rows"):
+            raise ValidationError(f"feature {filename} row count mismatch: expected {entry.get('rows')}, got {rows}")
+        if source_dir is not None:
+            source_name = entry.get("name")
+            if not isinstance(source_name, str):
+                raise ValidationError(f"feature manifest {path} image name is missing")
+            source_path = source_dir / _safe_relative(source_name, "feature source image path")
+            if not source_path.is_file():
+                raise ValidationError(f"source image is missing: {source_path}")
+            expected_source = _sha256(entry.get("source_sha256"), f"source image {source_name} hash")
+            actual_source = sha256_file(source_path)
+            if actual_source != expected_source:
+                raise ValidationError(
+                    f"source image {source_name} hash mismatch: expected {expected_source}, got {actual_source}"
+                )
+        total_rows += rows
+    return {
+        "image_count": len(images),
+        "image_names": [entry.get("name") for entry in images],
+        "total_rows": total_rows,
+        "sha256": sha256_file(path),
+    }
+
+
+def _run_command(command: list[str], log_path: Path, *, cwd: Path = REPO_ROOT) -> float:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    print(f"$ {shlex.join(command)}", file=sys.stderr)
+    try:
+        with log_path.open("w", encoding="utf-8") as log:
+            result = subprocess.run(command, cwd=cwd, stdout=log, stderr=subprocess.STDOUT, check=False)
+    except OSError as exc:
+        raise ValidationError(f"cannot execute {command[0]}: {exc}") from exc
+    if result.returncode != 0:
+        tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-30:]
+        raise ValidationError(f"command failed ({result.returncode}): {shlex.join(command)}\n" + "\n".join(tail))
+    return time.monotonic() - started
+
+
+def build_candidate_command(
+    binary: Path,
+    *,
+    features_dir: Path,
+    calibration_dir: Path,
+    candidate_manifest: Path,
+    feature_suffix: str = "_features.txt",
+    image_suffix: str = ".png",
+    images_dir: Path | None = None,
+    retrieval_topk: int = 32,
+    local_stem_window: int = 3,
+    candidate_budget: int | None = None,
+    rig_local_grouping: bool = False,
+    pair_source: str = "vlad-union",
+    temporal_pyramid_max_offset: int = 32,
+) -> list[str]:
+    """Build the GT-free command that generates one candidate manifest."""
+
+    if pair_source not in {"vlad-union", "temporal-pyramid"}:
+        raise ValidationError(
+            f"electro candidate runner supports vlad-union or temporal-pyramid, got {pair_source!r}"
+        )
+    if temporal_pyramid_max_offset <= 0:
+        raise ValidationError("temporal_pyramid_max_offset must be positive")
+
+    command = [
+        str(binary),
+        "--feature-extractor",
+        "files",
+        "--features-dir",
+        str(features_dir),
+        "--feature-suffix",
+        feature_suffix,
+        "--image-suffix",
+        image_suffix,
+        "--input-colmap-calibration",
+        str(calibration_dir),
+        "--pair-source",
+        pair_source,
+        "--retrieval-topk",
+        str(retrieval_topk),
+        "--export-candidate-manifest",
+        str(candidate_manifest),
+        # The demo parser keeps --out-colmap mandatory for all modes, even
+        # though candidate export exits before a model is written.
+        "--out-colmap",
+        str(candidate_manifest.parent / f"unused-model-{candidate_manifest.stem}"),
+    ]
+    if images_dir is not None:
+        command.extend(["--images-dir", str(images_dir)])
+    if pair_source == "vlad-union":
+        command.extend(["--local-stem-window", str(local_stem_window)])
+    if pair_source == "vlad-union" and rig_local_grouping:
+        command.append("--rig-local-grouping")
+    if pair_source == "temporal-pyramid":
+        command.extend(["--temporal-pyramid-max-offset", str(temporal_pyramid_max_offset)])
+    if candidate_budget is not None:
+        command.extend(["--candidate-budget", str(candidate_budget)])
+    return command
+
+
+def build_match_command(
+    binary: Path,
+    *,
+    features_dir: Path,
+    calibration_dir: Path,
+    candidate_shard: Path,
+    snapshot: Path,
+    feature_suffix: str = "_features.txt",
+    image_suffix: str = ".png",
+    images_dir: Path | None = None,
+    min_matches: int = 30,
+    match_ratio: float = 0.8,
+    max_mapper_matches_per_pair: int | None = None,
+) -> list[str]:
+    """Build one bounded, export-only matcher/verifier worker command."""
+
+    command = [
+        str(binary),
+        "--feature-extractor",
+        "files",
+        "--features-dir",
+        str(features_dir),
+        "--feature-suffix",
+        feature_suffix,
+        "--image-suffix",
+        image_suffix,
+        "--input-colmap-calibration",
+        str(calibration_dir),
+        "--candidate-manifest",
+        str(candidate_shard),
+        "--min-matches",
+        str(min_matches),
+        "--match-ratio",
+        str(match_ratio),
+        "--verification-mode",
+        "full",
+        "--export-verified-pairs-snapshot",
+        str(snapshot),
+        "--export-verified-pairs-only",
+        "--out-colmap",
+        str(snapshot.parent / f"unused-model-{snapshot.stem}"),
+    ]
+    if images_dir is not None:
+        command.extend(["--images-dir", str(images_dir)])
+    # Validate the optional cap for callers that pass one through a shared
+    # configuration, but deliberately do not put it on worker commands:
+    # snapshots are lossless and the final mapper owns the explicit resource
+    # guard.
+    if max_mapper_matches_per_pair is not None:
+        if max_mapper_matches_per_pair <= 0:
+            raise ValidationError("max_mapper_matches_per_pair must be positive")
+    return command
+
+
+def build_mapping_command(
+    binary: Path,
+    *,
+    features_dir: Path,
+    calibration_dir: Path,
+    merged_snapshot: Path,
+    output_model: Path,
+    feature_suffix: str = "_features.txt",
+    image_suffix: str = ".png",
+    images_dir: Path | None = None,
+    min_pnp_inliers: int = 12,
+    max_mapper_matches_per_pair: int | None = None,
+    final_ba: bool = True,
+) -> list[str]:
+    command = [
+        str(binary),
+        "--feature-extractor",
+        "files",
+        "--features-dir",
+        str(features_dir),
+        "--feature-suffix",
+        feature_suffix,
+        "--image-suffix",
+        image_suffix,
+        "--input-colmap-calibration",
+        str(calibration_dir),
+        "--import-verified-pairs-snapshot",
+        str(merged_snapshot),
+        "--verification-mode",
+        "full",
+        "--mapper",
+        "incremental",
+        "--min-pnp-inliers",
+        str(min_pnp_inliers),
+        "--out-colmap",
+        str(output_model),
+    ]
+    if images_dir is not None:
+        command.extend(["--images-dir", str(images_dir)])
+    if max_mapper_matches_per_pair is not None:
+        if max_mapper_matches_per_pair <= 0:
+            raise ValidationError("max_mapper_matches_per_pair must be positive")
+        command.extend(["--max-mapper-matches-per-pair", str(max_mapper_matches_per_pair)])
+    if not final_ba:
+        command.append("--no-final-ba")
+    return command
+
+
+def prepare_match_index(candidate_index_path: Path, output_dir: Path) -> dict[str, Any]:
+    candidate = validate_candidate_shards(candidate_index_path)
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shards = []
+    for shard in candidate["shards"]:
+        shards.append(
+            {
+                "id": shard["id"],
+                "candidate_path": shard["path"],
+                "candidate_sha256": shard["sha256"],
+                "snapshot_path": f"verified-{shard['id']:06d}.vps",
+                "status": "pending",
+            }
+        )
+    index = {
+        "schema": MATCH_INDEX_SCHEMA,
+        "candidate_index_sha256": candidate["index_sha256"],
+        "image_names": candidate["image_names"],
+        "pair_count": candidate["pair_count"],
+        "shards": shards,
+    }
+    atomic_json(output_dir / "index.json", index)
+    return index
+
+
+def validate_match_index(index_path: Path, candidate_index_path: Path) -> dict[str, Any]:
+    candidate = validate_candidate_shards(candidate_index_path)
+    index_path = index_path.resolve()
+    index = _load_json(index_path, "match index")
+    if index.get("schema") != MATCH_INDEX_SCHEMA:
+        raise ValidationError(f"match index {index_path} has unsupported schema")
+    if index.get("candidate_index_sha256") != candidate["index_sha256"]:
+        raise ValidationError("match index candidate index hash differs; regenerate the match plan")
+    if index.get("image_names") != candidate["image_names"] or index.get("pair_count") != candidate["pair_count"]:
+        raise ValidationError("match index image/pair envelope differs from candidate index")
+    shards = index.get("shards")
+    if not isinstance(shards, list) or len(shards) != len(candidate["shards"]):
+        raise ValidationError("match index shard list does not match candidate index")
+    for expected_id, (entry, candidate_entry) in enumerate(zip(shards, candidate["shards"])):
+        if not isinstance(entry, dict) or entry.get("id") != expected_id:
+            raise ValidationError(f"match index shard {expected_id} is malformed")
+        if entry.get("candidate_path") != candidate_entry["path"] or entry.get("candidate_sha256") != candidate_entry["sha256"]:
+            raise ValidationError(f"match index shard {expected_id} candidate binding differs")
+        status = entry.get("status")
+        if status not in {"pending", "running", "complete", "failed"}:
+            raise ValidationError(f"match index shard {expected_id} has invalid status {status!r}")
+        if status == "complete":
+            snapshot_path = index_path.parent / _safe_relative(entry.get("snapshot_path", ""), f"match shard {expected_id} snapshot path")
+            expected_hash = _sha256(entry.get("snapshot_sha256"), f"match shard {expected_id} snapshot hash")
+            actual_hash = sha256_file(snapshot_path)
+            if actual_hash != expected_hash:
+                raise ValidationError(f"match shard {expected_id} snapshot hash mismatch")
+    return {"index": index, "index_sha256": sha256_file(index_path), "candidate": candidate}
+
+
+def run_match_shards(
+    candidate_index_path: Path,
+    match_index_path: Path,
+    *,
+    binary: Path,
+    features_dir: Path,
+    calibration_dir: Path,
+    images_dir: Path | None = None,
+    feature_suffix: str = "_features.txt",
+    image_suffix: str = ".png",
+    min_matches: int = 30,
+    match_ratio: float = 0.8,
+    resume: bool = True,
+) -> dict[str, Any]:
+    """Run pending match shards, updating the index only after hash checks."""
+
+    plan = validate_match_index(match_index_path, candidate_index_path)
+    index = plan["index"]
+    root = match_index_path.resolve().parent
+    for entry in index["shards"]:
+        shard_id = entry["id"]
+        snapshot_path = root / _safe_relative(entry["snapshot_path"], f"match shard {shard_id} snapshot path")
+        if entry["status"] == "complete":
+            if resume:
+                continue
+            raise ValidationError(f"match shard {shard_id} is already complete; pass --resume")
+        candidate_path = candidate_index_path.resolve().parent / _safe_relative(entry["candidate_path"], f"candidate shard {shard_id} path")
+        entry["status"] = "running"
+        atomic_json(match_index_path, index)
+        command = build_match_command(
+            binary,
+            features_dir=features_dir,
+            calibration_dir=calibration_dir,
+            candidate_shard=candidate_path,
+            snapshot=snapshot_path,
+            feature_suffix=feature_suffix,
+            image_suffix=image_suffix,
+            images_dir=images_dir,
+            min_matches=min_matches,
+            match_ratio=match_ratio,
+        )
+        try:
+            elapsed = _run_command(command, root / f"match-{shard_id:06d}.log")
+            digest = sha256_file(snapshot_path)
+        except (ValidationError, OSError):
+            entry["status"] = "failed"
+            atomic_json(match_index_path, index)
+            raise
+        entry.update({"status": "complete", "snapshot_sha256": digest, "elapsed_s": elapsed})
+        atomic_json(match_index_path, index)
+    validated = validate_match_index(match_index_path, candidate_index_path)
+    complete = [entry for entry in validated["index"]["shards"] if entry["status"] == "complete"]
+    if len(complete) != len(validated["index"]["shards"]):
+        raise ValidationError("match stage ended with incomplete shards")
+    return validated
+
+
+def build_merge_command(merge_binary: Path, output: Path, snapshots: list[Path]) -> list[str]:
+    if not snapshots:
+        raise ValidationError("cannot merge an empty snapshot list")
+    command = [str(merge_binary), "--output", str(output)]
+    for snapshot in snapshots:
+        command.extend(["--snapshot", str(snapshot)])
+    return command
+
+
+def merge_match_shards(match_index_path: Path, *, merge_binary: Path, output: Path) -> dict[str, Any]:
+    index = _load_json(match_index_path, "match index")
+    if index.get("schema") != MATCH_INDEX_SCHEMA:
+        raise ValidationError("match index has unsupported schema")
+    root = match_index_path.resolve().parent
+    snapshots = []
+    for entry in index.get("shards", []):
+        if not isinstance(entry, dict) or entry.get("status") != "complete":
+            raise ValidationError("cannot merge while a match shard is incomplete")
+        path = root / _safe_relative(entry.get("snapshot_path", ""), "match snapshot path")
+        expected = _sha256(entry.get("snapshot_sha256"), "match snapshot hash")
+        if sha256_file(path) != expected:
+            raise ValidationError(f"match snapshot hash mismatch: {path}")
+        snapshots.append(path)
+    elapsed = _run_command(build_merge_command(merge_binary, output, snapshots), root / "merge.log")
+    return {"output": str(output), "sha256": sha256_file(output), "shards": len(snapshots), "elapsed_s": elapsed}
+
+
+def _binary(path: str | None, default: Path) -> Path:
+    value = Path(path).expanduser() if path else default
+    if not value.is_file():
+        raise ValidationError(f"executable is missing: {value}; build it first or pass an override")
+    return value.resolve()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--verify-only", action="store_true", help="validate existing manifests/artifacts (default)")
+    mode.add_argument("--prepare", action="store_true", help="generate and shard the candidate manifest")
+    mode.add_argument("--match", action="store_true", help="run/resume match shards and merge snapshots")
+    mode.add_argument("--map", action="store_true", help="map an existing merged snapshot")
+    mode.add_argument("--run", action="store_true", help="prepare, match, merge, and map")
+    parser.add_argument("--features-dir", type=Path, required=True)
+    parser.add_argument("--images-dir", type=Path)
+    parser.add_argument("--calibration-dir", type=Path, required=True)
+    parser.add_argument("--artifact-root", type=Path, required=True, help="external run root")
+    parser.add_argument("--candidate-manifest", type=Path, help="existing generated candidate manifest")
+    parser.add_argument("--feature-manifest", type=Path)
+    parser.add_argument("--pairs-per-shard", type=int, default=256)
+    parser.add_argument("--retrieval-topk", type=int, default=32)
+    parser.add_argument(
+        "--pair-source",
+        choices=("vlad-union", "temporal-pyramid"),
+        default="vlad-union",
+        help="candidate policy (temporal-pyramid is rig-aware and uses VLAD only as budget fill)",
+    )
+    parser.add_argument("--local-stem-window", type=int, default=3)
+    parser.add_argument(
+        "--rig-local-grouping",
+        action="store_true",
+        help="use camera-prefix/timestamp local edges plus same-timestamp rig edges",
+    )
+    parser.add_argument("--temporal-pyramid-max-offset", type=int, default=32)
+    parser.add_argument("--candidate-budget", type=int)
+    parser.add_argument("--feature-suffix", default="_features.txt")
+    parser.add_argument("--image-suffix", default=".png")
+    parser.add_argument("--min-matches", type=int, default=30)
+    parser.add_argument("--match-ratio", type=float, default=0.8)
+    parser.add_argument("--min-pnp-inliers", type=int, default=12)
+    parser.add_argument("--max-mapper-matches-per-pair", type=int)
+    parser.add_argument(
+        "--no-final-ba",
+        action="store_true",
+        help="skip the mapper's final bundle adjustment (for a phase-isolated baseline)",
+    )
+    parser.add_argument("--binary")
+    parser.add_argument("--merge-binary")
+    parser.add_argument("--resume", action="store_true", default=False)
+    parser.add_argument("--no-resume", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    mode = "verify" if args.verify_only or not any((args.prepare, args.match, args.map, args.run)) else next(name for name, value in (("prepare", args.prepare), ("match", args.match), ("map", args.map), ("run", args.run)) if value)
+    try:
+        artifact_root = args.artifact_root.expanduser().resolve()
+        if mode == "verify":
+            if not artifact_root.is_dir():
+                raise ValidationError(f"artifact root is missing: {artifact_root}")
+        else:
+            artifact_root.mkdir(parents=True, exist_ok=True)
+        features_dir = args.features_dir.expanduser().resolve()
+        calibration_dir = args.calibration_dir.expanduser().resolve()
+        if not features_dir.is_dir():
+            raise ValidationError(f"features directory is missing: {features_dir}")
+        if not calibration_dir.is_dir():
+            raise ValidationError(f"calibration directory is missing: {calibration_dir}")
+        feature_manifest_path = (args.feature_manifest or artifact_root / "features.json").resolve()
+        if feature_manifest_path.is_file():
+            feature_summary = validate_feature_manifest(
+                feature_manifest_path, features_dir, source_dir=args.images_dir
+            )
+        else:
+            if mode == "verify":
+                raise ValidationError(f"feature manifest is missing: {feature_manifest_path}")
+            feature_summary = feature_manifest(features_dir, feature_suffix=args.feature_suffix, source_dir=args.images_dir)
+            write_feature_manifest(feature_manifest_path, feature_summary)
+        candidate_source = args.candidate_manifest
+        if candidate_source is None:
+            candidate_source = artifact_root / "candidates.txt"
+        candidate_source = candidate_source.expanduser().resolve()
+        binary = None
+        merge_binary = None
+        if mode in {"prepare", "match", "map", "run"}:
+            binary = _binary(args.binary, REPO_ROOT / "target" / "release" / "examples" / "unordered_sfm_demo")
+        if mode in {"match", "run"}:
+            merge_binary = _binary(args.merge_binary, REPO_ROOT / "target" / "release" / "examples" / "merge_verified_pair_snapshots")
+        candidate_dir = artifact_root / "candidates"
+        candidate_index_path = candidate_dir / "index.json"
+        if mode in {"prepare", "run"}:
+            if not candidate_source.is_file():
+                candidate_source.parent.mkdir(parents=True, exist_ok=True)
+                _run_command(
+                    build_candidate_command(
+                        binary,
+                        features_dir=features_dir,
+                        calibration_dir=calibration_dir,
+                        candidate_manifest=candidate_source,
+                        feature_suffix=args.feature_suffix,
+                        image_suffix=args.image_suffix,
+                        images_dir=args.images_dir,
+                        retrieval_topk=args.retrieval_topk,
+                        local_stem_window=args.local_stem_window,
+                        candidate_budget=args.candidate_budget,
+                        rig_local_grouping=args.rig_local_grouping,
+                        pair_source=args.pair_source,
+                        temporal_pyramid_max_offset=args.temporal_pyramid_max_offset,
+                    ),
+                    artifact_root / "candidate-generation.log",
+                )
+            split_candidate_manifest(
+                candidate_source,
+                candidate_dir,
+                args.pairs_per_shard,
+                resume=not args.no_resume,
+                retrieval_topk=args.retrieval_topk,
+                local_stem_window=(
+                    args.local_stem_window if args.pair_source == "vlad-union" else None
+                ),
+                candidate_budget=args.candidate_budget,
+                pair_source=args.pair_source,
+                temporal_pyramid_max_offset=(
+                    args.temporal_pyramid_max_offset
+                    if args.pair_source == "temporal-pyramid"
+                    else None
+                ),
+                local_grouping=(
+                    "rig-prefix-timestamp-v1"
+                    if args.rig_local_grouping or args.pair_source == "temporal-pyramid"
+                    else None
+                ),
+            )
+        if mode in {"verify", "match", "map"} and not candidate_index_path.is_file():
+            raise ValidationError(f"candidate index is missing: {candidate_index_path}; run --prepare first")
+        candidate_summary = validate_candidate_shards(candidate_index_path)
+        feature_names = feature_summary.get("image_names")
+        if feature_names != candidate_summary["image_names"]:
+            raise ValidationError(
+                "candidate image order differs from the validated feature manifest"
+            )
+        match_dir = artifact_root / "matches"
+        match_index_path = match_dir / "index.json"
+        if mode in {"match", "run"}:
+            if not match_index_path.is_file() or args.no_resume:
+                prepare_match_index(candidate_index_path, match_dir)
+            run_match_shards(
+                candidate_index_path,
+                match_index_path,
+                binary=binary,
+                features_dir=features_dir,
+                calibration_dir=calibration_dir,
+                images_dir=args.images_dir,
+                feature_suffix=args.feature_suffix,
+                image_suffix=args.image_suffix,
+                min_matches=args.min_matches,
+                match_ratio=args.match_ratio,
+                resume=not args.no_resume,
+            )
+            merged_snapshot = artifact_root / "mapping" / "verified-merged.vps"
+            merge_match_shards(match_index_path, merge_binary=merge_binary, output=merged_snapshot)
+        else:
+            merged_snapshot = artifact_root / "mapping" / "verified-merged.vps"
+        if mode in {"map", "run"}:
+            if not merged_snapshot.is_file():
+                raise ValidationError(f"merged snapshot is missing: {merged_snapshot}; run --match first")
+            output_model = artifact_root / "mapping" / "colmap"
+            _run_command(
+                build_mapping_command(
+                    binary,
+                    features_dir=features_dir,
+                    calibration_dir=calibration_dir,
+                    merged_snapshot=merged_snapshot,
+                    output_model=output_model,
+                    feature_suffix=args.feature_suffix,
+                    image_suffix=args.image_suffix,
+                    images_dir=args.images_dir,
+                    min_pnp_inliers=args.min_pnp_inliers,
+                    max_mapper_matches_per_pair=args.max_mapper_matches_per_pair,
+                    final_ba=not args.no_final_ba,
+                ),
+                artifact_root / "mapping.log",
+            )
+        summary = {
+            "schema": "visloc_electro_run_summary_v1",
+            "mode": mode,
+            "features": feature_summary,
+            "candidate_index": str(candidate_index_path),
+            "candidate_index_sha256": sha256_file(candidate_index_path),
+            "candidate_pairs": candidate_summary["pair_count"],
+            "match_index": str(match_index_path) if match_index_path.is_file() else None,
+            "merged_snapshot": str(merged_snapshot) if merged_snapshot.is_file() else None,
+            "merged_snapshot_sha256": sha256_file(merged_snapshot) if merged_snapshot.is_file() else None,
+            "ground_truth_used_for_selection_or_mapping": False,
+        }
+        atomic_json(artifact_root / "summary.json", summary)
+        print(json.dumps(summary, sort_keys=True, indent=2))
+        return 0
+    except ValidationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_electro.sh
+++ b/scripts/benchmark_electro.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# Thin shell entry point for the dependency-free electro benchmark runner.
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec python3 "$script_dir/benchmark_electro.py" "$@"

--- a/scripts/benchmark_electro_colmap.py
+++ b/scripts/benchmark_electro_colmap.py
@@ -1,0 +1,897 @@
+#!/usr/bin/env python3
+"""Prepare and run an official COLMAP control for ETH3D ``electro``.
+
+The control uses COLMAP's own CPU SIFT extractor and ``matches_importer``
+with ``match_type=pairs``.  The latter is important: it makes COLMAP compute
+and geometrically verify exactly the image pairs from the visloc candidate
+manifest rather than silently switching to an exhaustive or vocabulary-tree
+pair schedule.  The four camera folders are extracted separately so each
+folder receives its official PINHOLE intrinsics, while the stored COLMAP
+image names remain the flat ``camN_timestamp.png`` names used by visloc.
+
+``--prepare`` is read-only with respect to the dataset and writes only a
+small external plan, pair list, and hashes.  ``--run`` is intentionally an
+explicit opt-in because feature extraction, matching, and mapping are CPU
+heavy.  Every phase is wrapped in ``/usr/bin/time -v`` and gets its own log
+and resource file, so the result is comparable with the visloc phase logs.
+The reference model is accepted only by the separate scoring script; it is
+never present in a feature, match, or mapper command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = SCRIPT_DIR.parent / "benchmarks" / "electro" / "colmap_1200_v1.json"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from benchmark_electro import (  # noqa: E402
+    ValidationError,
+    parse_candidate_manifest_with_metadata,
+    sha256_file,
+    validate_candidate_shards,
+)
+
+
+PLAN_SCHEMA = "visloc_electro_colmap_control_plan_v1"
+CONFIG_SCHEMA = "visloc_electro_colmap_control_config_v1"
+CAMERA_PREFIX_RE = re.compile(r"^cam(?P<camera>[0-9]+)_(?P<timestamp>[0-9]+)\.(?P<suffix>[^.]+)$")
+TIME_RSS_RE = re.compile(r"^\s*Maximum resident set size \(kbytes\):\s*([0-9]+)\s*$", re.MULTILINE)
+TIME_WALL_RE = re.compile(
+    r"^\s*Elapsed \(wall clock\) time \(h:mm:ss or m:ss\):\s*([0-9:.]+)\s*$",
+    re.MULTILINE,
+)
+TIME_USER_RE = re.compile(r"^\s*User time \(seconds\):\s*([0-9.eE+-]+)\s*$", re.MULTILINE)
+TIME_SYSTEM_RE = re.compile(r"^\s*System time \(seconds\):\s*([0-9.eE+-]+)\s*$", re.MULTILINE)
+
+
+def _atomic_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.parent / f".{path.name}.tmp-{os.getpid()}"
+    try:
+        with temporary.open("wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise ValidationError(f"cannot atomically install {path}: {exc}") from exc
+
+
+def atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    _atomic_bytes(path, (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode())
+
+
+def _safe_relative(value: str, label: str) -> Path:
+    path = Path(value)
+    if path.is_absolute() or not value or any(part in ("", ".", "..") for part in path.parts):
+        raise ValidationError(f"{label} must be a simple relative path: {value!r}")
+    return path
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot parse {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{label} {path} must contain a JSON object")
+    return value
+
+
+def parse_pinhole_cameras(path: Path) -> dict[int, dict[str, Any]]:
+    """Read official COLMAP PINHOLE camera rows keyed by CAMERA_ID."""
+
+    cameras: dict[int, dict[str, Any]] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read calibration cameras {path}: {exc}") from exc
+    for line_number, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        if len(fields) < 8:
+            raise ValidationError(f"calibration cameras {path}:{line_number} is malformed")
+        try:
+            camera_id = int(fields[0])
+            width, height = int(fields[2]), int(fields[3])
+            params = [float(value) for value in fields[4:]]
+        except ValueError as exc:
+            raise ValidationError(f"calibration cameras {path}:{line_number} is not numeric") from exc
+        if fields[1] != "PINHOLE" or len(params) != 4:
+            raise ValidationError(
+                f"calibration cameras {path}:{line_number} must be PINHOLE with four parameters"
+            )
+        if camera_id in cameras:
+            raise ValidationError(f"calibration cameras repeats CAMERA_ID {camera_id}")
+        cameras[camera_id] = {
+            "id": camera_id,
+            "model": fields[1],
+            "width": width,
+            "height": height,
+            "params": params,
+        }
+    if not cameras:
+        raise ValidationError(f"calibration cameras has no camera rows: {path}")
+    return cameras
+
+
+def parse_image_camera_assignments(path: Path) -> dict[str, int]:
+    """Read the image-to-camera assignments from a COLMAP text model."""
+
+    assignments: dict[str, int] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read calibration images {path}: {exc}") from exc
+    for line_number, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        # An images.txt pose row has IMAGE_ID, qvec, tvec, CAMERA_ID, NAME.
+        if len(fields) < 10:
+            continue
+        try:
+            int(fields[0])
+            camera_id = int(fields[8])
+            float(fields[1])
+            float(fields[2])
+            float(fields[3])
+            float(fields[4])
+            float(fields[5])
+            float(fields[6])
+            float(fields[7])
+        except ValueError:
+            continue
+        name = fields[9]
+        if name in assignments and assignments[name] != camera_id:
+            raise ValidationError(f"calibration image {name!r} has conflicting camera assignments")
+        assignments[name] = camera_id
+    if not assignments:
+        raise ValidationError(f"calibration images has no pose rows: {path}")
+    return assignments
+
+
+def _camera_for_flat_name(name: str, assignments: dict[str, int]) -> int | None:
+    """Resolve a flat camN_timestamp name to its calibration CAMERA_ID."""
+
+    if name in assignments:
+        return assignments[name]
+    match = CAMERA_PREFIX_RE.fullmatch(name)
+    if match is None:
+        return None
+    camera = int(match.group("camera"))
+    # The staging calibration uses flat names, but accepting the official
+    # basename here makes the helper useful with a source calibration model.
+    official = f"images_rig_cam{camera}_undistorted/{match.group('timestamp')}.{match.group('suffix')}"
+    return assignments.get(official)
+
+
+def _format_params(params: Iterable[float]) -> str:
+    return ",".join(format(value, ".17g") for value in params)
+
+
+def _candidate_source_from_index(candidate_index: Path) -> tuple[Path, dict[str, Any]]:
+    candidate = validate_candidate_shards(candidate_index)
+    source_value = candidate["index"].get("source_manifest")
+    if not isinstance(source_value, str) or not source_value:
+        raise ValidationError("candidate index source_manifest is missing")
+    source = Path(source_value).expanduser().resolve()
+    if not source.is_file():
+        raise ValidationError(f"candidate source manifest is missing: {source}")
+    names, pairs, _ = parse_candidate_manifest_with_metadata(source)
+    if names != candidate["image_names"] or len(pairs) != candidate["pair_count"]:
+        raise ValidationError("candidate source does not match its validated shard index")
+    # Validate the ordered pair stream against the index, not just its count.
+    indexed_pairs: list[tuple[int, int]] = []
+    for shard in candidate["shards"]:
+        shard_path = candidate_index.parent / _safe_relative(shard["path"], "candidate shard path")
+        shard_names, shard_pairs, _ = parse_candidate_manifest_with_metadata(shard_path)
+        if shard_names != names:
+            raise ValidationError("candidate shard image order differs from source manifest")
+        indexed_pairs.extend(shard_pairs)
+    if indexed_pairs != pairs:
+        raise ValidationError("candidate shards do not preserve source pair order")
+    return source, candidate
+
+
+def _identity_aliases(names: list[str]) -> dict[str, str]:
+    return {name: name for name in names}
+
+
+def parse_alias_tsv(path: Path) -> dict[str, str]:
+    """Read ``flat_name<TAB>official_name[<TAB>camera_id]`` aliases."""
+
+    aliases: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read image alias map {path}: {exc}") from exc
+    for line_number, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if fields and fields[0] == "flat_name":
+            continue
+        if len(fields) < 2 or not fields[0] or not fields[1] or any(" " in value for value in fields[:2]):
+            raise ValidationError(f"image alias map {path}:{line_number} is malformed")
+        if fields[0] in aliases and aliases[fields[0]] != fields[1]:
+            raise ValidationError(f"image alias map repeats {fields[0]!r} with different targets")
+        aliases[fields[0]] = fields[1]
+    if not aliases:
+        raise ValidationError(f"image alias map has no entries: {path}")
+    return aliases
+
+
+def write_pair_list(
+    candidate_manifest: Path,
+    output: Path,
+    *,
+    aliases: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Write a deterministic COLMAP image-pair list bound to a candidate file."""
+
+    names, pairs, metadata = parse_candidate_manifest_with_metadata(candidate_manifest)
+    aliases = aliases or _identity_aliases(names)
+    mapped_names: list[str] = []
+    for name in names:
+        mapped = aliases.get(name)
+        if not mapped:
+            raise ValidationError(f"image alias map has no target for candidate image {name!r}")
+        if any(char.isspace() for char in mapped):
+            raise ValidationError(f"COLMAP image name cannot contain whitespace: {mapped!r}")
+        mapped_names.append(mapped)
+    if len(set(mapped_names)) != len(mapped_names):
+        raise ValidationError("candidate image aliases are not one-to-one")
+    lines = [f"{mapped_names[first]} {mapped_names[second]}" for first, second in pairs]
+    _atomic_bytes(output, ("\n".join(lines) + ("\n" if lines else "")).encode())
+    return {
+        "candidate_manifest": str(candidate_manifest.resolve()),
+        "candidate_manifest_sha256": sha256_file(candidate_manifest),
+        "candidate_metadata": metadata,
+        "image_count": len(names),
+        "pair_count": len(pairs),
+        "candidate_image_names": names,
+        "colmap_image_names": mapped_names,
+        "pair_list": str(output.resolve()),
+        "pair_list_sha256": sha256_file(output),
+    }
+
+
+def _image_dir_for_camera(camera_root: Path, camera_number: int) -> Path:
+    candidates = (
+        camera_root / f"cam{camera_number}" / "images",
+        camera_root / f"cam{camera_number}",
+    )
+    for path in candidates:
+        if path.is_dir():
+            return path.resolve()
+    raise ValidationError(
+        f"camera image directory for cam{camera_number} is missing under {camera_root}"
+    )
+
+
+def build_commands(
+    *,
+    colmap_binary: Path,
+    database: Path,
+    image_root: Path,
+    camera_root: Path,
+    cameras: dict[int, dict[str, Any]],
+    pair_list: Path,
+    output_model: Path,
+    threads: int = 8,
+    max_num_features: int = 2048,
+    max_image_size: int = 5000,
+    first_octave: int = -1,
+    peak_threshold: float = 0.0066666667,
+    max_num_orientations: int = 2,
+    max_ratio: float = 0.8,
+    cross_check: bool = True,
+    min_num_inliers: int = 8,
+    max_error: float = 4.0,
+) -> dict[str, Any]:
+    """Build per-camera feature, exact-pair matching, and mapper commands."""
+
+    if threads <= 0 or max_num_features <= 0 or min_num_inliers <= 0:
+        raise ValidationError("threads, max_num_features, and min_num_inliers must be positive")
+    feature: list[list[str]] = []
+    # Use physical camera number for a stable, human-readable phase order;
+    # official CAMERA_ID values are not guaranteed to be cam4, cam5, ...
+    for camera_id in sorted(cameras, key=lambda value: cameras[value]["camera_number"]):
+        camera = cameras[camera_id]
+        camera_number = camera.get("camera_number")
+        if not isinstance(camera_number, int):
+            raise ValidationError(f"camera {camera_id} is missing its camN mapping")
+        feature.append(
+            [
+                str(colmap_binary),
+                "feature_extractor",
+                "--database_path",
+                str(database),
+                "--image_path",
+                str(_image_dir_for_camera(camera_root, camera_number)),
+                "--ImageReader.camera_model",
+                "PINHOLE",
+                "--ImageReader.single_camera",
+                "1",
+                "--ImageReader.camera_params",
+                _format_params(camera["params"]),
+                "--SiftExtraction.use_gpu",
+                "0",
+                "--SiftExtraction.num_threads",
+                str(threads),
+                "--SiftExtraction.max_num_features",
+                str(max_num_features),
+                "--SiftExtraction.max_image_size",
+                str(max_image_size),
+                "--SiftExtraction.first_octave",
+                str(first_octave),
+                "--SiftExtraction.peak_threshold",
+                format(peak_threshold, ".17g"),
+                "--SiftExtraction.max_num_orientations",
+                str(max_num_orientations),
+            ]
+        )
+    match = [
+        str(colmap_binary),
+        "matches_importer",
+        "--database_path",
+        str(database),
+        "--match_list_path",
+        str(pair_list),
+        "--match_type",
+        "pairs",
+        "--SiftMatching.use_gpu",
+        "0",
+        "--SiftMatching.num_threads",
+        str(threads),
+        "--SiftMatching.max_ratio",
+        format(max_ratio, ".17g"),
+        "--SiftMatching.cross_check",
+        "1" if cross_check else "0",
+        "--TwoViewGeometry.min_num_inliers",
+        str(min_num_inliers),
+        "--TwoViewGeometry.max_error",
+        format(max_error, ".17g"),
+        "--TwoViewGeometry.multiple_models",
+        "1",
+    ]
+    mapper = [
+        str(colmap_binary),
+        "mapper",
+        "--image_path",
+        str(image_root),
+        "--database_path",
+        str(database),
+        "--output_path",
+        str(output_model),
+        "--Mapper.multiple_models",
+        "0",
+        "--Mapper.min_model_size",
+        "10",
+        "--Mapper.num_threads",
+        str(threads),
+        "--Mapper.abs_pose_min_num_inliers",
+        str(min_num_inliers),
+        "--Mapper.ba_refine_focal_length",
+        "0",
+        "--Mapper.ba_refine_principal_point",
+        "0",
+        "--Mapper.ba_refine_extra_params",
+        "0",
+    ]
+    return {"feature_extractor": feature, "matches_importer": match, "mapper": mapper}
+
+
+def _parse_time(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    text = path.read_text(encoding="utf-8", errors="replace")
+    result: dict[str, Any] = {}
+    rss = TIME_RSS_RE.search(text)
+    if rss:
+        result["max_rss_kb"] = int(rss.group(1))
+    wall = TIME_WALL_RE.search(text)
+    if wall:
+        fields = wall.group(1).split(":")
+        try:
+            if len(fields) == 3:
+                result["gnu_elapsed_s"] = float(fields[0]) * 3600 + float(fields[1]) * 60 + float(fields[2])
+            elif len(fields) == 2:
+                result["gnu_elapsed_s"] = float(fields[0]) * 60 + float(fields[1])
+            elif len(fields) == 1:
+                result["gnu_elapsed_s"] = float(fields[0])
+        except ValueError:
+            pass
+    for key, pattern in (("user_s", TIME_USER_RE), ("system_s", TIME_SYSTEM_RE)):
+        match = pattern.search(text)
+        if match:
+            try:
+                result[key] = float(match.group(1))
+            except ValueError:
+                pass
+    return result
+
+
+def run_timed(
+    command: list[str],
+    log_path: Path,
+    time_path: Path,
+    *,
+    cwd: Path | None = None,
+    environment: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run one phase and return wall time plus GNU-time measurements."""
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    time_path.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    environment_value = None
+    if environment:
+        environment_value = os.environ.copy()
+        environment_value.update(environment)
+    with log_path.open("w", encoding="utf-8") as stream:
+        completed = subprocess.run(
+            ["/usr/bin/time", "-v", "-o", str(time_path), *command],
+            cwd=str(cwd) if cwd else None,
+            env=environment_value,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    elapsed = time.monotonic() - started
+    result = {"elapsed_s": elapsed, "returncode": completed.returncode}
+    result.update(_parse_time(time_path))
+    if completed.returncode != 0:
+        raise ValidationError(
+            f"COLMAP phase failed ({completed.returncode}); inspect {log_path}"
+        )
+    return result
+
+
+def _validate_plan_artifacts(plan: dict[str, Any], plan_path: Path) -> None:
+    """Reject a moved or tampered plan before starting any CPU-heavy phase."""
+
+    root = plan_path.resolve().parent
+    colmap = plan.get("colmap")
+    if not isinstance(colmap, dict):
+        raise ValidationError("COLMAP control plan has no COLMAP binding")
+    binary_value = colmap.get("binary")
+    binary_hash = colmap.get("binary_sha256")
+    if not isinstance(binary_value, str) or not isinstance(binary_hash, str):
+        raise ValidationError("COLMAP binary binding is incomplete")
+    binary = Path(binary_value).expanduser().resolve()
+    if not binary.is_file() or sha256_file(binary) != binary_hash:
+        raise ValidationError("COLMAP binary hash mismatch; regenerate the control plan")
+    protocol_config = plan.get("protocol_config")
+    if not isinstance(protocol_config, dict):
+        raise ValidationError("COLMAP control plan has no protocol config binding")
+    config_value = protocol_config.get("path")
+    config_hash = protocol_config.get("sha256")
+    if not isinstance(config_value, str) or not isinstance(config_hash, str):
+        raise ValidationError("COLMAP protocol config binding is incomplete")
+    config_path = Path(config_value).expanduser().resolve()
+    if not config_path.is_file() or sha256_file(config_path) != config_hash:
+        raise ValidationError("COLMAP protocol config hash mismatch; regenerate the control plan")
+    candidate = plan.get("candidate")
+    if not isinstance(candidate, dict):
+        raise ValidationError("COLMAP control plan has no candidate binding")
+
+    def check_hash(value: Any, label: str) -> None:
+        if not isinstance(value, str) or len(value) != 64:
+            raise ValidationError(f"{label} hash is missing from the plan")
+        path_value = candidate.get(label)
+        if not isinstance(path_value, str):
+            raise ValidationError(f"{label} path is missing from the plan")
+        path = Path(path_value).expanduser().resolve()
+        if not path.is_file() or sha256_file(path) != value:
+            raise ValidationError(f"{label} hash mismatch; regenerate the COLMAP plan")
+
+    check_hash(candidate.get("candidate_manifest_sha256"), "candidate_manifest")
+    pair_list = candidate.get("pair_list")
+    pair_list_hash = candidate.get("pair_list_sha256")
+    if not isinstance(pair_list, str) or not isinstance(pair_list_hash, str):
+        raise ValidationError("COLMAP control plan pair-list binding is incomplete")
+    pair_path = Path(pair_list).expanduser().resolve()
+    if not pair_path.is_file() or sha256_file(pair_path) != pair_list_hash:
+        raise ValidationError("candidate pair-list hash mismatch; regenerate the COLMAP plan")
+    candidate_index = candidate.get("index")
+    candidate_index_hash = candidate.get("index_sha256")
+    if candidate_index is not None:
+        if not isinstance(candidate_index, str) or not isinstance(candidate_index_hash, str):
+            raise ValidationError("candidate index binding is incomplete")
+        index_path = Path(candidate_index).expanduser().resolve()
+        if not index_path.is_file() or sha256_file(index_path) != candidate_index_hash:
+            raise ValidationError("candidate index hash mismatch; regenerate the COLMAP plan")
+        validated_index = validate_candidate_shards(index_path)
+        source_in_index = Path(validated_index["index"]["source_manifest"]).expanduser().resolve()
+        source_in_plan = Path(candidate["candidate_manifest"]).expanduser().resolve()
+        if source_in_index != source_in_plan:
+            raise ValidationError("candidate source path differs between index and COLMAP plan")
+
+    inputs = plan.get("inputs")
+    if not isinstance(inputs, dict):
+        raise ValidationError("COLMAP control plan has no input binding")
+    for key, filename in (
+        ("calibration_cameras_sha256", "cameras.txt"),
+        ("calibration_images_sha256", "images.txt"),
+    ):
+        directory = inputs.get("calibration_dir")
+        expected = inputs.get(key)
+        if not isinstance(directory, str) or not isinstance(expected, str):
+            raise ValidationError(f"COLMAP plan input binding {key} is incomplete")
+        path = Path(directory).expanduser().resolve() / filename
+        if not path.is_file() or sha256_file(path) != expected:
+            raise ValidationError(f"calibration {filename} hash mismatch; regenerate the COLMAP plan")
+
+    source_value = candidate.get("candidate_manifest")
+    source_names = candidate.get("candidate_image_names")
+    if not isinstance(source_value, str) or not isinstance(source_names, list):
+        raise ValidationError("COLMAP plan source image envelope is malformed")
+    source_path = Path(source_value).expanduser().resolve()
+    parsed_names, parsed_pairs, _ = parse_candidate_manifest_with_metadata(source_path)
+    if parsed_names != source_names:
+        raise ValidationError("candidate image names differ between source and COLMAP plan")
+    names = candidate.get("colmap_image_names")
+    count = candidate.get("pair_count")
+    if not isinstance(names, list) or not all(isinstance(name, str) for name in names) or not isinstance(count, int):
+        raise ValidationError("COLMAP plan candidate envelope is malformed")
+    try:
+        actual_lines = [line.strip() for line in pair_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read candidate pair list {pair_path}: {exc}") from exc
+    if len(actual_lines) != count:
+        raise ValidationError("candidate pair list count differs from the plan")
+    if any(len(line.split()) != 2 for line in actual_lines):
+        raise ValidationError("candidate pair list contains a malformed line")
+    known = set(names)
+    if any(value not in known for line in actual_lines for value in line.split()):
+        raise ValidationError("candidate pair list contains an image name outside the plan")
+    inputs_alias = inputs.get("alias_tsv")
+    inputs_alias_hash = inputs.get("alias_tsv_sha256")
+    aliases = parse_alias_tsv(Path(inputs_alias).expanduser().resolve()) if inputs_alias else _identity_aliases(source_names)
+    if inputs_alias:
+        if not isinstance(inputs_alias_hash, str):
+            raise ValidationError("COLMAP plan alias-map binding is incomplete")
+        alias_path = Path(inputs_alias).expanduser().resolve()
+        if not alias_path.is_file() or sha256_file(alias_path) != inputs_alias_hash:
+            raise ValidationError("candidate alias-map hash mismatch; regenerate the COLMAP plan")
+    expected_names = [aliases.get(name) for name in source_names]
+    if expected_names != names:
+        raise ValidationError("candidate image aliases differ between source and COLMAP plan")
+    expected_lines = [
+        f"{expected_names[first]} {expected_names[second]}" for first, second in parsed_pairs
+    ]
+    if len(parsed_pairs) != count:
+        raise ValidationError("candidate source pair count differs from the plan")
+    if actual_lines != expected_lines:
+        raise ValidationError("candidate pair list differs from the frozen candidate manifest")
+
+
+def _camera_specs(
+    calibration_dir: Path,
+    image_names: list[str],
+) -> tuple[dict[int, dict[str, Any]], dict[str, int]]:
+    cameras = parse_pinhole_cameras(calibration_dir / "cameras.txt")
+    assignments = parse_image_camera_assignments(calibration_dir / "images.txt")
+    camera_numbers: dict[int, int] = {}
+    for name in image_names:
+        camera_id = _camera_for_flat_name(name, assignments)
+        if camera_id is None:
+            raise ValidationError(f"no official calibration camera assignment for {name!r}")
+        match = CAMERA_PREFIX_RE.fullmatch(name)
+        if match is None:
+            raise ValidationError(f"candidate image is not camN_timestamp.png: {name!r}")
+        camera_number = int(match.group("camera"))
+        previous = camera_numbers.setdefault(camera_id, camera_number)
+        if previous != camera_number:
+            raise ValidationError(
+                f"camera id {camera_id} maps to both cam{previous} and cam{camera_number}"
+            )
+        if camera_id not in cameras:
+            raise ValidationError(f"image {name!r} refers to missing CAMERA_ID {camera_id}")
+    for camera_id, camera_number in camera_numbers.items():
+        cameras[camera_id]["camera_number"] = camera_number
+    return {camera_id: cameras[camera_id] for camera_id in sorted(camera_numbers)}, assignments
+
+
+def make_plan(
+    *,
+    candidate_index: Path | None,
+    candidate_manifest: Path | None,
+    output_root: Path,
+    image_root: Path,
+    camera_root: Path,
+    calibration_dir: Path,
+    colmap_binary: Path,
+    alias_tsv: Path | None = None,
+    threads: int = 8,
+    max_num_features: int = 2048,
+    max_image_size: int = 5000,
+    first_octave: int = -1,
+    peak_threshold: float = 0.0066666667,
+    max_num_orientations: int = 2,
+    max_ratio: float = 0.8,
+    min_num_inliers: int = 8,
+    max_error: float = 4.0,
+    colmap_library_path: Path | None = None,
+    config_path: Path | None = None,
+) -> dict[str, Any]:
+    if (candidate_index is None) == (candidate_manifest is None):
+        raise ValidationError("pass exactly one of --candidate-index and --candidate-manifest")
+    if candidate_index is not None:
+        source, candidate = _candidate_source_from_index(candidate_index.resolve())
+        candidate_index_hash = candidate["index_sha256"]
+    else:
+        source = candidate_manifest.resolve()
+        if not source.is_file():
+            raise ValidationError(f"candidate manifest is missing: {source}")
+        names, pairs, metadata = parse_candidate_manifest_with_metadata(source)
+        candidate = {
+            "index_sha256": None,
+            "image_names": names,
+            "pair_count": len(pairs),
+            "candidate_manifest_metadata": metadata,
+        }
+        candidate_index_hash = None
+    names = candidate["image_names"]
+    aliases = parse_alias_tsv(alias_tsv.resolve()) if alias_tsv else _identity_aliases(names)
+    output_root = output_root.resolve()
+    protocol_config_path = (config_path or DEFAULT_CONFIG).resolve()
+    protocol_config = _load_json(protocol_config_path, "COLMAP protocol config")
+    if protocol_config.get("schema") != CONFIG_SCHEMA:
+        raise ValidationError(
+            f"COLMAP protocol config has unsupported schema: {protocol_config.get('schema')!r}"
+        )
+    runtime_env: dict[str, str] = {}
+    if colmap_library_path is not None:
+        library_path = colmap_library_path.resolve()
+        if not library_path.is_dir():
+            raise ValidationError(f"COLMAP library directory is missing: {library_path}")
+        runtime_env["LD_LIBRARY_PATH"] = str(library_path)
+    pair_list = output_root / "candidate_pairs.txt"
+    pair_info = write_pair_list(source, pair_list, aliases=aliases)
+    if pair_info["image_count"] != len(names) or pair_info["pair_count"] != candidate["pair_count"]:
+        raise ValidationError("pair list envelope differs from candidate index")
+    cameras, _ = _camera_specs(calibration_dir.resolve(), names)
+    database = output_root / "database.db"
+    model = output_root / "models"
+    commands = build_commands(
+        colmap_binary=colmap_binary.resolve(),
+        database=database,
+        image_root=image_root.resolve(),
+        camera_root=camera_root.resolve(),
+        cameras=cameras,
+        pair_list=pair_list,
+        output_model=model,
+        threads=threads,
+        max_num_features=max_num_features,
+        max_image_size=max_image_size,
+        first_octave=first_octave,
+        peak_threshold=peak_threshold,
+        max_num_orientations=max_num_orientations,
+        max_ratio=max_ratio,
+        min_num_inliers=min_num_inliers,
+        max_error=max_error,
+    )
+    plan = {
+        "schema": PLAN_SCHEMA,
+        "protocol_config": {
+            "path": str(protocol_config_path),
+            "sha256": sha256_file(protocol_config_path),
+        },
+        "candidate": {
+            "index": str(candidate_index.resolve()) if candidate_index else None,
+            "index_sha256": candidate_index_hash,
+            **pair_info,
+        },
+        "inputs": {
+            "image_root": str(image_root.resolve()),
+            "camera_root": str(camera_root.resolve()),
+            "calibration_dir": str(calibration_dir.resolve()),
+            "calibration_cameras_sha256": sha256_file(calibration_dir / "cameras.txt"),
+            "calibration_images_sha256": sha256_file(calibration_dir / "images.txt"),
+            "alias_tsv": str(alias_tsv.resolve()) if alias_tsv else None,
+            "alias_tsv_sha256": sha256_file(alias_tsv) if alias_tsv else None,
+        },
+        "colmap": {
+            "binary": str(colmap_binary.resolve()),
+            "binary_sha256": sha256_file(colmap_binary),
+            "runtime_env": runtime_env,
+            "commands": commands,
+            "cameras": cameras,
+            "database": str(database),
+            "model": str(model),
+            "feature_settings": {
+                "max_num_features": max_num_features,
+                "max_image_size": max_image_size,
+                "first_octave": first_octave,
+                "peak_threshold": peak_threshold,
+                "max_num_orientations": max_num_orientations,
+            },
+            "matching_settings": {
+                "mode": "matches_importer",
+                "match_type": "pairs",
+                "max_ratio": max_ratio,
+                "cross_check": True,
+                "min_num_inliers": min_num_inliers,
+                "max_error": max_error,
+            },
+            "mapper_settings": {
+                "multiple_models": False,
+                "min_model_size": 10,
+                "num_threads": threads,
+                "abs_pose_min_num_inliers": min_num_inliers,
+                "ba_refine_focal_length": False,
+                "ba_refine_principal_point": False,
+                "ba_refine_extra_params": False,
+            },
+        },
+        "ground_truth_used_for_selection_or_mapping": False,
+    }
+    atomic_json(output_root / "plan.json", plan)
+    return plan
+
+
+def run_plan(plan_path: Path) -> dict[str, Any]:
+    plan = _load_json(plan_path.resolve(), "COLMAP control plan")
+    if plan.get("schema") != PLAN_SCHEMA:
+        raise ValidationError(f"unsupported COLMAP control plan schema: {plan.get('schema')!r}")
+    _validate_plan_artifacts(plan, plan_path)
+    root = plan_path.resolve().parent
+    commands = plan.get("colmap", {}).get("commands")
+    if not isinstance(commands, dict):
+        raise ValidationError("COLMAP control plan has no commands")
+    runtime_env = plan.get("colmap", {}).get("runtime_env", {})
+    if not isinstance(runtime_env, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str) for key, value in runtime_env.items()
+    ):
+        raise ValidationError("COLMAP control plan runtime_env is malformed")
+    model_value = plan.get("colmap", {}).get("model")
+    if not isinstance(model_value, str) or not model_value:
+        raise ValidationError("COLMAP control plan model output path is missing")
+    # COLMAP 3.9 expects mapper --output_path to already exist.  Creating the
+    # external run directory is safe and makes an interrupted prepare/run
+    # restartable without a hand-written shell prelude.
+    Path(model_value).expanduser().resolve().mkdir(parents=True, exist_ok=True)
+    phases: dict[str, Any] = {}
+    camera_specs = plan.get("colmap", {}).get("cameras", {})
+    camera_numbers = [
+        camera.get("camera_number")
+        for _, camera in sorted(
+            camera_specs.items(), key=lambda item: item[1].get("camera_number", 0)
+        )
+        if isinstance(camera, dict)
+    ]
+    for index, command in enumerate(commands.get("feature_extractor", [])):
+        if not isinstance(command, list) or not all(isinstance(value, str) for value in command):
+            raise ValidationError(f"feature command {index} is malformed")
+        camera_label = camera_numbers[index] if index < len(camera_numbers) else index
+        phases[f"feature_extractor_cam{camera_label}"] = run_timed(
+            command,
+            root / "logs" / f"feature_cam{camera_label}.log",
+            root / "timing" / f"feature_cam{camera_label}.time.txt",
+            environment=runtime_env,
+        )
+    for phase in ("matches_importer", "mapper"):
+        command = commands.get(phase)
+        if not isinstance(command, list) or not all(isinstance(value, str) for value in command):
+            raise ValidationError(f"COLMAP {phase} command is malformed")
+        phases[phase] = run_timed(
+            command,
+            root / "logs" / f"{phase}.log",
+            root / "timing" / f"{phase}.time.txt",
+            environment=runtime_env,
+        )
+    result = {
+        "schema": "visloc_electro_colmap_control_result_v1",
+        "plan": str(plan_path.resolve()),
+        "plan_sha256": sha256_file(plan_path),
+        "phases": phases,
+        "ground_truth_used_for_selection_or_mapping": False,
+    }
+    atomic_json(root / "result.json", result)
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--prepare", action="store_true", help="write a pair list and external execution plan")
+    mode.add_argument("--run", action="store_true", help="execute an existing plan (CPU-heavy, explicit opt-in)")
+    parser.add_argument("--plan", type=Path, help="existing plan.json for --run")
+    parser.add_argument("--candidate-index", type=Path)
+    parser.add_argument("--candidate-manifest", type=Path)
+    parser.add_argument("--output-root", type=Path)
+    parser.add_argument("--image-root", type=Path)
+    parser.add_argument("--camera-root", type=Path)
+    parser.add_argument("--calibration-dir", type=Path)
+    parser.add_argument("--colmap-binary", type=Path)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument(
+        "--colmap-library-path",
+        type=Path,
+        help="optional directory containing COLMAP's bundled shared libraries (recorded as LD_LIBRARY_PATH)",
+    )
+    parser.add_argument("--alias-tsv", type=Path)
+    parser.add_argument("--threads", type=int, default=8)
+    parser.add_argument("--max-num-features", type=int, default=2048)
+    parser.add_argument("--max-image-size", type=int, default=5000)
+    parser.add_argument("--first-octave", type=int, default=-1)
+    parser.add_argument("--peak-threshold", type=float, default=0.0066666667)
+    parser.add_argument("--max-num-orientations", type=int, default=2)
+    parser.add_argument("--max-ratio", type=float, default=0.8)
+    parser.add_argument("--min-num-inliers", type=int, default=8)
+    parser.add_argument("--max-error", type=float, default=4.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.run:
+            if args.plan is None:
+                raise ValidationError("--run requires --plan")
+            print(json.dumps(run_plan(args.plan), sort_keys=True, indent=2))
+            return 0
+        required = {
+            "--output-root": args.output_root,
+            "--image-root": args.image_root,
+            "--camera-root": args.camera_root,
+            "--calibration-dir": args.calibration_dir,
+            "--colmap-binary": args.colmap_binary,
+        }
+        missing = [name for name, value in required.items() if value is None]
+        if missing:
+            raise ValidationError(f"--prepare requires {', '.join(missing)}")
+        plan = make_plan(
+            candidate_index=args.candidate_index,
+            candidate_manifest=args.candidate_manifest,
+            output_root=args.output_root,
+            image_root=args.image_root,
+            camera_root=args.camera_root,
+            calibration_dir=args.calibration_dir,
+            colmap_binary=args.colmap_binary,
+            colmap_library_path=args.colmap_library_path,
+            config_path=args.config,
+            alias_tsv=args.alias_tsv,
+            threads=args.threads,
+            max_num_features=args.max_num_features,
+            max_image_size=args.max_image_size,
+            first_octave=args.first_octave,
+            peak_threshold=args.peak_threshold,
+            max_num_orientations=args.max_num_orientations,
+            max_ratio=args.max_ratio,
+            min_num_inliers=args.min_num_inliers,
+            max_error=args.max_error,
+        )
+        print(json.dumps(plan, sort_keys=True, indent=2))
+        return 0
+    except (ValidationError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_electro_colmap.sh
+++ b/scripts/benchmark_electro_colmap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Thin reproducible entry point for the explicit official COLMAP control.
+set -euo pipefail
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+exec python3 "$script_dir/benchmark_electro_colmap.py" "$@"

--- a/scripts/score_electro_model.py
+++ b/scripts/score_electro_model.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Score an ETH3D ``electro`` COLMAP model by camera centre.
+
+This is a post-mapping score only.  It maps both flat visloc/COLMAP names
+(``cam4_<timestamp>.png``) and official ETH3D names
+(``images_rig_cam4_undistorted/<timestamp>.png``) to the key
+``(camera_number, timestamp)`` and then Umeyama-aligns the query centres to
+the official reference centres.  The reference is never consumed by
+candidate generation, matching, or mapping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import numpy as np
+except ImportError as exc:  # pragma: no cover - exercised only on minimal hosts
+    raise SystemExit("score_electro_model.py requires numpy") from exc
+
+
+IMAGE_KEY_RE = re.compile(
+    r"^(?:images_rig_)?cam(?P<camera>[0-9]+)(?:_undistorted)?[_/](?P<timestamp>[0-9]+)\.(?P<suffix>[^./]+)$"
+)
+
+
+class ScoreError(RuntimeError):
+    """A reference or query model could not be scored."""
+
+
+REFERENCE_EXTENT_EPSILON_M = 1e-9
+
+
+def image_key(name: str) -> tuple[int, int]:
+    normalized = name.replace("\\", "/")
+    match = IMAGE_KEY_RE.fullmatch(normalized)
+    if match is None:
+        # The official path has the camera token in a directory and the flat
+        # path has it at the beginning.  Keep this fallback strict enough to
+        # avoid accidentally pairing unrelated numeric filenames.
+        match = re.search(
+            r"(?:^|/)images_rig_cam(?P<camera>[0-9]+)_undistorted/(?P<timestamp>[0-9]+)\.[^/]+$",
+            normalized,
+        )
+    if match is None:
+        match = re.search(r"(?:^|/)cam(?P<camera>[0-9]+)_(?P<timestamp>[0-9]+)\.[^/]+$", normalized)
+    if match is None:
+        raise ScoreError(f"unsupported electro image name: {name!r}")
+    return int(match.group("camera")), int(match.group("timestamp"))
+
+
+def _rotation(qw: float, qx: float, qy: float, qz: float) -> np.ndarray:
+    norm = math.sqrt(qw * qw + qx * qx + qy * qy + qz * qz)
+    if not math.isfinite(norm) or norm == 0:
+        raise ScoreError("COLMAP pose has a zero or non-finite quaternion")
+    qw, qx, qy, qz = (value / norm for value in (qw, qx, qy, qz))
+    return np.array(
+        [
+            [1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qw * qz), 2 * (qx * qz + qw * qy)],
+            [2 * (qx * qy + qw * qz), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qw * qx)],
+            [2 * (qx * qz - qw * qy), 2 * (qy * qz + qw * qx), 1 - 2 * (qx * qx + qy * qy)],
+        ],
+        dtype=float,
+    )
+
+
+def load_centres(path: Path) -> dict[tuple[int, int], np.ndarray]:
+    """Load camera centres from a COLMAP text ``images.txt``."""
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ScoreError(f"cannot read COLMAP images model {path}: {exc}") from exc
+    centres: dict[tuple[int, int], np.ndarray] = {}
+    expect_points = False
+    for line_number, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if expect_points:
+            # COLMAP stores one POINTS2D row immediately after every pose.
+            # It is intentionally ignored.  If a model omits that row, the
+            # next pose would be skipped; valid text models always include it.
+            expect_points = False
+            continue
+        fields = line.split()
+        if len(fields) < 10:
+            raise ScoreError(f"COLMAP pose row {path}:{line_number} is malformed")
+        try:
+            int(fields[0])
+            qw, qx, qy, qz = (float(value) for value in fields[1:5])
+            t = np.array([float(value) for value in fields[5:8]], dtype=float)
+            int(fields[8])
+        except ValueError as exc:
+            raise ScoreError(f"COLMAP pose row {path}:{line_number} is not numeric") from exc
+        name = fields[9]
+        key = image_key(name)
+        if key in centres:
+            raise ScoreError(f"COLMAP model contains duplicate electro image key {key}: {path}")
+        rotation = _rotation(qw, qx, qy, qz)
+        centres[key] = -rotation.T @ t
+        expect_points = True
+    if not centres:
+        raise ScoreError(f"COLMAP model contains no registered electro images: {path}")
+    return centres
+
+
+def umeyama(source: np.ndarray, destination: np.ndarray) -> tuple[float, np.ndarray, np.ndarray]:
+    """Return scale, rotation, translation mapping source to destination."""
+
+    if len(source) < 3:
+        raise ScoreError("at least three common camera centres are required")
+    source_mean = source.mean(axis=0)
+    destination_mean = destination.mean(axis=0)
+    centered_source = source - source_mean
+    centered_destination = destination - destination_mean
+    covariance = centered_destination.T @ centered_source / len(source)
+    u, singular, vt = np.linalg.svd(covariance)
+    correction = np.eye(3)
+    if np.linalg.det(u) * np.linalg.det(vt) < 0:
+        correction[2, 2] = -1
+    rotation = u @ correction @ vt
+    variance = float((centered_source**2).sum() / len(source))
+    if not math.isfinite(variance) or variance <= 0:
+        raise ScoreError("common query camera centres are degenerate")
+    scale = float(np.trace(np.diag(singular) @ correction) / variance)
+    translation = destination_mean - scale * rotation @ source_mean
+    return scale, rotation, translation
+
+
+def validate_reference_geometry(reference: dict[tuple[int, int], np.ndarray]) -> float:
+    """Reject calibration-only/identity pose files before Sim(3) scoring.
+
+    ETH3D's staging calibration helper can intentionally emit identity dummy
+    poses for intrinsics lookup.  Treating that file as a reference would
+    make a query with the same dummy poses appear to score perfectly.  A real
+    electro reference has a non-zero camera-centre extent, so fail closed on
+    an all-collapsed reference before looking at query overlap.
+    """
+
+    centres = np.asarray(list(reference.values()), dtype=float)
+    if centres.ndim != 2 or centres.shape[1] != 3 or not np.isfinite(centres).all():
+        raise ScoreError("reference camera centres contain non-finite or malformed values")
+    extent = float(np.linalg.norm(centres.max(axis=0) - centres.min(axis=0)))
+    if not math.isfinite(extent) or extent <= REFERENCE_EXTENT_EPSILON_M:
+        raise ScoreError(
+            "reference camera centres are degenerate (near-zero extent); "
+            "pass the official electro rig poses, not an identity staging calibration"
+        )
+    return extent
+
+
+def score(reference_path: Path, query_path: Path) -> dict[str, Any]:
+    reference = load_centres(reference_path)
+    reference_extent = validate_reference_geometry(reference)
+    query = load_centres(query_path)
+    common = sorted(set(reference) & set(query))
+    if len(common) < 3:
+        raise ScoreError(
+            f"only {len(common)} common electro cameras; at least three are required for Sim(3)"
+        )
+    source = np.array([query[key] for key in common], dtype=float)
+    destination = np.array([reference[key] for key in common], dtype=float)
+    scale, rotation, translation = umeyama(source, destination)
+    aligned = (scale * (rotation @ source.T).T) + translation
+    errors = np.linalg.norm(aligned - destination, axis=1)
+    extent = reference_extent
+    by_camera: dict[str, dict[str, Any]] = {}
+    for camera in sorted({key[0] for key in common}):
+        camera_errors = errors[[key[0] == camera for key in common]]
+        by_camera[str(camera)] = {
+            "common": int(len(camera_errors)),
+            "rmse_m": float(np.sqrt(np.mean(camera_errors**2))),
+            "median_m": float(np.median(camera_errors)),
+            "p95_m": float(np.percentile(camera_errors, 95)),
+            "max_m": float(np.max(camera_errors)),
+        }
+    return {
+        "schema": "visloc_electro_model_score_v1",
+        "reference_images": str(reference_path.resolve()),
+        "query_images": str(query_path.resolve()),
+        "reference_registered": len(reference),
+        "query_registered": len(query),
+        "common": len(common),
+        "missing_query": len(set(reference) - set(query)),
+        "missing_reference": len(set(query) - set(reference)),
+        "sim3_scale": scale,
+        "rmse_m": float(np.sqrt(np.mean(errors**2))),
+        "median_m": float(np.median(errors)),
+        "p95_m": float(np.percentile(errors, 95)),
+        "max_m": float(np.max(errors)),
+        "reference_extent_m": extent,
+        "relative_rmse": float(np.sqrt(np.mean(errors**2)) / extent) if extent > 0 else None,
+        "by_camera": by_camera,
+        "reference_used_only_for_post_mapping_score": True,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reference", type=Path, help="official electro model images.txt")
+    parser.add_argument("query", type=Path, help="completed COLMAP model images.txt")
+    parser.add_argument("--output-json", type=Path, help="write the score object to this path")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = score(args.reference.resolve(), args.query.resolve())
+        if args.output_json:
+            args.output_json.parent.mkdir(parents=True, exist_ok=True)
+            args.output_json.write_text(json.dumps(result, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(result, sort_keys=True, indent=2))
+        return 0
+    except ScoreError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -1,0 +1,243 @@
+"""Focused tests for the resumable ETH3D electro runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_electro", ROOT / "scripts" / "benchmark_electro.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(benchmark)
+
+
+class ElectroBenchmarkTests(unittest.TestCase):
+    def _candidate(self, root: Path) -> tuple[Path, list[str], list[tuple[int, int]]]:
+        names = [f"{index:06d}.png" for index in range(5)]
+        pairs = [(0, 1), (0, 2), (1, 2), (1, 3), (2, 4)]
+        path = root / "candidates.txt"
+        benchmark.write_candidate_manifest(path, names, pairs)
+        return path, names, pairs
+
+    def test_candidate_shards_are_contiguous_and_hash_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, names, pairs = self._candidate(root)
+            index = benchmark.split_candidate_manifest(source, root / "candidates", 2)
+            self.assertEqual(index["pair_count"], len(pairs))
+            validated = benchmark.validate_candidate_shards(root / "candidates" / "index.json")
+            self.assertEqual(validated["image_names"], names)
+            self.assertEqual(len(validated["shards"]), 3)
+            self.assertEqual(
+                [entry["start"] for entry in validated["shards"]], [0, 2, 4]
+            )
+
+            shard = root / "candidates" / "candidate-000001.txt"
+            shard.write_text(shard.read_text(encoding="utf-8") + "# tampered\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_candidate_shards(root / "candidates" / "index.json")
+
+    def test_candidate_metadata_survives_sharding_and_tampering_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            names = ["cam4_100.png", "cam5_100.png", "cam4_101.png"]
+            source = root / "candidates.txt"
+            metadata = {
+                "candidate_policy": "vlad-union-v1",
+                "cross_camera_rule": "same-timestamp",
+                "local_grouping": "rig-prefix-timestamp-v1",
+            }
+            benchmark.write_candidate_manifest(source, names, [(0, 1), (0, 2)], metadata=metadata)
+            index = benchmark.split_candidate_manifest(
+                source,
+                root / "candidates",
+                1,
+                local_grouping="rig-prefix-timestamp-v1",
+            )
+            self.assertEqual(index["candidate_manifest_metadata"], metadata)
+            parsed = benchmark.parse_candidate_manifest_with_metadata(source)
+            self.assertEqual(parsed[2], metadata)
+            benchmark.validate_candidate_shards(root / "candidates" / "index.json")
+            shard = root / "candidates" / "candidate-000000.txt"
+            shard.write_text(shard.read_text(encoding="utf-8").replace("same-timestamp", "other"), encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_candidate_shards(root / "candidates" / "index.json")
+
+    def test_resume_rewrites_corrupt_candidate_shard_atomically(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _, _ = self._candidate(root)
+            first = benchmark.split_candidate_manifest(
+                source,
+                root / "candidates",
+                3,
+                retrieval_topk=32,
+                local_stem_window=3,
+                candidate_budget=5,
+            )
+            shard = root / "candidates" / "candidate-000000.txt"
+            shard.write_text("broken\n", encoding="utf-8")
+            second = benchmark.split_candidate_manifest(source, root / "candidates", 3)
+            self.assertEqual(first["shards"][0]["sha256"], second["shards"][0]["sha256"])
+            self.assertEqual(
+                first["candidate_policy"],
+                {"retrieval_topk": 32, "local_stem_window": 3, "candidate_budget": 5},
+            )
+            benchmark.validate_candidate_shards(root / "candidates" / "index.json")
+
+    def test_match_plan_binds_candidate_index_hash_and_commands_are_gt_free(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _, _ = self._candidate(root)
+            benchmark.split_candidate_manifest(source, root / "candidates", 2)
+            candidate_index = root / "candidates" / "index.json"
+            match_index = benchmark.prepare_match_index(candidate_index, root / "matches")
+            self.assertEqual(match_index["schema"], benchmark.MATCH_INDEX_SCHEMA)
+            self.assertEqual(
+                match_index["candidate_index_sha256"], benchmark.sha256_file(candidate_index)
+            )
+            benchmark.validate_match_index(root / "matches" / "index.json", candidate_index)
+
+            candidate_command = benchmark.build_candidate_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                candidate_manifest=Path("/run/candidates.txt"),
+            )
+            match_command = benchmark.build_match_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                candidate_shard=Path("/run/candidate.txt"),
+                snapshot=Path("/run/matches.vps"),
+            )
+            map_command = benchmark.build_mapping_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                merged_snapshot=Path("/run/merged.vps"),
+                output_model=Path("/run/model"),
+                max_mapper_matches_per_pair=128,
+            )
+            for command in (candidate_command, match_command, map_command):
+                self.assertNotIn("--gt", command)
+                self.assertNotIn("points3D.txt", command)
+            self.assertIn("--export-verified-pairs-only", match_command)
+            self.assertNotIn("--max-mapper-matches-per-pair", match_command)
+            self.assertIn("--max-mapper-matches-per-pair", map_command)
+            no_ba_command = benchmark.build_mapping_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                merged_snapshot=Path("/run/merged.vps"),
+                output_model=Path("/run/model"),
+                final_ba=False,
+            )
+            self.assertIn("--no-final-ba", no_ba_command)
+
+            rig_candidate_command = benchmark.build_candidate_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                candidate_manifest=Path("/run/candidates.txt"),
+                rig_local_grouping=True,
+            )
+            self.assertIn("--rig-local-grouping", rig_candidate_command)
+
+            temporal_candidate_command = benchmark.build_candidate_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                candidate_manifest=Path("/run/temporal-candidates.txt"),
+                pair_source="temporal-pyramid",
+                temporal_pyramid_max_offset=64,
+                candidate_budget=12000,
+            )
+            self.assertIn("--pair-source", temporal_candidate_command)
+            self.assertIn("temporal-pyramid", temporal_candidate_command)
+            self.assertIn("--temporal-pyramid-max-offset", temporal_candidate_command)
+            self.assertIn("64", temporal_candidate_command)
+            self.assertNotIn("--local-stem-window", temporal_candidate_command)
+            self.assertNotIn("--rig-local-grouping", temporal_candidate_command)
+
+    def test_temporal_candidate_policy_is_hash_bound_in_shard_index(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _, _ = self._candidate(root)
+            index = benchmark.split_candidate_manifest(
+                source,
+                root / "temporal-candidates",
+                2,
+                retrieval_topk=32,
+                candidate_budget=12000,
+                pair_source="temporal-pyramid",
+                temporal_pyramid_max_offset=32,
+                local_grouping="rig-prefix-timestamp-v1",
+            )
+            self.assertEqual(
+                index["candidate_policy"],
+                {
+                    "retrieval_topk": 32,
+                    "local_stem_window": None,
+                    "candidate_budget": 12000,
+                    "pair_source": "temporal-pyramid",
+                    "temporal_pyramid_max_offset": 32,
+                    "local_grouping": "rig-prefix-timestamp-v1",
+                },
+            )
+            benchmark.validate_candidate_shards(root / "temporal-candidates" / "index.json")
+
+    def test_feature_manifest_rejects_changed_bytes_even_with_same_size(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            features = root / "features"
+            features.mkdir()
+            feature = features / "000000_features.txt"
+            feature.write_text("0 0 1 2\n", encoding="utf-8")
+            manifest = benchmark.feature_manifest(features)
+            manifest_path = root / "features.json"
+            benchmark.write_feature_manifest(manifest_path, manifest)
+            benchmark.validate_feature_manifest(manifest_path, features)
+            feature.write_text("0 0 1 3\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_feature_manifest(manifest_path, features)
+
+    def test_verify_mode_does_not_require_rust_binaries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            features = root / "features"
+            features.mkdir()
+            (features / "000000_features.txt").write_text("0 0 1 2\n", encoding="utf-8")
+            (features / "000001_features.txt").write_text("0 0 1 2\n", encoding="utf-8")
+            feature_manifest = benchmark.feature_manifest(features)
+            benchmark.write_feature_manifest(root / "features.json", feature_manifest)
+            source = root / "source.txt"
+            benchmark.write_candidate_manifest(source, ["000000.png", "000001.png"], [(0, 1)])
+            benchmark.split_candidate_manifest(source, root / "candidates", 1)
+            self.assertEqual(
+                benchmark.main(
+                    [
+                        "--verify-only",
+                        "--features-dir",
+                        str(features),
+                        "--calibration-dir",
+                        str(root),
+                        "--artifact-root",
+                        str(root),
+                    ]
+                ),
+                0,
+            )
+            summary = json.loads((root / "summary.json").read_text(encoding="utf-8"))
+            self.assertFalse(summary["ground_truth_used_for_selection_or_mapping"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_benchmark_electro_colmap.py
+++ b/tests/test_benchmark_electro_colmap.py
@@ -1,0 +1,229 @@
+"""Tests for the exact-candidate official COLMAP control preparation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = load_module("benchmark_electro", ROOT / "scripts" / "benchmark_electro.py")
+colmap = load_module("benchmark_electro_colmap", ROOT / "scripts" / "benchmark_electro_colmap.py")
+score = load_module("score_electro_model", ROOT / "scripts" / "score_electro_model.py")
+
+
+class ElectroColmapControlTests(unittest.TestCase):
+    def _calibration(self, root: Path) -> Path:
+        calibration = root / "calibration"
+        calibration.mkdir()
+        (calibration / "cameras.txt").write_text(
+            "# cameras\n"
+            "1 PINHOLE 10 8 5 5 5 4\n"
+            "2 PINHOLE 12 9 6 6 6 4.5\n",
+            encoding="utf-8",
+        )
+        (calibration / "images.txt").write_text(
+            "# image assignments\n"
+            "1 1 0 0 0 0 0 0 1 cam4_100.png\n"
+            "# points omitted\n"
+            "2 1 0 0 0 0 0 0 2 cam5_100.png\n"
+            "# points omitted\n"
+            "3 1 0 0 0 0 0 0 1 cam4_101.png\n",
+            encoding="utf-8",
+        )
+        return calibration
+
+    def _candidate(self, root: Path) -> Path:
+        path = root / "candidates.txt"
+        benchmark.write_candidate_manifest(
+            path,
+            ["cam4_100.png", "cam5_100.png", "cam4_101.png"],
+            [(0, 1), (0, 2)],
+            metadata={"candidate_policy": "vlad-union-v1"},
+        )
+        return path
+
+    def test_pair_list_preserves_order_and_maps_names(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = self._candidate(root)
+            pair_list = root / "pairs.txt"
+            info = colmap.write_pair_list(
+                candidate,
+                pair_list,
+                aliases={
+                    "cam4_100.png": "cam4/100.png",
+                    "cam5_100.png": "cam5/100.png",
+                    "cam4_101.png": "cam4/101.png",
+                },
+            )
+            self.assertEqual(
+                pair_list.read_text(encoding="utf-8").splitlines(),
+                ["cam4/100.png cam5/100.png", "cam4/100.png cam4/101.png"],
+            )
+            self.assertEqual(info["pair_count"], 2)
+            self.assertEqual(info["candidate_image_names"][0], "cam4_100.png")
+
+    def test_prepare_binds_validated_index_and_uses_exact_pair_importer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = self._candidate(root)
+            candidate_index = root / "candidate_shards"
+            benchmark.split_candidate_manifest(candidate, candidate_index, 1)
+            calibration = self._calibration(root)
+            camera_root = root / "camera_shards"
+            (camera_root / "cam4" / "images").mkdir(parents=True)
+            (camera_root / "cam5" / "images").mkdir(parents=True)
+            image_root = root / "images"
+            image_root.mkdir()
+            output = root / "control"
+            plan = colmap.make_plan(
+                candidate_index=candidate_index / "index.json",
+                candidate_manifest=None,
+                output_root=output,
+                image_root=image_root,
+                camera_root=camera_root,
+                calibration_dir=calibration,
+                colmap_binary=Path("/bin/true"),
+            )
+            self.assertEqual(plan["candidate"]["pair_count"], 2)
+            self.assertEqual(plan["colmap"]["matching_settings"]["mode"], "matches_importer")
+            self.assertEqual(plan["colmap"]["matching_settings"]["match_type"], "pairs")
+            self.assertEqual(len(plan["colmap"]["commands"]["feature_extractor"]), 2)
+            match = plan["colmap"]["commands"]["matches_importer"]
+            self.assertIn("matches_importer", match)
+            self.assertIn("--match_type", match)
+            self.assertIn("pairs", match)
+            for command in [*plan["colmap"]["commands"]["feature_extractor"], match, plan["colmap"]["commands"]["mapper"]]:
+                self.assertNotIn("points3D.txt", command)
+                self.assertNotIn("--gt", command)
+            self.assertEqual(json.loads((output / "plan.json").read_text())["schema"], colmap.PLAN_SCHEMA)
+
+    def test_score_joins_flat_and_official_names(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            reference = root / "reference_images.txt"
+            query = root / "query_images.txt"
+            names = [
+                "1474975187520882738.png",
+                "1474975187594610738.png",
+                "1474975187668338738.png",
+                "1474975187742066738.png",
+            ]
+            reference_centres = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+            query_centres = [(2 * x + 3, 2 * y - 4, 2 * z + 5) for x, y, z in reference_centres]
+
+            def write_model(path: Path, prefix: str, centres: list[tuple[float, float, float]]) -> None:
+                rows: list[str] = []
+                for image_id, (name, centre) in enumerate(zip(names, centres), 1):
+                    rows.append(
+                        f"{image_id} 1 0 0 0 {-centre[0]} {-centre[1]} {-centre[2]} 1 {prefix}{name}"
+                    )
+                    rows.append("0 0 -1")
+                path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+            write_model(reference, "images_rig_cam4_undistorted/", reference_centres)
+            write_model(query, "cam4_", query_centres)
+            result = score.score(reference, query)
+            self.assertEqual(result["common"], 4)
+            self.assertEqual(result["query_registered"], 4)
+            self.assertAlmostEqual(result["sim3_scale"], 0.5, places=6)
+            self.assertLess(result["rmse_m"], 1e-9)
+
+    def test_score_rejects_non_electro_name(self) -> None:
+        with self.assertRaises(score.ScoreError):
+            score.image_key("frame_0001.png")
+
+    def test_score_rejects_identity_staging_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            reference = root / "identity_reference_images.txt"
+            query = root / "query_images.txt"
+            names = [
+                "1474975187520882738.png",
+                "1474975187594610738.png",
+                "1474975187668338738.png",
+            ]
+
+            def write_model(path: Path, centres: list[tuple[float, float, float]]) -> None:
+                rows: list[str] = []
+                for image_id, (name, centre) in enumerate(zip(names, centres), 1):
+                    rows.append(
+                        f"{image_id} 1 0 0 0 {-centre[0]} {-centre[1]} {-centre[2]} 1 images_rig_cam4_undistorted/{name}"
+                    )
+                    rows.append("0 0 -1")
+                path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+            write_model(reference, [(0.0, 0.0, 0.0)] * len(names))
+            write_model(query, [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)])
+            with self.assertRaisesRegex(score.ScoreError, "identity staging calibration"):
+                score.score(reference, query)
+
+    def test_run_rejects_tampered_pair_list_before_starting_colmap(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = self._candidate(root)
+            candidate_index = root / "candidate_shards"
+            benchmark.split_candidate_manifest(candidate, candidate_index, 1)
+            calibration = self._calibration(root)
+            camera_root = root / "camera_shards"
+            (camera_root / "cam4" / "images").mkdir(parents=True)
+            (camera_root / "cam5" / "images").mkdir(parents=True)
+            output = root / "control"
+            colmap.make_plan(
+                candidate_index=candidate_index / "index.json",
+                candidate_manifest=None,
+                output_root=output,
+                image_root=root / "images",
+                camera_root=camera_root,
+                calibration_dir=calibration,
+                colmap_binary=Path("/bin/true"),
+            )
+            pair_list = output / "candidate_pairs.txt"
+            pair_list.write_text(pair_list.read_text(encoding="utf-8") + "cam4_101.png cam5_100.png\n", encoding="utf-8")
+            with self.assertRaisesRegex(colmap.ValidationError, "pair-list hash mismatch"):
+                colmap.run_plan(output / "plan.json")
+
+    def test_run_plan_creates_mapper_output_directory_and_records_cam_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = self._candidate(root)
+            candidate_index = root / "candidate_shards"
+            benchmark.split_candidate_manifest(candidate, candidate_index, 1)
+            calibration = self._calibration(root)
+            camera_root = root / "camera_shards"
+            (camera_root / "cam4" / "images").mkdir(parents=True)
+            (camera_root / "cam5" / "images").mkdir(parents=True)
+            output = root / "control"
+            colmap.make_plan(
+                candidate_index=candidate_index / "index.json",
+                candidate_manifest=None,
+                output_root=output,
+                image_root=root / "images",
+                camera_root=camera_root,
+                calibration_dir=calibration,
+                colmap_binary=Path("/bin/true"),
+            )
+            result = colmap.run_plan(output / "plan.json")
+            self.assertTrue((output / "models").is_dir())
+            self.assertEqual(
+                sorted(result["phases"]),
+                ["feature_extractor_cam4", "feature_extractor_cam5", "mapper", "matches_importer"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add hash-validated prepare/match/map/resume runner for ETH3D electro
- add same-candidate official COLMAP CPU control and post-map scorer
- add fail-closed Python and shell validation coverage

## Stack
Depends on #51.

## Validation
- python3 -m unittest tests.test_benchmark_electro tests.test_benchmark_electro_colmap
- bash -n scripts/benchmark_electro.sh scripts/benchmark_electro_colmap.sh
- jq empty benchmarks/electro/colmap_1200_v1.json
- git diff --check