### PR TITLE
bench(electro): close the 300-image reliability gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ contract, so this is not an end-to-end speed claim. See the
 <a href="docs/electro_performance_roadmap.md">performance and memory roadmap</a>
 and <a href="benchmarks/electro/visloc_1200_v1.json">frozen result manifest</a>.</sub></p>
 
+<p align="center"><sub><a href="docs/assets/electro_1200_sfm_comparison.png">Open the full-resolution still comparison</a>.</sub></p>
+
+### 300-image reliability gate
+
+Before another 1,200-image tuning run, the resumable pipeline was killed,
+restarted, corrupted, and repeated on a frozen 300-image probe. The bounded
+K=64 schedule retained **99.871%** of exhaustive verified pairs and lost only
+**0.667 percentage point** of registration; two complete runs reproduced the
+same candidate, feature, snapshot, and COLMAP-model hashes.
+
+| Measured probe result | Bounded K=64 | Exhaustive control |
+| --- | ---: | ---: |
+| Candidate / verified pairs | 10,634 / 3,878 | 44,850 / 3,883 |
+| Verified-pair recall | **99.871%** | 100% |
+| Registered cameras | 200/300 | 202/300 |
+| Matching / mapper wall | 90.65 s / 75.97 s | 160.58 s / 90.38 s |
+| Mapper peak RSS | **169.7 MiB** | 170.2 MiB |
+
+<p align="center"><sub>Feature extraction was 630.76 s with 193.4 MiB peak
+RSS; the full generated feature + run footprint was 318.8 MiB. Same-size
+corruption is rejected and SIGKILL resume reproduces uninterrupted hashes. See the
+<a href="benchmarks/electro/electro-300-phase-ledger.json">phase ledger</a>
+and <a href="benchmarks/electro/electro-300-failure-injection.log">failure-injection record</a>.</sub></p>
+
 ## Measured courtyard SfM control
 
 <p align="center">

--- a/benchmarks/electro/electro-300-failure-injection.log
+++ b/benchmarks/electro/electro-300-failure-injection.log
@@ -1,0 +1,35 @@
+ETH3D electro 300-image M1 failure-injection record
+Recorded: 2026-09-01
+
+FEATURE EXTRACTION SIGKILL / RESUME
+- Injection: timeout --signal=KILL 8s, RAYON_NUM_THREADS=1, resumable SIFT stream export.
+- Exit status: 137.
+- Durable outputs at kill: 4 feature files, 4 loci files, 4 completion sidecars.
+- Temporary final-name files after kill: 0.
+- Resume log reused exactly 4 images; all remaining images were extracted.
+- Resumed and uninterrupted roots each contain 900 files.
+- Relative-path SHA-256 lists are byte-identical:
+  07609d6c6bbc2b1995b8a339cceb89dde5ceffdb39fa79c75b23d368d90f7f11
+
+MATCH SHARD SIGKILL / RESUME
+- Injection: timeout --signal=KILL 2s while shard 0 was running.
+- Exit status: 137; index retained shard 0 as running and shards 1..7 as pending.
+- Resume reran the incomplete shard and completed all 8 shards.
+- Resumed merged snapshot SHA-256:
+  b1c8897271af7ec435fe3ec735a30231ea3b4befaf61cebb6d99bf84dd237bbd
+- Two uninterrupted reference runs produced the same merged snapshot hash.
+
+SAME-SIZE CORRUPTION
+- Copied a completed artifact root, then replaced byte 0 of verified-000000.vps.
+- Size before and after: 1,441,640 bytes.
+- SHA-256 before:
+  12982752bd2e97ec2ab956bc999d322290ea9f5e1e060918048921cb2e621b27
+- SHA-256 after:
+  4ea595dfa6f82ca6e49d18eea2385d2d6646682a5dd27207e5c8debb3a24cab7
+- Before the runner fix, --verify-only incorrectly returned 0. A regression test and
+  complete-match-index validation were added.
+- After the fix, the valid root returned 0 and the corrupt root returned 1 with:
+  error: match shard 0 snapshot hash mismatch
+
+All failure injections used copies or dedicated external artifact roots. Ground truth
+was not available to feature extraction, candidate generation, matching, or mapping.

--- a/benchmarks/electro/electro-300-phase-ledger.json
+++ b/benchmarks/electro/electro-300-phase-ledger.json
@@ -1,0 +1,135 @@
+{
+  "schema": "visloc_electro_probe_phase_ledger_v1",
+  "recorded_at": "2026-09-01",
+  "benchmark": {
+    "id": "eth3d-electro-cam4-sequential-300-k64-cap512-v1",
+    "scene": "electro",
+    "image_count": 300,
+    "camera_count": 1,
+    "source_revision_base": "4eef6989ae50f58db01ad25284ae9eb293fef171",
+    "source_branch": "feat/electro-probe-reliability",
+    "source_had_uncommitted_changes": true,
+    "ground_truth_used_for_selection_or_mapping": false
+  },
+  "host": {
+    "cpu": "11th Gen Intel(R) Core(TM) i5-1145G7 @ 2.60GHz",
+    "logical_cpus": 8,
+    "memory_bytes": 33237082112,
+    "kernel": "Linux 7.0.0-30-generic x86_64"
+  },
+  "inputs": {
+    "feature_rows": 153600,
+    "feature_manifest_sha256": "8d259be603174613220a2395984893dbe2ab76ca69c1990032495a333e722315",
+    "candidate_policy": "vlad-union-v1",
+    "retrieval_topk": 64,
+    "local_stem_window": 3,
+    "candidate_pairs": 10634,
+    "candidate_manifest_sha256": "d2c1025c988570e21f9a2c78dcf73a8d51dbebad69d84cc5bd2aaf67cc933d5a",
+    "candidate_index_sha256": "90d69f73f5c150ca543bbeffb311f6384970778cd93b7f16ff64285346aa1b2b",
+    "candidate_shards": 16,
+    "pairs_per_shard": 700,
+    "verified_pairs": 3878,
+    "verified_correspondences": 271703,
+    "merged_snapshot_sha256": "14fc78c260dec0f9de9a88ad39125d443d84c796d80258ff7219c46520b4b762"
+  },
+  "phases": {
+    "feature_extraction_uninterrupted": {
+      "wall_s": 630.76,
+      "peak_rss_kib": 196984,
+      "output_files": 900,
+      "output_bytes": 292381375,
+      "file_list_sha256": "07609d6c6bbc2b1995b8a339cceb89dde5ceffdb39fa79c75b23d368d90f7f11"
+    },
+    "feature_extraction_resumed": {
+      "resume_wall_s": 626.29,
+      "peak_rss_kib": 198056,
+      "reused_images": 4,
+      "output_files": 900,
+      "file_list_sha256": "07609d6c6bbc2b1995b8a339cceb89dde5ceffdb39fa79c75b23d368d90f7f11"
+    },
+    "candidate_generation": {
+      "wall_s": 31.16,
+      "peak_rss_kib": 108200
+    },
+    "candidate_sharding": {
+      "wall_s": 0.030620871984865516
+    },
+    "matching": {
+      "shard_elapsed_sum_s": 90.65220290893922,
+      "peak_rss_kib": 121284
+    },
+    "merge": {
+      "wall_s": 0.15581606497289613,
+      "peak_rss_kib": 86036
+    },
+    "mapping": {
+      "wall_s": 75.97479640995152,
+      "peak_rss_kib": 173744
+    },
+    "scoring": {
+      "wall_s": 0.26,
+      "peak_rss_kib": 110320,
+      "reference_used_only_post_mapping": true
+    }
+  },
+  "determinism": {
+    "complete_runs": 2,
+    "candidate_index_exact": true,
+    "feature_manifest_exact": true,
+    "snapshot_exact": true,
+    "model_exact": true,
+    "cameras_txt_sha256": "7aa640a7e06329e63adb4d089bc5f4e2f0d53f43f77d8ec2b81483a1eae5cb81",
+    "images_txt_sha256": "3ee567a4c9173d4aa131f86ddff7e5d203b1346b1d94fd328ceed8247e2bb6ff",
+    "points3d_txt_sha256": "9bad99c530eeb6528e36a7ad4d4920241809bc37591d0221c0fd71097cf2b4f4"
+  },
+  "quality": {
+    "registered_images": 200,
+    "registered_fraction": 0.6666666666666666,
+    "tracks": 5863,
+    "mean_reprojection_px": 0.768,
+    "score": {
+      "rmse_m": 0.5333205811388725,
+      "median_m": 0.5105903120219273,
+      "p95_m": 0.8260768932038765,
+      "max_m": 1.044889163055154
+    }
+  },
+  "exhaustive_control": {
+    "candidate_pairs": 44850,
+    "candidate_manifest_sha256": "a1f1f0b80fd0a7f698ed31171256d5a8d4dbbaaec3691aea193999cc996d0850",
+    "verified_pairs": 3883,
+    "merged_snapshot_sha256": "92cfd3354bce99479429b82a47d412e615f18f2c607040dfd378c2b2751c8a88",
+    "registered_images": 202,
+    "verified_pair_recall": 0.998712335822817,
+    "registration_loss_percentage_points": 0.6666666666666666,
+    "score_rmse_m": 0.5409516970876312
+  },
+  "resource_gates": {
+    "max_process_peak_rss_kib": 198056,
+    "rss_limit_kib": 16777216,
+    "final_feature_plus_run_bytes": 334263515,
+    "disk_limit_bytes": 53687091200,
+    "rss_pass": true,
+    "disk_pass": true
+  },
+  "failure_injection": {
+    "feature_sigkill_exit_status": 137,
+    "feature_complete_sidecars_before_resume": 4,
+    "feature_temporary_files_after_kill": 0,
+    "match_sigkill_exit_status": 137,
+    "resumed_snapshot_matches_uninterrupted": true,
+    "same_size_corruption_rejected": true,
+    "details": "benchmarks/electro/electro-300-failure-injection.log"
+  },
+  "binaries": {
+    "unordered_sfm_demo_sha256": "50cf76ac8b017e05656bda9dd947116a0f4d9e07bb41eac6b5dfd457acaf47f6",
+    "merge_verified_pair_snapshots_sha256": "0572a6b0da938d136f30f2f2427cab7a84af7e13734012cd9806d37315678271",
+    "inspect_verified_pair_snapshot_sha256": "106f181bc76054024e577cb068558ec42570c6d714b96fd3d5803a4389851487"
+  },
+  "external_artifact_root": "/home/sasaki/datasets/eth3d/large_scale/electro/probe300_cam4_20260831",
+  "notes": [
+    "External paths are descriptive provenance only; dataset and generated artifacts are not committed.",
+    "The 300-image single-camera sequential probe is a reliability and resource gate, not the 1,200-image quality target.",
+    "The absolute camera-centre error remains an M2 optimization target."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -694,3 +694,26 @@ exhaustive championではない。manifest replay runのhashは
 10k級へ進む前に候補recall・登録率・再現hash・RSS/disk上限を確認する。
 この計画はdownload/large runを含まず、courtyard exhaustive 703-pair / 38/38 /
 0.005379 m gateとM3 200-pair A/Bを変更しない。
+
+## 18. Electro roadmap M0/M1 closure (2026-09-01)
+
+M0の6依存PRはmainへ統合済みで、README冒頭にはElectro 1,200画像のGIF・PNG・
+COLMAP比較表、courtyardのGIF・比較表、SfM demo commandを配置した。Electroの
+主張はmapper 9.61倍高速というphase claimに限定し、matching 4.43倍遅いこと、
+RSS 3.17倍、登録7画像差、feature extraction未計測のためend-to-end claimでは
+ないことを同じ表で明示している。
+
+M1の300画像single-camera probeはK=64、local stem window 3、cap512、10,634
+candidateで凍結した。exhaustive 44,850 candidate / 3,883 verifiedに対して
+3,878 verified（99.871% recall）、登録200/300対202/300（loss 0.667 percentage
+point）で両gateを満たす。独立2 runのcandidate index、feature manifest、merged
+snapshot、cameras/images/points3D hashは完全一致した。feature SIGKILLでは4画像の
+sidecarを再利用して900 fileがuninterrupted runと一致し、match SIGKILL resumeも
+merged snapshotが一致した。同サイズ1-byte破損が当初verify-onlyを通る不具合を
+発見し、complete match indexをverify modeでも再検証するよう修正した。
+
+証跡は benchmarks/electro/electro-300-phase-ledger.json と
+benchmarks/electro/electro-300-failure-injection.log。次はroadmap M2で、同じ
+12,000 pairのElectro 1,200画像における7未登録画像をfirst-divergence ledgerと
+cap32/64/96/128/uncapped controlで切り分ける。M1の300画像absolute RMSE 0.533 mは
+quality championではなく、M2で改善する対象である。

--- a/docs/electro_performance_roadmap.md
+++ b/docs/electro_performance_roadmap.md
@@ -120,6 +120,16 @@ baseline commit that introduced the discrepancy.
 
 ## 4. Milestone 1 — calibrate measurement and restart behavior
 
+**Status (2026-09-01): complete.** The K=64 bounded probe retains 3,878 of
+3,883 exhaustive verified pairs (99.871%) and registers 200/300 images versus
+202/300 exhaustive (0.667 percentage-point loss). Two complete runs reproduce
+candidate, feature, snapshot, and model hashes. Feature and match SIGKILL
+resume paths reproduce uninterrupted artifacts, and same-size snapshot
+corruption now fails closed. Peak process RSS was 198,056 KiB and the final
+feature-plus-run footprint was 334,263,515 bytes. Evidence is frozen in
+benchmarks/electro/electro-300-phase-ledger.json and
+benchmarks/electro/electro-300-failure-injection.log.
+
 **Purpose:** prove the runner and resource accounting on the 300-image probe
 before expensive quality or performance searches on 1,200 images.
 

--- a/examples/inspect_verified_pair_snapshot.rs
+++ b/examples/inspect_verified_pair_snapshot.rs
@@ -1,0 +1,85 @@
+//! Inspect a verified-pair snapshot without rerunning matching or mapping.
+//!
+//! The TSV output is intentionally simple so benchmark scripts can compute
+//! verified-edge recall against a diagnostic control while the binary codec
+//! remains implemented and validated in Rust.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use visloc_rs::verified_pair_snapshot::read;
+
+fn usage() -> ! {
+    eprintln!("usage: inspect_verified_pair_snapshot --snapshot PATH [--pairs-tsv PATH]");
+    std::process::exit(2);
+}
+
+fn next_path(args: &[String], index: &mut usize, flag: &str) -> Result<PathBuf, String> {
+    let Some(value) = args.get(*index + 1) else {
+        return Err(format!("{flag} requires PATH"));
+    };
+    *index += 1;
+    if value.trim().is_empty() {
+        return Err(format!("{flag} requires a non-empty PATH"));
+    }
+    Ok(PathBuf::from(value))
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        usage();
+    }
+    let mut snapshot_path = None;
+    let mut pairs_path = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--snapshot" => snapshot_path = Some(next_path(&args, &mut index, "--snapshot")?),
+            "--pairs-tsv" => pairs_path = Some(next_path(&args, &mut index, "--pairs-tsv")?),
+            "-h" | "--help" => usage(),
+            other => return Err(format!("unknown argument {other:?}")),
+        }
+        index += 1;
+    }
+    let snapshot_path = snapshot_path.ok_or_else(|| "--snapshot is required".to_owned())?;
+    let snapshot = read(&snapshot_path)
+        .map_err(|error| format!("invalid snapshot {}: {error}", snapshot_path.display()))?;
+    if let Some(path) = pairs_path {
+        let mut tsv = String::from(
+            "image_i\timage_j\traw_matches\taccepted_matches\te_inliers\tf_inliers\th_inliers\n",
+        );
+        for pair in &snapshot.pairs {
+            writeln!(
+                tsv,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                pair.image_i,
+                pair.image_j,
+                pair.raw_match_count,
+                pair.matches.len(),
+                pair.e_inlier_count,
+                pair.f_inlier_count,
+                pair.h_inlier_count,
+            )
+            .map_err(|error| error.to_string())?;
+        }
+        std::fs::write(&path, tsv)
+            .map_err(|error| format!("cannot write {}: {error}", path.display()))?;
+    }
+    println!(
+        "images={} verified_pairs={} accepted_correspondences={} pair_order_hash={:016x} unordered_edge_hash={:016x}",
+        snapshot.image_names.len(),
+        snapshot.pairs.len(),
+        snapshot.accepted_match_count,
+        snapshot.pair_order_hash,
+        snapshot.unordered_edge_hash,
+    );
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -7222,7 +7222,6 @@ fn snapshot_metadata_matches_pair(pair: &PairwiseMatches, metadata: &SnapshotPai
 
 fn write_verified_pair_snapshot(
     path: &Path,
-    effective_config: &str,
     image_names: &[String],
     features: &[FeatureSet],
     camera: &Camera,
@@ -7248,6 +7247,7 @@ fn write_verified_pair_snapshot(
         })
         .collect();
     let verifier_config = snapshot_verifier_config(args);
+    let snapshot_config = snapshot_export_config(args);
     let snapshot = VerifiedPairSnapshot {
         schema_version: verified_pair_snapshot::SCHEMA_VERSION,
         image_names: image_names.to_vec(),
@@ -7257,8 +7257,13 @@ fn write_verified_pair_snapshot(
         width: u64::from(camera.width),
         height: u64::from(camera.height),
         intrinsics_bits: snapshot_intrinsics_bits(camera)?,
-        effective_config_hash: effective_config_hash(effective_config),
-        effective_config: effective_config.to_owned(),
+        // The full Args debug snapshot is already in the phase log. It
+        // contains candidate/output paths, so storing it here made otherwise
+        // identical snapshots differ across resumable run roots. Keep the
+        // binary envelope path-independent; pair hashes and the runner index
+        // retain the data/provenance bindings.
+        effective_config_hash: effective_config_hash(&snapshot_config),
+        effective_config: snapshot_config,
         verifier_config_hash: effective_config_hash(&verifier_config),
         verifier_config,
         pair_order_hash: ordered_pairwise_edge_hash(pairwise),
@@ -7341,6 +7346,10 @@ fn snapshot_verifier_config(args: &Args) -> String {
         args.force_essential_uncalibrated_only,
         args.colmap_guided_matching,
     )
+}
+
+fn snapshot_export_config(args: &Args) -> String {
+    format!("verified-pair-export-v1;{}", snapshot_verifier_config(args))
 }
 
 /// Hash the exact pair and correspondence order consumed by track building.
@@ -14817,7 +14826,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(path) = args.export_verified_pairs_snapshot.as_deref() {
         write_verified_pair_snapshot(
             path,
-            &config_snapshot,
             &image_names,
             &features,
             &args.camera,
@@ -15635,7 +15643,7 @@ mod diagnose_cli_tests {
         parse_args_from, parse_candidate_manifest, parse_candidate_manifest_with_metadata,
         parse_colmap_image_camera_assignments, parse_colmap_track_membership, parse_diagnose_stems,
         remap_feature_keypoints_by_old_to_new, replace_feature_keypoints_from_native,
-        rig_local_pairs, rig_temporal_pyramid_pairs, robust_huber_mean,
+        rig_local_pairs, rig_temporal_pyramid_pairs, robust_huber_mean, snapshot_export_config,
         summarize_model_cross_validation_bucket, temporal_pyramid_offsets_string,
         translation_direction_delta_deg, unordered_pairwise_edge_hash, validate_diagnose_options,
         verified_pair_oracle_map, write_candidate_manifest, write_candidate_manifest_with_metadata,
@@ -17603,6 +17611,18 @@ mod diagnose_cli_tests {
             effective_config_hash(""),
             0xcbf29ce484222325,
             "the snapshot label uses the stable FNV-1a offset basis"
+        );
+        let mut path_a = parse_args_from(minimal_args(&[])).unwrap();
+        let mut path_b = parse_args_from(minimal_args(&[])).unwrap();
+        path_a.out_colmap = PathBuf::from("/tmp/electro-repeat-a/model");
+        path_b.out_colmap = PathBuf::from("/tmp/electro-repeat-b/model");
+        assert_ne!(
+            effective_config_snapshot(&path_a),
+            effective_config_snapshot(&path_b)
+        );
+        assert_eq!(
+            snapshot_export_config(&path_a),
+            snapshot_export_config(&path_b)
         );
 
         // Every experimental mapper/verification switch is opt-in. Values

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -36,6 +36,7 @@ CANDIDATE_INDEX_SCHEMA = "visloc_electro_candidate_shards_v1"
 MATCH_INDEX_SCHEMA = "visloc_electro_match_shards_v1"
 FEATURE_MANIFEST_SCHEMA = "visloc_electro_feature_manifest_v1"
 SHA256_RE = set("0123456789abcdef")
+GNU_TIME = Path("/usr/bin/time")
 
 
 class ValidationError(RuntimeError):
@@ -541,15 +542,108 @@ def validate_feature_manifest(
     }
 
 
-def _run_command(command: list[str], log_path: Path, *, cwd: Path = REPO_ROOT) -> float:
+def parse_gnu_time(path: Path) -> dict[str, Any]:
+    """Parse the stable resource fields emitted by ``/usr/bin/time -v``."""
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationError(f"cannot read GNU time report {path}: {exc}") from exc
+    fields: dict[str, str] = {}
+    for line in lines:
+        if ":" not in line:
+            continue
+        key, value = line.strip().split(":", 1)
+        fields[key] = value.strip()
+
+    def number(key: str, *, integer: bool = False) -> float | int:
+        value = fields.get(key)
+        if value is None:
+            raise ValidationError(f"GNU time report {path} is missing {key!r}")
+        try:
+            return int(value) if integer else float(value)
+        except ValueError as exc:
+            raise ValidationError(
+                f"GNU time report {path} has invalid {key!r}: {value!r}"
+            ) from exc
+
+    return {
+        "user_s": number("User time (seconds)"),
+        "system_s": number("System time (seconds)"),
+        "peak_rss_kib": number("Maximum resident set size (kbytes)", integer=True),
+        "major_page_faults": number("Major (requiring I/O) page faults", integer=True),
+        "minor_page_faults": number("Minor (reclaiming a frame) page faults", integer=True),
+        "filesystem_inputs": number("File system inputs", integer=True),
+        "filesystem_outputs": number("File system outputs", integer=True),
+        "exit_status": number("Exit status", integer=True),
+        "report": str(path.resolve()),
+        "report_sha256": sha256_file(path),
+    }
+
+
+def measured_phase(path: Path, elapsed_s: float) -> dict[str, Any]:
+    measurement = parse_gnu_time(path)
+    measurement["elapsed_s"] = elapsed_s
+    return measurement
+
+
+def carry_forward_phase_ledger(
+    current: dict[str, Any], previous: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Keep completed phase measurements across prepare/match/map invocations."""
+
+    if not isinstance(previous, dict):
+        return current
+    result = dict(current)
+    for key in ("candidate_generation", "candidate_sharding", "merge", "mapping"):
+        if result.get(key) is None and previous.get(key) is not None:
+            result[key] = previous[key]
+    return result
+
+
+def tree_bytes(path: Path) -> int:
+    """Return allocated artifact bytes without following symlinks."""
+
+    total = 0
+    if not path.exists():
+        return total
+    for entry in path.rglob("*"):
+        if entry.is_file() and not entry.is_symlink():
+            try:
+                total += entry.stat().st_size
+            except OSError as exc:
+                raise ValidationError(f"cannot stat artifact {entry}: {exc}") from exc
+    return total
+
+
+def _run_command(
+    command: list[str],
+    log_path: Path,
+    *,
+    cwd: Path = REPO_ROOT,
+    timing_path: Path | None = None,
+) -> float:
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    executed = command
+    if timing_path is not None:
+        if not GNU_TIME.is_file():
+            raise ValidationError(f"GNU time executable is missing: {GNU_TIME}")
+        timing_path.parent.mkdir(parents=True, exist_ok=True)
+        executed = [str(GNU_TIME), "-v", "-o", str(timing_path), "--", *command]
     started = time.monotonic()
-    print(f"$ {shlex.join(command)}", file=sys.stderr)
+    print(f"$ {shlex.join(executed)}", file=sys.stderr)
     try:
         with log_path.open("w", encoding="utf-8") as log:
-            result = subprocess.run(command, cwd=cwd, stdout=log, stderr=subprocess.STDOUT, check=False)
+            result = subprocess.run(
+                executed,
+                cwd=cwd,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=False,
+                env={**os.environ, "LC_ALL": "C"},
+            )
     except OSError as exc:
-        raise ValidationError(f"cannot execute {command[0]}: {exc}") from exc
+        raise ValidationError(f"cannot execute {executed[0]}: {exc}") from exc
     if result.returncode != 0:
         tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-30:]
         raise ValidationError(f"command failed ({result.returncode}): {shlex.join(command)}\n" + "\n".join(tail))
@@ -745,7 +839,12 @@ def prepare_match_index(candidate_index_path: Path, output_dir: Path) -> dict[st
     return index
 
 
-def validate_match_index(index_path: Path, candidate_index_path: Path) -> dict[str, Any]:
+def validate_match_index(
+    index_path: Path,
+    candidate_index_path: Path,
+    *,
+    require_complete: bool = False,
+) -> dict[str, Any]:
     candidate = validate_candidate_shards(candidate_index_path)
     index_path = index_path.resolve()
     index = _load_json(index_path, "match index")
@@ -766,6 +865,10 @@ def validate_match_index(index_path: Path, candidate_index_path: Path) -> dict[s
         status = entry.get("status")
         if status not in {"pending", "running", "complete", "failed"}:
             raise ValidationError(f"match index shard {expected_id} has invalid status {status!r}")
+        if require_complete and status != "complete":
+            raise ValidationError(
+                f"match shard {expected_id} is not complete (status {status!r})"
+            )
         if status == "complete":
             snapshot_path = index_path.parent / _safe_relative(entry.get("snapshot_path", ""), f"match shard {expected_id} snapshot path")
             expected_hash = _sha256(entry.get("snapshot_sha256"), f"match shard {expected_id} snapshot hash")
@@ -817,13 +920,25 @@ def run_match_shards(
             match_ratio=match_ratio,
         )
         try:
-            elapsed = _run_command(command, root / f"match-{shard_id:06d}.log")
+            timing_path = root / "timing" / f"match-{shard_id:06d}.time.txt"
+            elapsed = _run_command(
+                command,
+                root / f"match-{shard_id:06d}.log",
+                timing_path=timing_path,
+            )
             digest = sha256_file(snapshot_path)
         except (ValidationError, OSError):
             entry["status"] = "failed"
             atomic_json(match_index_path, index)
             raise
-        entry.update({"status": "complete", "snapshot_sha256": digest, "elapsed_s": elapsed})
+        entry.update(
+            {
+                "status": "complete",
+                "snapshot_sha256": digest,
+                "elapsed_s": elapsed,
+                "measurement": measured_phase(timing_path, elapsed),
+            }
+        )
         atomic_json(match_index_path, index)
     validated = validate_match_index(match_index_path, candidate_index_path)
     complete = [entry for entry in validated["index"]["shards"] if entry["status"] == "complete"]
@@ -855,8 +970,19 @@ def merge_match_shards(match_index_path: Path, *, merge_binary: Path, output: Pa
         if sha256_file(path) != expected:
             raise ValidationError(f"match snapshot hash mismatch: {path}")
         snapshots.append(path)
-    elapsed = _run_command(build_merge_command(merge_binary, output, snapshots), root / "merge.log")
-    return {"output": str(output), "sha256": sha256_file(output), "shards": len(snapshots), "elapsed_s": elapsed}
+    timing_path = root / "timing" / "merge.time.txt"
+    elapsed = _run_command(
+        build_merge_command(merge_binary, output, snapshots),
+        root / "merge.log",
+        timing_path=timing_path,
+    )
+    return {
+        "output": str(output),
+        "sha256": sha256_file(output),
+        "shards": len(snapshots),
+        "elapsed_s": elapsed,
+        "measurement": measured_phase(timing_path, elapsed),
+    }
 
 
 def _binary(path: str | None, default: Path) -> Path:
@@ -930,6 +1056,7 @@ def main(argv: list[str] | None = None) -> int:
             raise ValidationError(f"features directory is missing: {features_dir}")
         if not calibration_dir.is_dir():
             raise ValidationError(f"calibration directory is missing: {calibration_dir}")
+        feature_validation_started = time.monotonic()
         feature_manifest_path = (args.feature_manifest or artifact_root / "features.json").resolve()
         if feature_manifest_path.is_file():
             feature_summary = validate_feature_manifest(
@@ -940,6 +1067,10 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValidationError(f"feature manifest is missing: {feature_manifest_path}")
             feature_summary = feature_manifest(features_dir, feature_suffix=args.feature_suffix, source_dir=args.images_dir)
             write_feature_manifest(feature_manifest_path, feature_summary)
+            feature_summary = validate_feature_manifest(
+                feature_manifest_path, features_dir, source_dir=args.images_dir
+            )
+        feature_validation_elapsed = time.monotonic() - feature_validation_started
         candidate_source = args.candidate_manifest
         if candidate_source is None:
             candidate_source = artifact_root / "candidates.txt"
@@ -952,10 +1083,15 @@ def main(argv: list[str] | None = None) -> int:
             merge_binary = _binary(args.merge_binary, REPO_ROOT / "target" / "release" / "examples" / "merge_verified_pair_snapshots")
         candidate_dir = artifact_root / "candidates"
         candidate_index_path = candidate_dir / "index.json"
+        candidate_measurement = None
+        candidate_sharding_elapsed = None
+        merge_result = None
+        mapping_measurement = None
         if mode in {"prepare", "run"}:
             if not candidate_source.is_file():
                 candidate_source.parent.mkdir(parents=True, exist_ok=True)
-                _run_command(
+                candidate_timing_path = artifact_root / "timing" / "candidate-generation.time.txt"
+                candidate_elapsed = _run_command(
                     build_candidate_command(
                         binary,
                         features_dir=features_dir,
@@ -972,7 +1108,12 @@ def main(argv: list[str] | None = None) -> int:
                         temporal_pyramid_max_offset=args.temporal_pyramid_max_offset,
                     ),
                     artifact_root / "candidate-generation.log",
+                    timing_path=candidate_timing_path,
                 )
+                candidate_measurement = measured_phase(
+                    candidate_timing_path, candidate_elapsed
+                )
+            sharding_started = time.monotonic()
             split_candidate_manifest(
                 candidate_source,
                 candidate_dir,
@@ -995,6 +1136,7 @@ def main(argv: list[str] | None = None) -> int:
                     else None
                 ),
             )
+            candidate_sharding_elapsed = time.monotonic() - sharding_started
         if mode in {"verify", "match", "map"} and not candidate_index_path.is_file():
             raise ValidationError(f"candidate index is missing: {candidate_index_path}; run --prepare first")
         candidate_summary = validate_candidate_shards(candidate_index_path)
@@ -1005,6 +1147,10 @@ def main(argv: list[str] | None = None) -> int:
             )
         match_dir = artifact_root / "matches"
         match_index_path = match_dir / "index.json"
+        if mode == "verify" and match_index_path.is_file():
+            validate_match_index(
+                match_index_path, candidate_index_path, require_complete=True
+            )
         if mode in {"match", "run"}:
             if not match_index_path.is_file() or args.no_resume:
                 prepare_match_index(candidate_index_path, match_dir)
@@ -1022,14 +1168,17 @@ def main(argv: list[str] | None = None) -> int:
                 resume=not args.no_resume,
             )
             merged_snapshot = artifact_root / "mapping" / "verified-merged.vps"
-            merge_match_shards(match_index_path, merge_binary=merge_binary, output=merged_snapshot)
+            merge_result = merge_match_shards(
+                match_index_path, merge_binary=merge_binary, output=merged_snapshot
+            )
         else:
             merged_snapshot = artifact_root / "mapping" / "verified-merged.vps"
         if mode in {"map", "run"}:
             if not merged_snapshot.is_file():
                 raise ValidationError(f"merged snapshot is missing: {merged_snapshot}; run --match first")
             output_model = artifact_root / "mapping" / "colmap"
-            _run_command(
+            mapping_timing_path = artifact_root / "timing" / "mapping.time.txt"
+            mapping_elapsed = _run_command(
                 build_mapping_command(
                     binary,
                     features_dir=features_dir,
@@ -1044,7 +1193,48 @@ def main(argv: list[str] | None = None) -> int:
                     final_ba=not args.no_final_ba,
                 ),
                 artifact_root / "mapping.log",
+                timing_path=mapping_timing_path,
             )
+            mapping_measurement = measured_phase(mapping_timing_path, mapping_elapsed)
+        match_measurements = []
+        if match_index_path.is_file():
+            match_index = _load_json(match_index_path, "match index")
+            match_measurements = [
+                entry["measurement"]
+                for entry in match_index.get("shards", [])
+                if isinstance(entry, dict) and isinstance(entry.get("measurement"), dict)
+            ]
+        phase_ledger = {
+            "feature_manifest_validation": {
+                "elapsed_s": feature_validation_elapsed,
+                "feature_extraction_included": False,
+            },
+            "candidate_generation": candidate_measurement,
+            "candidate_sharding": (
+                {"elapsed_s": candidate_sharding_elapsed}
+                if candidate_sharding_elapsed is not None
+                else None
+            ),
+            "match_shards": match_measurements,
+            "matching_elapsed_sum_s": sum(
+                float(entry.get("elapsed_s", 0.0)) for entry in match_measurements
+            ),
+            "matching_peak_rss_kib": max(
+                (int(entry.get("peak_rss_kib", 0)) for entry in match_measurements),
+                default=0,
+            ),
+            "merge": merge_result["measurement"] if merge_result else None,
+            "mapping": mapping_measurement,
+        }
+        previous_summary_path = artifact_root / "summary.json"
+        previous_phase_ledger = None
+        if previous_summary_path.is_file():
+            previous_summary = _load_json(previous_summary_path, "previous run summary")
+            if previous_summary.get("schema") == "visloc_electro_run_summary_v1":
+                previous_phase_ledger = previous_summary.get("phase_ledger")
+        phase_ledger = carry_forward_phase_ledger(
+            phase_ledger, previous_phase_ledger
+        )
         summary = {
             "schema": "visloc_electro_run_summary_v1",
             "mode": mode,
@@ -1055,6 +1245,8 @@ def main(argv: list[str] | None = None) -> int:
             "match_index": str(match_index_path) if match_index_path.is_file() else None,
             "merged_snapshot": str(merged_snapshot) if merged_snapshot.is_file() else None,
             "merged_snapshot_sha256": sha256_file(merged_snapshot) if merged_snapshot.is_file() else None,
+            "phase_ledger": phase_ledger,
+            "artifact_bytes": tree_bytes(artifact_root),
             "ground_truth_used_for_selection_or_mapping": False,
         }
         atomic_json(artifact_root / "summary.json", summary)

--- a/scripts/score_electro_model.py
+++ b/scripts/score_electro_model.py
@@ -70,7 +70,42 @@ def _rotation(qw: float, qx: float, qy: float, qz: float) -> np.ndarray:
     )
 
 
-def load_centres(path: Path) -> dict[tuple[int, int], np.ndarray]:
+def load_aliases(path: Path, *, camera: int | None = None) -> dict[str, str]:
+    """Load ``alias -> canonical electro name`` from a staging TSV."""
+
+    try:
+        rows = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ScoreError(f"cannot read image aliases {path}: {exc}") from exc
+    if not rows or rows[0].split("\t") != ["index", "alias", "source_name"]:
+        raise ScoreError(f"image aliases {path} have an unsupported header")
+    aliases: dict[str, str] = {}
+    for line_number, row in enumerate(rows[1:], 2):
+        fields = row.split("\t")
+        if len(fields) != 3 or not fields[0].isdigit():
+            raise ScoreError(f"image alias row {path}:{line_number} is malformed")
+        alias, source_name = fields[1:]
+        canonical = source_name
+        try:
+            image_key(canonical)
+        except ScoreError:
+            stem = Path(source_name).stem
+            if camera is None or not stem.isdigit():
+                raise ScoreError(
+                    f"image alias source {source_name!r} needs --query-alias-camera"
+                )
+            canonical = f"cam{camera}_{source_name}"
+        if not alias or alias in aliases:
+            raise ScoreError(f"image aliases {path} contain an empty or duplicate alias")
+        aliases[alias] = canonical
+    if not aliases:
+        raise ScoreError(f"image aliases {path} contain no mappings")
+    return aliases
+
+
+def load_centres(
+    path: Path, aliases: dict[str, str] | None = None
+) -> dict[tuple[int, int], np.ndarray]:
     """Load camera centres from a COLMAP text ``images.txt``."""
 
     try:
@@ -100,6 +135,13 @@ def load_centres(path: Path) -> dict[tuple[int, int], np.ndarray]:
         except ValueError as exc:
             raise ScoreError(f"COLMAP pose row {path}:{line_number} is not numeric") from exc
         name = fields[9]
+        if aliases is not None:
+            try:
+                name = aliases[name]
+            except KeyError as exc:
+                raise ScoreError(
+                    f"COLMAP image {fields[9]!r} is absent from the query aliases"
+                ) from exc
         key = image_key(name)
         if key in centres:
             raise ScoreError(f"COLMAP model contains duplicate electro image key {key}: {path}")
@@ -156,10 +198,15 @@ def validate_reference_geometry(reference: dict[tuple[int, int], np.ndarray]) ->
     return extent
 
 
-def score(reference_path: Path, query_path: Path) -> dict[str, Any]:
+def score(
+    reference_path: Path,
+    query_path: Path,
+    *,
+    query_aliases: dict[str, str] | None = None,
+) -> dict[str, Any]:
     reference = load_centres(reference_path)
     reference_extent = validate_reference_geometry(reference)
-    query = load_centres(query_path)
+    query = load_centres(query_path, query_aliases)
     common = sorted(set(reference) & set(query))
     if len(common) < 3:
         raise ScoreError(
@@ -206,6 +253,12 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("reference", type=Path, help="official electro model images.txt")
     parser.add_argument("query", type=Path, help="completed COLMAP model images.txt")
+    parser.add_argument("--query-aliases", type=Path, help="staging image_aliases.tsv")
+    parser.add_argument(
+        "--query-alias-camera",
+        type=int,
+        help="camera number when alias source names contain only a timestamp",
+    )
     parser.add_argument("--output-json", type=Path, help="write the score object to this path")
     return parser
 
@@ -213,7 +266,16 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
-        result = score(args.reference.resolve(), args.query.resolve())
+        aliases = None
+        if args.query_aliases:
+            aliases = load_aliases(
+                args.query_aliases.resolve(), camera=args.query_alias_camera
+            )
+        elif args.query_alias_camera is not None:
+            raise ScoreError("--query-alias-camera requires --query-aliases")
+        result = score(
+            args.reference.resolve(), args.query.resolve(), query_aliases=aliases
+        )
         if args.output_json:
             args.output_json.parent.mkdir(parents=True, exist_ok=True)
             args.output_json.write_text(json.dumps(result, sort_keys=True, indent=2) + "\n", encoding="utf-8")

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -44,9 +44,10 @@ pub struct PairRecord {
     pub relative_translation_bits: Option<[u64; 3]>,
 }
 
-/// Complete snapshot envelope.  Manifest/configuration hashes are checked on
-/// import; the textual forms remain in the file so a failed validation can be
-/// diagnosed without guessing which command produced the snapshot.
+/// Complete snapshot envelope. Manifest/configuration hashes are checked on
+/// import. The embedded configuration is deliberately path-independent so
+/// the same inputs produce identical bytes in different resumable run roots;
+/// full command paths remain in the runner log and shard index.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Snapshot {
     pub schema_version: u32,

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -7,6 +7,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -44,6 +45,111 @@ class ElectroBenchmarkTests(unittest.TestCase):
             with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
                 benchmark.validate_candidate_shards(root / "candidates" / "index.json")
 
+    def test_measured_command_records_peak_rss_and_exit_status(self) -> None:
+        if not benchmark.GNU_TIME.is_file():
+            self.skipTest("GNU time is unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            timing = root / "true.time.txt"
+            elapsed = benchmark._run_command(
+                ["/bin/true"], root / "true.log", cwd=root, timing_path=timing
+            )
+            measurement = benchmark.measured_phase(timing, elapsed)
+            self.assertEqual(measurement["exit_status"], 0)
+            self.assertGreaterEqual(measurement["peak_rss_kib"], 0)
+            self.assertGreaterEqual(measurement["elapsed_s"], 0.0)
+
+    def test_phase_ledger_keeps_completed_prior_phases(self) -> None:
+        current = {
+            "candidate_generation": None,
+            "candidate_sharding": None,
+            "merge": None,
+            "mapping": {"elapsed_s": 3.0},
+        }
+        previous = {
+            "candidate_generation": {"elapsed_s": 1.0},
+            "candidate_sharding": {"elapsed_s": 0.1},
+            "merge": {"elapsed_s": 2.0},
+            "mapping": None,
+        }
+        self.assertEqual(
+            benchmark.carry_forward_phase_ledger(current, previous),
+            {
+                "candidate_generation": {"elapsed_s": 1.0},
+                "candidate_sharding": {"elapsed_s": 0.1},
+                "merge": {"elapsed_s": 2.0},
+                "mapping": {"elapsed_s": 3.0},
+            },
+        )
+
+    def test_interrupted_match_shard_is_rerun_and_corruption_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _, _ = self._candidate(root)
+            benchmark.split_candidate_manifest(source, root / "candidates", 10)
+            candidate_index = root / "candidates" / "index.json"
+            benchmark.prepare_match_index(candidate_index, root / "matches")
+            match_index = root / "matches" / "index.json"
+
+            def interrupted(command, _log_path, **_kwargs):
+                snapshot = Path(command[command.index("--export-verified-pairs-snapshot") + 1])
+                snapshot.write_bytes(b"partial")
+                raise benchmark.ValidationError("injected interruption")
+
+            with mock.patch.object(benchmark, "_run_command", side_effect=interrupted):
+                with self.assertRaisesRegex(benchmark.ValidationError, "injected"):
+                    benchmark.run_match_shards(
+                        candidate_index,
+                        match_index,
+                        binary=Path("/bin/visloc"),
+                        features_dir=root,
+                        calibration_dir=root,
+                    )
+            failed = json.loads(match_index.read_text(encoding="utf-8"))
+            self.assertEqual(failed["shards"][0]["status"], "failed")
+
+            def completed(command, _log_path, *, timing_path=None, **_kwargs):
+                snapshot = Path(command[command.index("--export-verified-pairs-snapshot") + 1])
+                snapshot.write_bytes(b"complete")
+                assert timing_path is not None
+                timing_path.parent.mkdir(parents=True, exist_ok=True)
+                timing_path.write_text(
+                    "\n".join(
+                        [
+                            "User time (seconds): 0.01",
+                            "System time (seconds): 0.00",
+                            "Maximum resident set size (kbytes): 1024",
+                            "Major (requiring I/O) page faults: 0",
+                            "Minor (reclaiming a frame) page faults: 1",
+                            "File system inputs: 0",
+                            "File system outputs: 8",
+                            "Exit status: 0",
+                        ]
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return 0.01
+
+            with mock.patch.object(benchmark, "_run_command", side_effect=completed):
+                benchmark.run_match_shards(
+                    candidate_index,
+                    match_index,
+                    binary=Path("/bin/visloc"),
+                    features_dir=root,
+                    calibration_dir=root,
+                )
+            complete = json.loads(match_index.read_text(encoding="utf-8"))
+            self.assertEqual(complete["shards"][0]["status"], "complete")
+            self.assertEqual(complete["shards"][0]["measurement"]["peak_rss_kib"], 1024)
+
+            snapshot = root / "matches" / complete["shards"][0]["snapshot_path"]
+            payload = bytearray(snapshot.read_bytes())
+            payload[0] ^= 1
+            snapshot.write_bytes(payload)
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_match_index(match_index, candidate_index)
+
     def test_candidate_metadata_survives_sharding_and_tampering_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -66,9 +172,26 @@ class ElectroBenchmarkTests(unittest.TestCase):
             self.assertEqual(parsed[2], metadata)
             benchmark.validate_candidate_shards(root / "candidates" / "index.json")
             shard = root / "candidates" / "candidate-000000.txt"
-            shard.write_text(shard.read_text(encoding="utf-8").replace("same-timestamp", "other"), encoding="utf-8")
+            shard.write_text(
+                shard.read_text(encoding="utf-8").replace("same-timestamp", "other"),
+                encoding="utf-8",
+            )
             with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
                 benchmark.validate_candidate_shards(root / "candidates" / "index.json")
+
+    def test_complete_verification_rejects_pending_match_shard(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _, _ = self._candidate(root)
+            benchmark.split_candidate_manifest(source, root / "candidates", 10)
+            candidate_index = root / "candidates" / "index.json"
+            benchmark.prepare_match_index(candidate_index, root / "matches")
+            with self.assertRaisesRegex(benchmark.ValidationError, "not complete"):
+                benchmark.validate_match_index(
+                    root / "matches" / "index.json",
+                    candidate_index,
+                    require_complete=True,
+                )
 
     def test_resume_rewrites_corrupt_candidate_shard_atomically(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -237,6 +360,52 @@ class ElectroBenchmarkTests(unittest.TestCase):
             )
             summary = json.loads((root / "summary.json").read_text(encoding="utf-8"))
             self.assertFalse(summary["ground_truth_used_for_selection_or_mapping"])
+
+    def test_verify_mode_rejects_corrupt_complete_match_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            features = root / "features"
+            features.mkdir()
+            for image_id in range(2):
+                (features / f"{image_id:06d}_features.txt").write_text(
+                    "0 0 1 2\n", encoding="utf-8"
+                )
+            feature_manifest = benchmark.feature_manifest(features)
+            benchmark.write_feature_manifest(root / "features.json", feature_manifest)
+            source = root / "source.txt"
+            benchmark.write_candidate_manifest(
+                source, ["000000.png", "000001.png"], [(0, 1)]
+            )
+            benchmark.split_candidate_manifest(source, root / "candidates", 1)
+            candidate_index = root / "candidates" / "index.json"
+            benchmark.prepare_match_index(candidate_index, root / "matches")
+            match_index = root / "matches" / "index.json"
+            index = json.loads(match_index.read_text(encoding="utf-8"))
+            snapshot = root / "matches" / index["shards"][0]["snapshot_path"]
+            snapshot.write_bytes(b"complete")
+            index["shards"][0].update(
+                {
+                    "status": "complete",
+                    "snapshot_sha256": benchmark.sha256_file(snapshot),
+                }
+            )
+            benchmark.atomic_json(match_index, index)
+            snapshot.write_bytes(b"Xomplete")
+
+            self.assertEqual(
+                benchmark.main(
+                    [
+                        "--verify-only",
+                        "--features-dir",
+                        str(features),
+                        "--calibration-dir",
+                        str(root),
+                        "--artifact-root",
+                        str(root),
+                    ]
+                ),
+                1,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_electro_colmap.py
+++ b/tests/test_benchmark_electro_colmap.py
@@ -147,6 +147,19 @@ class ElectroColmapControlTests(unittest.TestCase):
         with self.assertRaises(score.ScoreError):
             score.image_key("frame_0001.png")
 
+    def test_score_loads_numeric_staging_aliases_with_camera(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            aliases_path = Path(directory) / "image_aliases.tsv"
+            aliases_path.write_text(
+                "index\talias\tsource_name\n"
+                "0\t000000.png\t1474975187520882738.png\n",
+                encoding="utf-8",
+            )
+            aliases = score.load_aliases(aliases_path, camera=4)
+            self.assertEqual(
+                aliases, {"000000.png": "cam4_1474975187520882738.png"}
+            )
+
     def test_score_rejects_identity_staging_reference(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Outcome
- makes verified-pair snapshots path-independent across resumable run roots
- adds GNU time phase/RSS accounting, complete verify-only validation, and cross-invocation ledger retention
- proves feature/match SIGKILL resume and same-size corruption rejection
- freezes the 300-image K=64 vs exhaustive ledger (99.871% verified-pair recall, 0.667 pp registration loss)
- adds snapshot inspection and numeric staging-alias scoring
- keeps the README showcase visual-first with GIF, full-resolution PNG, COLMAP comparison, and a compact reliability table

## Validation
- cargo test -p visloc-slam (577 passed, 7 ignored; integration suites pass)
- cargo test --example unordered_sfm_demo --features image-io (50 passed)
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-targets --features image-io -- -D warnings
- Python benchmark, scorer, docs-asset, and registry tests (29 passed)
- actual valid artifact verify=0; same-size corrupt artifact verify=1
- two K=64 runs: identical candidate, feature, snapshot, cameras, images, and points3D hashes