### PR TITLE
perf: add persistent Electro matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to `visloc-rs` will be documented here.
 
 ### Added
 
+- **Persistent Electro matcher and end-to-end performance audit (2026-09-01).**
+  Added an opt-in, versioned persistent-worker plan that loads the feature bank
+  once, writes atomic resumable match shards, validates recovery state
+  strictly, and merges shard payloads by ownership instead of cloning them.
+  Exact one-GEMM cross-check matching and strict-winner RANSAC early exits keep
+  the frozen 12,000-pair snapshot byte-identical. On Electro 1,200, median
+  matching wall fell from 2,085.89 s to **439.01 s (4.75x)**; the owned merge
+  cut peak RSS 22.3% to 1.56 GiB. A fresh byte-identical feature/candidate run
+  plus the memory-bounded mapper completes conservatively in **1,649.48 s**,
+  versus COLMAP's 5,705.05 s (**3.46x faster**), while retaining 1200/1200 at
+  0.03501 m centre RMSE. Added a machine-readable audit, recovery tests,
+  detailed report, and an above-the-fold README GIF/image/comparison table.
+
 - **Memory-bounded Electro snapshot replay (2026-09-01).** Added the explicit,
   default-off `--snapshot-keypoints-only` path for file-backed verified-pair
   snapshot replay with the plain incremental mapper. It retains keypoints and

--- a/README.md
+++ b/README.md
@@ -17,31 +17,36 @@
   <img src="docs/assets/electro_1200_sfm_comparison.gif" alt="Measured ETH3D Electro 1,200-image reconstruction: visloc-rs and COLMAP camera centres, sparse structure, residuals, mapper time, and peak memory" width="820">
 </p>
 
-**visloc-rs now registers all 1,200 cameras with 25.2% lower centre RMSE than
-COLMAP. Its memory-bounded snapshot replay is 14.63× faster on the same frozen
-12,000-pair workload while peaking at 1.39 GiB; the fastest exact-model replay
-remains 18.36× faster.** Matching is still 4.43× slower and feature extraction
-has not yet been measured under the same contract, so this is a phase-level
-result rather than an end-to-end speed claim.
+**visloc-rs completes the measured CPU8 pipeline 3.46× faster than COLMAP
+while registering all 1,200 cameras with 25.2% lower centre RMSE.** The new
+persistent matcher is itself 1.074× faster on the identical frozen 12,000-pair
+manifest, and the memory-bounded mapper is 14.63× faster. Every accepted run
+reproduces the same snapshot and model bytes.
 
-| Same-input phase / result | Memory-bounded visloc | Fastest visloc | COLMAP 3.9.1 CPU |
+| Same-input CPU8 phase / result | visloc-rs | COLMAP 3.9.1 CPU | Winner |
 | --- | ---: | ---: | ---: |
-| Exact-pair matching | 2,085.89 s | 2,085.89 s | **471.37 s** |
-| Snapshot-to-model / mapper wall (2-run median) | **336.90 s (14.63×)** | **268.49 s (18.36×)** | 4,929.56 s |
-| Peak RSS | **1.39 GiB** | 3.83 GiB | **1.20 GiB** |
-| Registered cameras | **1200/1200** | **1200/1200** | **1200/1200** |
-| Camera-centre RMSE | **3.50 cm** | **3.50 cm** | 4.68 cm |
-| Model reproducibility | byte-identical ×2 | byte-identical ×2 | frozen control |
+| Feature extraction | 721.42 s | **304.12 s** | COLMAP 2.37× |
+| Manifest validation + candidate generation/sharding | 148.58 s | frozen manifest supplied | — |
+| Exact-pair matching + merge | **442.58 s** | 471.37 s | **visloc 1.06×** |
+| Mapper / model writing | **336.90 s** | 4,929.56 s | **visloc 14.63×** |
+| Conservative end-to-end wall | **1,649.48 s** | 5,705.05 s | **visloc 3.46×** |
+| Matching peak RSS | 1.89 GiB | **0.26 GiB** | COLMAP |
+| Mapper peak RSS | 1.39 GiB | **1.20 GiB** | COLMAP |
+| Registered cameras | **1200/1200** | **1200/1200** | parity |
+| Camera-centre RMSE | **3.50 cm** | 4.68 cm | **visloc −25.2%** |
+| Reproducibility | exact snapshot ×3; exact model ×2 | frozen control | verified |
 
 <p align="center"><sub>The camera-centre plot uses all 1,200 stems and Sim(3)
 alignment to the supplied calibration proxy. Ground truth is score-only. The
 two visloc columns use the same explicit 96-correspondence mapper cap, one
 bounded post-refinement registration pass, four 8-iteration global solves, and
 no follow-up global-refinement rounds; these controls are not global defaults.
-The memory-bounded replay additionally re-reads one feature file at a time to
-validate the descriptor-bound snapshot hash, then keeps keypoints only. Its
-1,459,194 KiB median peak is 63.6% below the prior visloc run and 1.16× the
-COLMAP peak. See the
+The visloc total conservatively includes its candidate generation; COLMAP
+consumes the already frozen identical candidate manifest. The two systems
+extract and verify their own features/matches. The memory-bounded replay
+re-reads one feature file at a time to validate the descriptor-bound snapshot
+hash, then keeps keypoints only. Its 1,459,194 KiB median peak is 63.6% below
+the prior visloc run and 1.16× the COLMAP mapper peak. See the
 <a href="docs/electro_performance_roadmap.md">performance and memory roadmap</a>
 and <a href="benchmarks/electro/quality-attribution.json">quality-attribution ledger</a>.</sub></p>
 <p align="center"><sub>BA implementation and all nine A/B timings:
@@ -51,8 +56,15 @@ and <a href="benchmarks/electro/quality-attribution.json">quality-attribution le
 <p align="center"><sub>Descriptor-lifetime audit, two-run memory trace, and
 exact-model proof: <a href="docs/electro_snapshot_memory_audit.md">1.39 GiB
 snapshot replay report</a>.</sub></p>
+<p align="center"><sub>Persistent worker, three-run matching median,
+bounded merge, byte-identical feature re-extraction, and end-to-end ledger:
+<a href="docs/electro_persistent_matcher_audit.md">3.46× CPU8 report</a>.</sub></p>
 
-<p align="center"><sub><a href="docs/assets/electro_1200_sfm_comparison.png">Open the full-resolution still comparison</a>.</sub></p>
+<p align="center">
+  <a href="docs/assets/electro_1200_sfm_comparison.png"><img src="docs/assets/electro_1200_sfm_comparison.png" alt="Full-resolution ETH3D Electro comparison with aligned camera centres, sparse structure, error distribution, mapper wall, and peak memory" width="820"></a><br>
+  <sub>Full-resolution measured still · camera centres are ordered by timestamp
+  and camera; sparse points are a deterministic final-model sample.</sub>
+</p>
 
 ### 300-image reliability gate
 

--- a/benchmarks/electro/persistent-matcher-audit.json
+++ b/benchmarks/electro/persistent-matcher-audit.json
@@ -1,0 +1,157 @@
+{
+  "schema": "visloc_electro_persistent_matcher_audit_v1",
+  "recorded_at": "2026-09-01",
+  "scene": "electro",
+  "images": 1200,
+  "candidate_policy": "temporal-pyramid-v1",
+  "candidate_pairs": 12000,
+  "candidate_shards": 375,
+  "pairs_per_shard": 32,
+  "verified_pairs": 11625,
+  "accepted_correspondences": 7475384,
+  "execution": {
+    "implementation_parent_commit": "29068b75653bfcfff2b00432b320a0d959e692b8",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)",
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "unordered_sfm_demo_sha256": "5adb56811bc84525e2570df57614002ac9dbea84950266aabdbe155fd9e3970d",
+    "merge_helper_sha256": "8277f0b8441ef9f46a645d3fa7f350ab88dfbffe258e07e0e23ae79c22fe8234",
+    "cpu_affinity": "taskset -c 0-7",
+    "rayon_num_threads": 4,
+    "malloc_arena_max": 1,
+    "feature_dir": "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/staging1200/features_vlfeat2048",
+    "image_dir": "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/staging1200/images",
+    "calibration_dir": "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/staging1200/calibration",
+    "feature_manifest_sha256": "d6ddbde3ae2d7743baf8b99f1ed748966f46c3fa716157212446aa238ed24cf9",
+    "candidate_index_sha256": "131b1ccd48f75c52f6fdf7285d29f825d52a3a83225b89e6eb34a45ec698c5c1",
+    "worker_plan_sha256": "3fff61e0a7277056bd1527bf7015fa1562f956ad28c8b3413f999aa6606f1692"
+  },
+  "implementation": {
+    "mode": "persistent-v1",
+    "default_enabled": false,
+    "feature_bank_loads": 1,
+    "matcher": "NN Lowe 0.8 plus cross-check",
+    "verification": "full",
+    "cross_check_dot_products": "one GEMM, one column-major bidirectional top-2 scan",
+    "ransac_pruning": "strict-winner upper-bound exit; sampling and winning model unchanged",
+    "publication": "per-shard atomic snapshots followed by owned bounded-memory merge",
+    "resume": "hash-valid complete shards only"
+  },
+  "runs": [
+    {
+      "worker_wall_seconds": 439.0054540539859,
+      "shard_elapsed_sum_seconds": 378.041782434,
+      "worker_peak_rss_kib": 1981752,
+      "merge_wall_seconds": 3.2920387759804726,
+      "merge_peak_rss_kib": 1632432,
+      "merged_snapshot_sha256": "55b2c1d9ec30df502e14d8f2de44b80042742428df4a62efbd903cd2850051f3"
+    },
+    {
+      "worker_wall_seconds": 399.69246310496237,
+      "shard_elapsed_sum_seconds": 344.967814169,
+      "worker_peak_rss_kib": 1981352,
+      "merge_wall_seconds": 3.5714121549972333,
+      "merge_peak_rss_kib": 1632656,
+      "merged_snapshot_sha256": "55b2c1d9ec30df502e14d8f2de44b80042742428df4a62efbd903cd2850051f3"
+    },
+    {
+      "worker_wall_seconds": 442.61989656003425,
+      "shard_elapsed_sum_seconds": 381.481673868,
+      "worker_peak_rss_kib": 1969708,
+      "merge_wall_seconds": 3.6209028249722905,
+      "merge_peak_rss_kib": 1632484,
+      "merged_snapshot_sha256": "55b2c1d9ec30df502e14d8f2de44b80042742428df4a62efbd903cd2850051f3"
+    }
+  ],
+  "median": {
+    "worker_wall_seconds": 439.0054540539859,
+    "shard_elapsed_sum_seconds": 378.041782434,
+    "worker_peak_rss_kib": 1981352,
+    "worker_peak_rss_gib": 1.8895645141601562,
+    "merge_wall_seconds": 3.5714121549972333,
+    "merge_peak_rss_kib": 1632484,
+    "merge_peak_rss_gib": 1.5568580627441406
+  },
+  "comparison": {
+    "prior_visloc_matching_seconds": 2085.89,
+    "speedup_vs_prior_visloc": 4.751402068409568,
+    "colmap_matching_seconds": 471.37,
+    "colmap_matching_peak_rss_kib": 270248,
+    "speedup_vs_colmap": 1.073722423371155,
+    "wall_reduction_vs_colmap_percent": 6.865670152927416,
+    "worker_rss_ratio_vs_colmap": 7.331607265733327,
+    "pre_owned_merge_peak_rss_kib": 2102056,
+    "owned_merge_peak_rss_reduction_percent": 22.33869735221173
+  },
+  "end_to_end": {
+    "feature_extraction": {
+      "execution": "eight fixed 150-image workers on CPU8",
+      "command_flags": [
+        "--sift-max-keypoints=2048",
+        "--sift-contrast-threshold=0.0066666667",
+        "--sift-vlfeat-compatible-detector",
+        "--sift-vlfeat-compatible-descriptor",
+        "--sift-vlfeat-bilinear-orientations",
+        "--sift-vlfeat-compatible-output-order",
+        "--sift-colmap-compatible-grayscale",
+        "--sift-stream-export",
+        "--export-features-only"
+      ],
+      "wall_seconds": 721.42,
+      "maximum_single_worker_peak_rss_kib": 200388,
+      "feature_files": 1200,
+      "locus_files": 1200,
+      "output_bytes": 4032291915,
+      "feature_locus_sha256_list": "00d54f69ca7fd89a3e8ea016ce3d2c94eb6988e81b7d4048814373b0432cd9c6",
+      "matches_frozen_bank_byte_for_byte": true
+    },
+    "feature_manifest_validation_seconds": 12.779213440022431,
+    "candidate_generation_seconds": 134.90865257498808,
+    "candidate_sharding_seconds": 0.895997753017582,
+    "candidate_generation_peak_rss_kib": 1907036,
+    "candidate_manifest_sha256": "1b5cece6bddd718cf8ca3dbc167654b0cbfeaf03f482d9783a5b9edf155c1186",
+    "candidate_manifest_matches_frozen_control": true,
+    "persistent_matching_median_seconds": 439.0054540539859,
+    "owned_merge_median_seconds": 3.5714121549972333,
+    "memory_bounded_mapper_median_seconds": 336.895,
+    "visloc_conservative_total_seconds": 1649.4757299770113,
+    "colmap_feature_extraction_seconds": 304.12,
+    "colmap_matching_seconds": 471.37,
+    "colmap_mapper_seconds": 4929.56,
+    "colmap_total_seconds": 5705.05,
+    "speedup_vs_colmap": 3.4587050274935,
+    "accounting_note": "visloc total conservatively includes its 12.78 s manifest validation and 135.80 s candidate generation/sharding; COLMAP consumes the already frozen identical candidate manifest",
+    "quality": {
+      "registered": 1200,
+      "rmse_m": 0.03501132650718982,
+      "p95_m": 0.07709687017668192,
+      "model_byte_identical_to_memory_bounded_champion": true
+    },
+    "passed": true,
+    "external_artifacts": [
+      "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/m4_feature_extract_cpu8",
+      "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/m4_end_to_end_prepare_cpu8"
+    ]
+  },
+  "integrity": {
+    "canonical_merged_snapshot_sha256": "55b2c1d9ec30df502e14d8f2de44b80042742428df4a62efbd903cd2850051f3",
+    "legacy_path_bound_snapshot_sha256": "93bf51451866cc066718b827d0ecec8f498ffc23842bd2c1e3902fd7a2697a86",
+    "legacy_migration": "pair records are identical; merge canonicalizes the old path-containing effective config to the verifier config",
+    "repeat_snapshot_byte_identical": true,
+    "single_shard_old_new_sha256": "dd483410581c977ab86c3c60668d271cb6e5b80346c14c368eff95f713cb0367",
+    "ground_truth_used_for_selection_or_mapping": false
+  },
+  "gate": {
+    "maximum_median_matching_seconds": 471.37,
+    "maximum_peak_rss_kib": 2097152,
+    "snapshot_must_match_canonical_oracle": true,
+    "matching_parity_passed": true,
+    "end_to_end_faster_than_colmap": true,
+    "memory_passed": true,
+    "integrity_passed": true
+  },
+  "external_artifacts": [
+    "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/runner_full1200_temporal_b12000/persistent_worker_b32_single_scan_run1",
+    "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/runner_full1200_temporal_b12000/persistent_worker_b32_single_scan_run2",
+    "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/runner_full1200_temporal_b12000/persistent_worker_b32_single_scan_run3"
+  ]
+}

--- a/benchmarks/electro/snapshot-memory-audit.json
+++ b/benchmarks/electro/snapshot-memory-audit.json
@@ -99,6 +99,11 @@
   },
   "readme_visuals": {
     "generator": "scripts/generate_electro_readme_visuals.py",
+    "visloc_model": "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/runner_full1200_temporal_b12000/mapping/m3-snapshot-keypoints-only-i8",
+    "colmap_model": "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/runner_full1200_temporal_b12000/colmap_temporal_candidate12000/models_txt/0",
+    "reference_model": "/home/sasaki/datasets/eth3d/large_scale/electro/full1200_20260831/electro/rig_calibration_undistorted",
+    "metrics_source": "this audit's median, quality, and comparison fields",
+    "display_semantics": "timestamp/camera ordered centre overlay with a deterministic final-model sparse-point sample; not mapper registration progress",
     "png_sha256": "4a98f145b479ceb8b1ffc2e489847f5129803d8b20f618e3a9883fbb940f459b",
     "png_dimensions": [1690, 936],
     "gif_sha256": "13e2fd25e45811c14f851badefb8101f0ba69f0fdd20a51e4145aba0b68efb82",

--- a/crates/vision/src/matching/mod.rs
+++ b/crates/vision/src/matching/mod.rs
@@ -48,6 +48,142 @@ impl BruteForceMatcher {
             .sum::<f32>();
         Some(squared.sqrt())
     }
+
+    /// Match with a mutual-nearest-neighbour check using one descriptor
+    /// matrix product for both directions.
+    ///
+    /// This is equivalent to wrapping this matcher in [`CrossCheckMatcher`],
+    /// but avoids recomputing the transposed dot-product matrix.
+    pub fn match_descriptors_cross_checked(
+        &self,
+        query: &[Vec<f32>],
+        train: &[Vec<f32>],
+    ) -> Vec<DescriptorMatch> {
+        let n_query = query.len();
+        let n_train = train.len();
+        if n_query == 0 || n_train == 0 {
+            return Vec::new();
+        }
+        let dim = query[0].len();
+        let uniform = dim != 0
+            && query.iter().all(|descriptor| descriptor.len() == dim)
+            && train.iter().all(|descriptor| descriptor.len() == dim);
+        if !uniform {
+            let forward = self.match_descriptors_elementwise(query, train);
+            let reverse = self.match_descriptors_elementwise(train, query);
+            let mut reverse_best_query_by_train = vec![None; n_train];
+            for descriptor_match in reverse {
+                reverse_best_query_by_train[descriptor_match.query_index] =
+                    Some(descriptor_match.train_index);
+            }
+            return forward
+                .into_iter()
+                .filter(|descriptor_match| {
+                    reverse_best_query_by_train[descriptor_match.train_index]
+                        == Some(descriptor_match.query_index)
+                })
+                .collect();
+        }
+
+        let q = nalgebra::DMatrix::from_fn(n_query, dim, |i, k| query[i][k]);
+        let t = nalgebra::DMatrix::from_fn(n_train, dim, |j, k| train[j][k]);
+        let dots = q * t.transpose();
+        let query_norm_sq: Vec<f32> = query
+            .iter()
+            .map(|descriptor| descriptor.iter().map(|value| value * value).sum())
+            .collect();
+        let train_norm_sq: Vec<f32> = train
+            .iter()
+            .map(|descriptor| descriptor.iter().map(|value| value * value).sum())
+            .collect();
+
+        // nalgebra matrices are column-major. Walk every dot product once in
+        // its contiguous order and update both directional top-2 states. The
+        // query index still increases within each train column, and each
+        // query observes train indices in increasing outer-loop order, so the
+        // original strict-`<` first-wins tie behavior is preserved.
+        let mut forward_best = vec![None; n_query];
+        let mut forward_second = vec![None; n_query];
+        let mut reverse_best = vec![None; n_train];
+        let mut reverse_second = vec![None; n_train];
+        for train_index in 0..n_train {
+            for query_index in 0..n_query {
+                let dot = dots[(query_index, train_index)];
+                let reverse_score = query_norm_sq[query_index] - 2.0 * dot;
+                if reverse_best[train_index]
+                    .is_none_or(|(_, best_score)| reverse_score < best_score)
+                {
+                    reverse_second[train_index] =
+                        reverse_best[train_index].map(|(_, best_score)| best_score);
+                    reverse_best[train_index] = Some((query_index, reverse_score));
+                } else if reverse_second[train_index]
+                    .is_none_or(|second_score| reverse_score < second_score)
+                {
+                    reverse_second[train_index] = Some(reverse_score);
+                }
+
+                let forward_score = train_norm_sq[train_index] - 2.0 * dot;
+                if forward_best[query_index]
+                    .is_none_or(|(_, best_score)| forward_score < best_score)
+                {
+                    forward_second[query_index] = forward_best[query_index];
+                    forward_best[query_index] = Some((train_index, forward_score));
+                } else if forward_second[query_index]
+                    .is_none_or(|(_, second_score)| forward_score < second_score)
+                {
+                    forward_second[query_index] = Some((train_index, forward_score));
+                }
+            }
+        }
+
+        let mut reverse_best_query_by_train = vec![None; n_train];
+        for train_index in 0..n_train {
+            let Some((query_index, best_score)) = reverse_best[train_index] else {
+                continue;
+            };
+            let distance = (train_norm_sq[train_index] + best_score).max(0.0).sqrt();
+            let second_distance = reverse_second[train_index]
+                .map(|second_score| (train_norm_sq[train_index] + second_score).max(0.0).sqrt());
+            if self
+                .ratio
+                .zip(second_distance)
+                .is_some_and(|(ratio, second)| distance >= ratio * second)
+            {
+                continue;
+            }
+            reverse_best_query_by_train[train_index] = Some(query_index);
+        }
+
+        let mut matches = Vec::new();
+        for query_index in 0..n_query {
+            let Some((train_index, best_score)) = forward_best[query_index] else {
+                continue;
+            };
+            if reverse_best_query_by_train[train_index] != Some(query_index) {
+                continue;
+            }
+            let distance = (query_norm_sq[query_index] + best_score).max(0.0).sqrt();
+            let second_distance = forward_second[query_index].map(|(_, second_score)| {
+                (query_norm_sq[query_index] + second_score).max(0.0).sqrt()
+            });
+            if self
+                .ratio
+                .zip(second_distance)
+                .is_some_and(|(ratio, second)| distance >= ratio * second)
+            {
+                continue;
+            }
+            matches.push(DescriptorMatch {
+                query_index,
+                train_index,
+                distance,
+                second_best_distance: second_distance,
+                ratio: second_distance.map(|second| distance / second),
+                confidence: None,
+            });
+        }
+        matches
+    }
 }
 
 impl Matcher for BruteForceMatcher {
@@ -247,6 +383,46 @@ where
 #[cfg(test)]
 mod tests {
     use super::{BruteForceMatcher, CrossCheckMatcher, Matcher};
+
+    #[test]
+    fn single_gemm_cross_check_matches_two_pass_reference() {
+        for (query_count, train_count, dim) in [(3, 5, 4), (17, 11, 32), (9, 13, 128)] {
+            let descriptors = |count: usize, salt: usize| {
+                (0..count)
+                    .map(|row| {
+                        (0..dim)
+                            .map(|column| {
+                                let value = (row * 131 + column * 17 + salt * 29) % 251;
+                                (value as f32 - 125.0) / 127.0
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let query = descriptors(query_count, 3);
+            let train = descriptors(train_count, 7);
+            for ratio in [None, Some(0.8), Some(0.95)] {
+                let matcher = BruteForceMatcher { ratio };
+                let reference = CrossCheckMatcher::new(matcher).match_descriptors(&query, &train);
+                assert_eq!(
+                    matcher.match_descriptors_cross_checked(&query, &train),
+                    reference
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn single_gemm_cross_check_preserves_mixed_dimension_fallback() {
+        let query = vec![vec![0.0, 1.0], vec![1.0]];
+        let train = vec![vec![0.0, 1.0], vec![2.0]];
+        let matcher = BruteForceMatcher { ratio: Some(0.8) };
+        let reference = CrossCheckMatcher::new(matcher).match_descriptors(&query, &train);
+        assert_eq!(
+            matcher.match_descriptors_cross_checked(&query, &train),
+            reference
+        );
+    }
 
     #[test]
     fn matches_nearest_descriptor_with_ratio_test() {

--- a/crates/vision/src/two_view/fundamental.rs
+++ b/crates/vision/src/two_view/fundamental.rs
@@ -170,7 +170,14 @@ pub fn fundamental_ransac(
         let Some(candidate) = estimate_fundamental_dlt(&sample) else {
             continue;
         };
-        let inliers = score_fundamental_inliers(&candidate, correspondences, threshold_sq);
+        let Some(inliers) = score_fundamental_inliers_if_competitive(
+            &candidate,
+            correspondences,
+            threshold_sq,
+            best_inliers.len(),
+        ) else {
+            continue;
+        };
         if inliers.len() > best_inliers.len() {
             best_inliers = inliers;
             best_fundamental = Some(candidate);
@@ -209,4 +216,23 @@ fn score_fundamental_inliers(
         .filter(|(_, c)| fundamental_squared_sampson_error(fundamental, c) <= threshold_sq)
         .map(|(i, _)| i)
         .collect()
+}
+
+fn score_fundamental_inliers_if_competitive(
+    fundamental: &Matrix3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    threshold_sq: f64,
+    incumbent_count: usize,
+) -> Option<Vec<usize>> {
+    let mut inliers = Vec::new();
+    for (i, correspondence) in correspondences.iter().enumerate() {
+        if fundamental_squared_sampson_error(fundamental, correspondence) <= threshold_sq {
+            inliers.push(i);
+        }
+        let remaining = correspondences.len() - i - 1;
+        if inliers.len() + remaining <= incumbent_count {
+            return None;
+        }
+    }
+    Some(inliers)
 }

--- a/crates/vision/src/two_view/homography.rs
+++ b/crates/vision/src/two_view/homography.rs
@@ -151,7 +151,14 @@ pub fn homography_ransac(
         let Some(candidate) = estimate_homography_dlt(&sample) else {
             continue;
         };
-        let inliers = score_homography_inliers(&candidate, correspondences, threshold_sq);
+        let Some(inliers) = score_homography_inliers_if_competitive(
+            &candidate,
+            correspondences,
+            threshold_sq,
+            best_inliers.len(),
+        ) else {
+            continue;
+        };
         if inliers.len() > best_inliers.len() {
             best_inliers = inliers;
             best_homography = Some(candidate);
@@ -192,6 +199,25 @@ fn score_homography_inliers(
             Some(i)
         })
         .collect()
+}
+
+fn score_homography_inliers_if_competitive(
+    homography: &Matrix3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    threshold_sq: f64,
+    incumbent_count: usize,
+) -> Option<Vec<usize>> {
+    let mut inliers = Vec::new();
+    for (i, correspondence) in correspondences.iter().enumerate() {
+        if homography_squared_error(homography, correspondence).is_some_and(|e| e <= threshold_sq) {
+            inliers.push(i);
+        }
+        let remaining = correspondences.len() - i - 1;
+        if inliers.len() + remaining <= incumbent_count {
+            return None;
+        }
+    }
+    Some(inliers)
 }
 
 /// One candidate `(rotation, translation, plane_normal)` motion from

--- a/crates/vision/src/two_view/mod.rs
+++ b/crates/vision/src/two_view/mod.rs
@@ -323,7 +323,15 @@ where
                 continue;
             };
 
-            let inliers = score_inliers(&candidate, correspondences, camera, threshold_sq);
+            let Some(inliers) = score_inliers_if_competitive(
+                &candidate,
+                correspondences,
+                camera,
+                threshold_sq,
+                best_inliers.len(),
+            ) else {
+                continue;
+            };
             if inliers.len() > best_inliers.len() {
                 best_inliers = inliers;
                 best_essential = Some(candidate);
@@ -355,6 +363,31 @@ where
             mean_sampson_error: mean,
         })
     }
+}
+
+/// Scores a RANSAC hypothesis only while it can still strictly beat the
+/// incumbent. The loop's winner update uses `>`, so equality cannot change
+/// the selected model and the unvisited suffix is safe to skip.
+fn score_inliers_if_competitive(
+    essential: &Matrix3<f64>,
+    correspondences: &[TwoViewCorrespondence],
+    camera: &Camera,
+    threshold_sq: f64,
+    incumbent_count: usize,
+) -> Option<Vec<usize>> {
+    let mut inliers = Vec::new();
+    for (i, correspondence) in correspondences.iter().enumerate() {
+        if sampson_distance_squared(essential, correspondence, camera)
+            .is_some_and(|distance_sq| distance_sq <= threshold_sq)
+        {
+            inliers.push(i);
+        }
+        let remaining = correspondences.len() - i - 1;
+        if inliers.len() + remaining <= incumbent_count {
+            return None;
+        }
+    }
+    Some(inliers)
 }
 
 /// Gates applied when selecting among the four essential-matrix (R, t)

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -2,8 +2,17 @@
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`
-**ブランチ:** `perf/electro-m3-snapshot-memory`
-**現在地:** M0/M1/M2とM3の速度PRはmainへ統合済み。M3 memory PRではdefault-offの`--snapshot-keypoints-only`を追加し、Electro 1200枚の2回の完全runで **1200/1200、RMSE 0.03501 m、既存championと3 model hashが完全一致、peak RSS中央値1,459,194 KiB (1.39 GiB)** を確認した。旧3.83 GiBから63.6%削減し、2 GiB gateを通過。descriptor hashは較正後に1ファイルずつ再読込して既存snapshot manifestと完全照合する。snapshot-to-model wall中央値336.90 sで同一pairのCOLMAP mapperより14.63倍高速。次はこのPRのCI/merge後にM4 persistent matcherとend-to-end計測へ進む。
+**ブランチ:** `perf/electro-m4-persistent-matcher`
+**現在地:** M0–M3はmainへ統合済み。M4ではdefault-offのpersistent
+matcher、single-GEMM cross-check、single-scan top-2、exact RANSAC枝刈り、
+owned bounded-memory mergeを実装した。Electro 1200枚・同一12,000 pairの
+3回runで **snapshot SHA完全一致、matching中央値439.01 s、worker peak
+RSS中央値1.89 GiB** を確認し、COLMAP 471.37 sを1.074倍上回った。CPU8
+feature extractionは721.42 sで全2,400 feature/locusファイルが旧bankと
+byte一致。candidate/mapperを含む保守的end-to-endは **1,649.48 s対
+5,705.05 s（3.46倍高速）**、品質は1200/1200、RMSE 0.03501 m、mapper
+peak 1.39 GiBを維持。次はM4のCI/merge/branch整理後、M5の全ETH3D
+scene・単一大規模環境・10k/100k I/O stressへ進む。
 
 今後の実装順、数値ゲート、PR境界、停止条件は
 [`docs/electro_performance_roadmap.md`](electro_performance_roadmap.md) を正とする。

--- a/docs/electro_performance_roadmap.md
+++ b/docs/electro_performance_roadmap.md
@@ -20,8 +20,10 @@ run with the same deterministic 12,000-pair `temporal-pyramid-v1` candidate
 manifest.
 
 The merged verified-pair snapshot contains 11,625 verified pairs and
-7,475,384 correspondences; its SHA-256 is
-`93bf51451866cc066718b827d0ecec8f498ffc23842bd2c1e3902fd7a2697a86`.
+7,475,384 correspondences; its path-independent canonical SHA-256 is
+`55b2c1d9ec30df502e14d8f2de44b80042742428df4a62efbd903cd2850051f3`.
+The former `93bf...a86` artifact has identical pair records but embedded an
+absolute path in its diagnostic effective config.
 
 | phase / metric | visloc-rs M2 champion | COLMAP 3.9.1 CPU | gap |
 | --- | ---: | ---: | ---: |
@@ -32,6 +34,13 @@ The merged verified-pair snapshot contains 11,625 verified pairs and
 | registered images | 1200 / 1200 | 1200 / 1200 | parity |
 | centre RMSE after Sim(3) | 0.03224 m | 0.04679 m | visloc 31.1% lower |
 | median / p95 | 0.01719 / 0.07150 m | 0.03156 / 0.09681 m | visloc lower |
+
+The completed M4 CPU8 pipeline now measures 721.42 s feature extraction,
+148.58 s manifest validation plus candidate generation/sharding, 439.01 s
+persistent matching, 3.57 s owned merge, and 336.90 s memory-bounded mapping:
+1,649.48 s conservatively charged end to end versus COLMAP's 5,705.05 s.
+Both regenerate the same frozen candidate manifest; visloc's feature/locus
+bank is byte-identical to the quality champion.
 
 The frozen cap64 baseline and its pre-memory-optimization control are
 byte-identical. The memory work reduced peak RSS from 8,485,216 KiB to
@@ -281,6 +290,20 @@ Work proceeds in this order, one PR and A/B per item:
   `<COLMAP` mapper result is retained as a hard non-regression ceiling.
 
 ## 7. Milestone 4 — matching and end-to-end speed
+
+**Status (2026-09-01): complete.** A versioned default-off persistent worker
+loads the descriptor bank once, atomically publishes 375 ordered shards, and
+resumes only hash-valid completions. One GEMM plus a single column-major
+bidirectional top-two scan preserves cross-check bytes; strict-winner RANSAC
+upper-bound exits preserve the selected hypotheses. Three complete runs
+reproduced the canonical snapshot SHA exactly. Matching wall was 439.01 s
+median (1.074x faster than COLMAP's 471.37 s) at 1.89 GiB median peak RSS.
+The owned merge reduced peak RSS from 2,102,056 to 1,632,484 KiB without
+changing output. A fresh CPU8 extraction regenerated all 2,400 feature/locus
+files byte for byte, and the conservative end-to-end total is 1,649.48 s,
+3.46x faster than COLMAP while retaining 1200/1200 and 0.03501 m RMSE.
+Evidence: [`persistent-matcher-audit.json`](../benchmarks/electro/persistent-matcher-audit.json)
+and [`electro_persistent_matcher_audit.md`](electro_persistent_matcher_audit.md).
 
 **Purpose:** remove the current 24-fold feature-bank reload pattern and beat
 COLMAP on the exact same pair workload.

--- a/docs/electro_persistent_matcher_audit.md
+++ b/docs/electro_persistent_matcher_audit.md
@@ -1,0 +1,77 @@
+# Electro persistent matcher audit
+
+The M4 persistent worker loads the frozen 1,200-image descriptor bank once,
+then processes 375 ordered 32-pair shards in one Rust process. Each shard is
+published atomically and remains independently hash-valid for restart. The
+final merge moves owned pair payloads instead of cloning the complete decoded
+stream.
+
+The accepted implementation also computes cross-check matching from one GEMM
+and one column-major scan that updates both directional top-two states. Safe
+RANSAC scoring exits only when the unvisited suffix cannot strictly beat the
+incumbent. Neither optimization changes sampling, strict tie order, accepted
+indices, pair order, or snapshot bytes.
+
+| Frozen 12,000-pair result | Run 1 | Run 2 | Run 3 | Median |
+| --- | ---: | ---: | ---: | ---: |
+| Persistent worker wall | 439.01 s | 399.69 s | 442.62 s | **439.01 s** |
+| Shard elapsed sum | 378.04 s | 344.97 s | 381.48 s | **378.04 s** |
+| Worker peak RSS | 1,981,752 KiB | 1,981,352 KiB | 1,969,708 KiB | **1.89 GiB** |
+| Owned merge wall | 3.29 s | 3.57 s | 3.62 s | **3.57 s** |
+| Owned merge peak RSS | 1,632,432 KiB | 1,632,656 KiB | 1,632,484 KiB | **1.56 GiB** |
+
+COLMAP 3.9.1 CPU matched the same frozen candidate manifest in 471.37 s.
+The persistent visloc worker is therefore **1.074x faster** (6.9% less wall
+time) and 4.75x faster than the former 2,085.89 s multi-process visloc path.
+COLMAP's matching memory remains substantially lower (270,248 KiB versus
+1.89 GiB).
+
+## CPU8 end-to-end result
+
+Eight fixed 150-image workers re-extracted the 1,200-image bank in 721.42 s.
+All 1,200 feature files and 1,200 locus files match the frozen bank byte for
+byte; their sorted SHA-256 list hashes to
+`00d54f69ca7fd89a3e8ea016ce3d2c94eb6988e81b7d4048814373b0432cd9c6`.
+The maximum single extractor-worker peak was 200,388 KiB. Regenerating the
+candidate manifest from that bank also reproduced the frozen manifest SHA
+`1b5cece...51186` exactly.
+
+| End-to-end CPU8 phase | visloc-rs | COLMAP 3.9.1 CPU |
+| --- | ---: | ---: |
+| Feature extraction | 721.42 s | **304.12 s** |
+| Manifest validation + candidate generation/sharding | 148.58 s | frozen manifest supplied |
+| Exact-pair matching + merge | **442.58 s** | 471.37 s |
+| Mapper / model writing | **336.90 s** | 4,929.56 s |
+| Conservative total | **1,649.48 s** | 5,705.05 s |
+
+The complete visloc pipeline is therefore **3.46x faster** while retaining
+1,200/1,200 cameras, 3.50 cm centre RMSE, the accepted model hashes, and the
+bounded-memory mapper. The accounting is conservative: visloc is charged
+12.78 s of manifest validation and 135.80 s of candidate generation/sharding,
+while the COLMAP exact-pair control consumes the already frozen identical
+candidate manifest. Feature extraction alone remains 2.37x slower than
+COLMAP and is the next optimization target.
+
+All three runs produced the canonical merged snapshot SHA-256:
+
+```text
+55b2c1d9ec30df502e14d8f2de44b80042742428df4a62efbd903cd2850051f3
+```
+
+It contains 11,625 verified pairs and 7,475,384 accepted correspondences. A
+single-shard old/new comparison also reproduced
+`dd483410581c977ab86c3c60668d271cb6e5b80346c14c368eff95f713cb0367`.
+The older full snapshot hash `93bf...a86` embedded an absolute candidate/output
+path in its diagnostic effective config; pair-by-pair comparison was equal,
+and the merge now canonicalizes both forms to the path-independent verifier
+config.
+
+The owned merge reduced its measured peak from 2,102,056 KiB to a 1,632,484
+KiB median (22.3%) while preserving the output SHA. Worker and merge therefore
+both pass the predeclared 2 GiB M4 ceiling. Failed 4- and 2-thread parallel
+text-loader probes were rejected because they exceeded the ceiling; the
+accepted worker retains the exact serial compatibility loader.
+
+Machine-readable commands, hashes, timings, memory, negative-control outcome,
+and external artifact roots are recorded in
+[`persistent-matcher-audit.json`](../benchmarks/electro/persistent-matcher-audit.json).

--- a/examples/merge_verified_pair_snapshots.rs
+++ b/examples/merge_verified_pair_snapshots.rs
@@ -9,7 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
-use visloc_rs::verified_pair_snapshot::{merge, read, write_atomic};
+use visloc_rs::verified_pair_snapshot::{merge_owned, read, write_atomic};
 
 fn usage() -> ! {
     eprintln!(
@@ -88,7 +88,7 @@ fn run() -> Result<(), String> {
             read(path).map_err(|error| format!("invalid snapshot {}: {error}", path.display()))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let merged = merge(&decoded)?;
+    let merged = merge_owned(decoded)?;
     write_atomic(&output, &merged)?;
     println!(
         "merged {} snapshot shard(s): {} pairs, {} accepted correspondences -> {}",

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -252,6 +252,12 @@
 //! the exact descriptor-bound manifest hash.  It cannot be combined with
 //! coordinate overrides, feature/snapshot export, canonical row ordering,
 //! orientation-locus canonicalization, or model-score diagnostics.
+//! `--persistent-match-worker-plan PLAN` is the default-off M4 worker mode:
+//! it consumes a versioned, image-order-bound candidate/shard plan, loads the
+//! file feature bank and NN matcher once, and atomically publishes one
+//! lossless verified-pair snapshot per shard.  It is restricted to
+//! `files` + `nn` + `full` + plain `incremental`; the Python electro runner's
+//! `--persistent-matcher` option generates and validates this plan.
 //!
 //! For machine-readable NN diagnostics (and an early exit without
 //! reconstruction), add `--diagnose-pairs-csv /tmp/pairs.csv`; it uses the
@@ -432,7 +438,7 @@ use std::env;
 #[cfg(feature = "image-io")]
 use std::io::Read;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use nalgebra::{Matrix3, Point2, Point3, UnitQuaternion, Vector3};
@@ -469,15 +475,30 @@ use visloc_rs::{
     reconstruct_global_sfm, reconstruct_global_sfm_with_priors, relative_pose_from_essential,
     rematch_essential_admission_ok, triangulate_two_view_left_frame,
     write_colmap_reconstruction_for_3dgs, write_colmap_reconstruction_for_3dgs_with_cameras,
-    BaConfig, BruteForceMatcher, Camera, CameraModel, CrossCheckMatcher, DescriptorMatch,
-    FeatureSet, GlobalReconstructionTuning, IncrementalSfmConfig, LinearSolver, Matcher,
-    NextImagePolicy, PairwiseMatches, PerImageCameras, Pose, RobustKernel, TrackSource, SE3,
+    BaConfig, BruteForceMatcher, Camera, CameraModel, DescriptorMatch, FeatureSet,
+    GlobalReconstructionTuning, IncrementalSfmConfig, LinearSolver, Matcher, NextImagePolicy,
+    PairwiseMatches, PerImageCameras, Pose, RobustKernel, TrackSource, SE3,
 };
 
 use visloc_rs::slam::incremental_sfm::log_process_memory;
 use visloc_rs::verified_pair_snapshot::{
     self, PairRecord as SnapshotPairRecord, Snapshot as VerifiedPairSnapshot,
 };
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn trim_process_allocator() {
+    unsafe extern "C" {
+        fn malloc_trim(pad: usize) -> std::ffi::c_int;
+    }
+    // SAFETY: `malloc_trim(0)` has no pointer arguments and only asks glibc
+    // to return currently unused allocator pages to the operating system.
+    unsafe {
+        malloc_trim(0);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+fn trim_process_allocator() {}
 
 /// A COLMAP-export landmark: world position + `(image, keypoint, pixel)` track.
 type ExportLandmark = (Point3<f64>, Vec<(usize, usize, Point2<f64>)>);
@@ -2037,6 +2058,11 @@ struct Args {
     /// This is the opt-in match-shard worker mode and requires
     /// `export_verified_pairs_snapshot`.
     export_verified_pairs_only: bool,
+    /// Run one persistent, plan-driven match worker.  The worker loads the
+    /// file-backed feature bank and matcher once, then writes one atomic
+    /// snapshot per plan shard.  This is default-off and intentionally
+    /// restricted to the frozen NN/full/plain incremental match path.
+    persistent_match_worker_plan: Option<PathBuf>,
     /// Diagnostic-only coordinate replacement after a validated snapshot
     /// import.  The override directory must have the same image names, row
     /// counts, and descriptor bit patterns as the snapshot's base features;
@@ -3563,6 +3589,241 @@ fn parse_candidate_manifest_with_metadata(
     Ok((pairs, metadata))
 }
 
+const PERSISTENT_MATCH_WORKER_PLAN_MAGIC: &str = "visloc_match_worker_plan_v1";
+
+#[derive(Debug, Clone)]
+struct PersistentMatchWorkerShard {
+    id: usize,
+    candidate_path: PathBuf,
+    snapshot_path: PathBuf,
+    candidate_sha256: String,
+}
+
+#[derive(Debug, Clone)]
+struct PersistentMatchWorkerPlan {
+    root: PathBuf,
+    image_names: Vec<String>,
+    pair_count: usize,
+    candidate_index_sha256: String,
+    feature_manifest_sha256: String,
+    shards: Vec<PersistentMatchWorkerShard>,
+}
+
+/// Reject plan paths that could escape the plan directory.  The external
+/// runner writes plans at the artifact root, so both candidate and snapshot
+/// paths are intentionally simple POSIX-style relative paths.
+fn persistent_plan_relative_path(raw: &str, label: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(raw);
+    if raw.is_empty()
+        || raw.contains('\\')
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err(format!(
+            "persistent match worker {label} must be a simple relative path: {raw:?}"
+        ));
+    }
+    Ok(path)
+}
+
+/// Parse the dependency-free, versioned plan consumed by the persistent match
+/// worker.  The candidate files remain the source of truth for pair metadata;
+/// this plan only binds image order, total coverage, and each input/output
+/// path.  Python performs the stronger SHA-256/index validation before launch.
+fn parse_persistent_match_worker_plan(path: &Path) -> Result<PersistentMatchWorkerPlan, String> {
+    let text = std::fs::read_to_string(path).map_err(|error| {
+        format!(
+            "cannot read persistent match worker plan {}: {error}",
+            path.display()
+        )
+    })?;
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect();
+    let mut cursor = 0usize;
+    let next = |cursor: &mut usize, label: &str| -> Result<&str, String> {
+        let line = lines.get(*cursor).copied().ok_or_else(|| {
+            format!(
+                "persistent match worker plan {} is truncated while reading {label}",
+                path.display()
+            )
+        })?;
+        *cursor += 1;
+        Ok(line)
+    };
+    if next(&mut cursor, "header")? != PERSISTENT_MATCH_WORKER_PLAN_MAGIC {
+        return Err(format!(
+            "persistent match worker plan {} has unsupported header (expected {PERSISTENT_MATCH_WORKER_PLAN_MAGIC})",
+            path.display()
+        ));
+    }
+    let parse_count = |line: &str, kind: &str| -> Result<usize, String> {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 2 || fields[0] != kind {
+            return Err(format!(
+                "persistent match worker plan {} requires `{kind} N`",
+                path.display()
+            ));
+        }
+        fields[1].parse::<usize>().map_err(|error| {
+            format!(
+                "persistent match worker plan {} {kind} count is not numeric: {error}",
+                path.display()
+            )
+        })
+    };
+    let image_count = parse_count(next(&mut cursor, "image count")?, "images")?;
+    if image_count < 2 {
+        return Err(format!(
+            "persistent match worker plan {} needs at least two images",
+            path.display()
+        ));
+    }
+    let mut image_names = Vec::with_capacity(image_count);
+    for expected_index in 0..image_count {
+        let line = next(&mut cursor, "image entry")?;
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 3 || fields[0] != "image" {
+            return Err(format!(
+                "persistent match worker plan {} image entry must be image INDEX NAME",
+                path.display()
+            ));
+        }
+        let index = fields[1].parse::<usize>().map_err(|error| {
+            format!(
+                "persistent match worker plan {} image index is not numeric: {error}",
+                path.display()
+            )
+        })?;
+        if index != expected_index || fields[2].is_empty() {
+            return Err(format!(
+                "persistent match worker plan {} image entry {expected_index} is not ordered",
+                path.display()
+            ));
+        }
+        image_names.push(fields[2].to_owned());
+    }
+    let parse_hash = |line: &str, kind: &str| -> Result<String, String> {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let value = fields.get(1).copied().unwrap_or_default();
+        if fields.len() != 2
+            || fields[0] != kind
+            || value.len() != 64
+            || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(format!(
+                "persistent match worker plan {} requires `{kind} SHA256`",
+                path.display()
+            ));
+        }
+        Ok(value.to_ascii_lowercase())
+    };
+    let candidate_index_sha256 = parse_hash(
+        next(&mut cursor, "candidate index hash")?,
+        "candidate_index_sha256",
+    )?;
+    let feature_manifest_sha256 = parse_hash(
+        next(&mut cursor, "feature manifest hash")?,
+        "feature_manifest_sha256",
+    )?;
+    let pair_count = parse_count(next(&mut cursor, "pair count")?, "pairs")?;
+    if pair_count == 0 {
+        return Err(format!(
+            "persistent match worker plan {} must contain at least one pair",
+            path.display()
+        ));
+    }
+    let shard_count = parse_count(next(&mut cursor, "shard count")?, "shards")?;
+    if shard_count == 0 {
+        return Err(format!(
+            "persistent match worker plan {} must contain at least one shard",
+            path.display()
+        ));
+    }
+    let mut shards = Vec::with_capacity(shard_count);
+    let mut all_paths = HashSet::with_capacity(shard_count * 2);
+    let mut previous_id = None;
+    for _shard_index in 0..shard_count {
+        let line = next(&mut cursor, "shard entry")?;
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 5 || fields[0] != "shard" {
+            return Err(format!(
+                "persistent match worker plan {} shard entry must be shard ID CANDIDATE SNAPSHOT CANDIDATE_SHA256",
+                path.display()
+            ));
+        }
+        let id = fields[1].parse::<usize>().map_err(|error| {
+            format!(
+                "persistent match worker plan {} shard id is not numeric: {error}",
+                path.display()
+            )
+        })?;
+        if previous_id.is_some_and(|previous| id <= previous) {
+            return Err(format!(
+                "persistent match worker plan {} shard IDs must be strictly increasing",
+                path.display()
+            ));
+        }
+        previous_id = Some(id);
+        let candidate_path =
+            persistent_plan_relative_path(fields[2], &format!("shard {id} candidate path"))?;
+        let snapshot_path =
+            persistent_plan_relative_path(fields[3], &format!("shard {id} snapshot path"))?;
+        let candidate_sha256 = parse_hash(
+            &format!("candidate_sha256 {}", fields[4]),
+            "candidate_sha256",
+        )?;
+        if candidate_path == snapshot_path {
+            return Err(format!(
+                "persistent match worker plan {} shard {id} reuses one path for candidate and snapshot",
+                path.display()
+            ));
+        }
+        if !all_paths.insert(candidate_path.clone()) {
+            return Err(format!(
+                "persistent match worker plan {} repeats candidate or snapshot path {}",
+                path.display(),
+                candidate_path.display()
+            ));
+        }
+        if !all_paths.insert(snapshot_path.clone()) {
+            return Err(format!(
+                "persistent match worker plan {} repeats candidate or snapshot path {}",
+                path.display(),
+                snapshot_path.display()
+            ));
+        }
+        shards.push(PersistentMatchWorkerShard {
+            id,
+            candidate_path,
+            snapshot_path,
+            candidate_sha256,
+        });
+    }
+    if cursor != lines.len() {
+        return Err(format!(
+            "persistent match worker plan {} has unexpected trailing data",
+            path.display()
+        ));
+    }
+    let root = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    Ok(PersistentMatchWorkerPlan {
+        root,
+        image_names,
+        pair_count,
+        candidate_index_sha256,
+        feature_manifest_sha256,
+        shards,
+    })
+}
+
 /// Write a candidate manifest through a same-directory temporary file and
 /// rename.  This keeps an interrupted cheap retrieval pass from leaving a
 /// file that a later benchmark could mistake for a complete schedule.
@@ -3916,6 +4177,7 @@ where
     let mut import_verified_pairs_snapshot: Option<PathBuf> = None;
     let mut snapshot_keypoints_only = false;
     let mut export_verified_pairs_only = false;
+    let mut persistent_match_worker_plan: Option<PathBuf> = None;
     let mut candidate_manifest: Option<PathBuf> = None;
     let mut export_candidate_manifest: Option<PathBuf> = None;
     let mut snapshot_coordinate_override_dir: Option<PathBuf> = None;
@@ -4637,6 +4899,17 @@ where
             }
             "--snapshot-keypoints-only" => snapshot_keypoints_only = true,
             "--export-verified-pairs-only" => export_verified_pairs_only = true,
+            "--persistent-match-worker-plan" => {
+                let raw = a
+                    .get(i + 1)
+                    .ok_or("--persistent-match-worker-plan requires PATH")?
+                    .clone();
+                if raw.trim().is_empty() {
+                    return Err("--persistent-match-worker-plan requires a non-empty PATH".into());
+                }
+                a.remove(i + 1);
+                persistent_match_worker_plan = Some(PathBuf::from(raw));
+            }
             "--candidate-manifest" => {
                 let raw = a
                     .get(i + 1)
@@ -5241,7 +5514,7 @@ where
         None,
     )?;
 
-    Ok(Args {
+    let parsed = Args {
         feature_extractor,
         features_dir: features_dir.unwrap_or_default(),
         hybrid_filter_priors,
@@ -5444,13 +5717,268 @@ where
         import_verified_pairs_snapshot,
         snapshot_keypoints_only,
         export_verified_pairs_only,
+        persistent_match_worker_plan,
         snapshot_coordinate_override_dir,
         diagnose_ba_oracle_poses_file,
         diagnose_fixed_rotation_ba,
         diagnose_model_score_file,
         initial_poses_file,
         diagnose_colmap_track_membership,
-    })
+    };
+    validate_persistent_match_worker_args(&parsed)?;
+    Ok(parsed)
+}
+
+/// Keep the plan-driven worker as a narrow, reproducible matching path.  The
+/// worker exits before mapper construction, but accepting mapper/diagnostic
+/// switches here would make a typo look like a successful persistent A/B.
+fn validate_persistent_match_worker_args(args: &Args) -> Result<(), String> {
+    if args.persistent_match_worker_plan.is_none() {
+        return Ok(());
+    }
+    if args.feature_extractor != FeatureExtractorKind::Files {
+        return Err(
+            "--persistent-match-worker-plan currently requires --feature-extractor files".into(),
+        );
+    }
+    if args.input_colmap_calibration.is_none() {
+        return Err(
+            "--persistent-match-worker-plan requires --input-colmap-calibration for the frozen per-image camera contract".into(),
+        );
+    }
+    if args.mapper != MapperKind::Incremental || args.colmap_style {
+        return Err(
+            "--persistent-match-worker-plan currently requires the plain incremental mapper (remove --mapper global|hybrid and --colmap-style)".into(),
+        );
+    }
+    if args.matcher != MatcherKind::Nn {
+        return Err("--persistent-match-worker-plan currently requires --matcher nn".into());
+    }
+    if args.verification_mode != VerificationMode::Full {
+        return Err(
+            "--persistent-match-worker-plan currently requires --verification-mode full".into(),
+        );
+    }
+    if args.persistent_match_worker_plan.is_some()
+        && (args.candidate_manifest.is_some()
+            || args.export_candidate_manifest.is_some()
+            || args.exhaustive
+            || args.pair_stem_window.is_some()
+            || args.local_stem_window.is_some()
+            || args.rig_local_grouping
+            || args.candidate_budget.is_some()
+            || args.pair_source != PairSource::Vlad
+            || args.retrieval_topk != 12
+            || args.vocab_size != 64
+            || args.vocab_tree_branching != 10
+            || args.vocab_tree_depth != 3
+            || args.vocab_tree_num_images != 100)
+    {
+        return Err(
+            "--persistent-match-worker-plan owns the candidate shard schedule; remove candidate generation/filter flags".into(),
+        );
+    }
+    if args.export_verified_pairs_snapshot.is_some()
+        || args.export_verified_pairs_only
+        || args.import_verified_pairs_file.is_some()
+        || args.import_verified_pairs_snapshot.is_some()
+        || args.snapshot_keypoints_only
+        || args.snapshot_coordinate_override_dir.is_some()
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with snapshot/raw-pair import or export modes".into(),
+        );
+    }
+    if args.import_matches_file.is_some() || args.import_matches_supplement_file.is_some() {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with raw match imports".into(),
+        );
+    }
+    if args.export_features_dir.is_some()
+        || args.export_features_only
+        || args.sift_stream_export
+        || args.sift_stream_resume
+        || args.incremental_correspondence_triangulation
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with feature export or alternate incremental modes".into(),
+        );
+    }
+    if args.guided_matching
+        || args.colmap_guided_matching
+        || args.multiple_models
+        || args.min_e_f_inlier_ratio.is_some()
+        || args.calibrated_prefer_essential
+        || args.refine_uncalibrated_f_to_essential
+        || args.strict_uncalibrated_f_to_essential
+        || args.calibrated_essential_primary
+        || args.force_essential_matches
+        || args.force_essential_uncalibrated_only
+        || args.prefer_essential_inliers
+        || args.prefer_essential_free_endpoints
+        || !args.prefer_essential_stems.is_empty()
+        || args.prefer_essential_stem_clique
+        || !args.prefer_essential_pairs.is_empty()
+        || args.require_essential_selected_edges
+        || !args.require_essential_stems.is_empty()
+        || args.require_essential_min_e_inliers != 0
+        || args.essential_edge_weight_boost != 1.0
+    {
+        return Err(
+            "--persistent-match-worker-plan currently supports only the frozen simple NN/full verifier settings".into(),
+        );
+    }
+    if args.sift_append_descriptor_magnification.is_some()
+        || args.sift_extra_matches_append_only
+        || args.canonical_feature_order
+        || args.orientation_locus_canonicalization
+        || args.union_traversal_order != UnionTraversalOrder::Original
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with alternate descriptor, feature-order, or union-traversal modes".into(),
+        );
+    }
+    if args.rescue_bridging
+        || args.rescue_cross_check
+        || args.rescue_match_ratio != 0.95
+        || args.rescue_min_matches != 15
+        || args.rescue_max_candidates != 200
+        || args.sequence_relative_pose_fallback
+        || args.sequence_fallback_after_post
+        || args.sequence_constant_velocity_scale
+        || args.sequence_relaxed_constant_velocity_scale
+        || args.sequence_fallback_carry_scale
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with rematch, rescue, or sequence-fallback modes".into(),
+        );
+    }
+    if !args.rematch_stems.is_empty()
+        || args.rematch_ratio != 0.9
+        || !args.rematch_cross_check
+        || args.rematch_guided
+        || args.rematch_free_vs_priors
+        || args.rematch_prefer_min_e_inliers != 0
+        || !args.rematch_prefer_strong_stems.is_empty()
+        || args.rematch_tracks_use_essential
+        || args.rematch_min_chirality_margin != 0.0
+        || args.rematch_prior_anchor
+        || args.rematch_min_e_f_inlier_ratio.is_some()
+        || args.rematch_calibrated_prefer_essential
+        || args.rematch_prior_ray_guided
+        || args.rematch_prior_ray_min_rays != 2
+        || args.rematch_prior_ray_min_e_inliers != 25
+        || args.rematch_anchor_min_e_inliers != 25
+        || args.rematch_prefer_strong_min_e != 50
+        || args.rematch_verification_mode.is_some()
+        || args.rematch_pose_guided_after_global
+        || args.rematch_pose_guided_gt.is_some()
+        || args.rematch_max_gt_bearing_deg != 0.0
+        || args.rematch_gt_bearing_path.is_some()
+        || args.rematch_guided_max_error_px.is_some()
+        || args.rematch_guided_lowe_ratio.is_some()
+        || args.rematch_require_calibrated
+        || args.rematch_max_mean_sampson != 0.0
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with rematch configuration".into(),
+        );
+    }
+    if args.diagnose_ba_oracle_poses_file.is_some()
+        || args.diagnose_fixed_rotation_ba.is_some()
+        || args.diagnose_model_score_file.is_some()
+        || args.initial_poses_file.is_some()
+        || args.diagnose_colmap_track_membership.is_some()
+        || !args.diagnose_pairs.is_empty()
+        || args.diagnose_pairs_csv.is_some()
+        || !args.diagnose_pair_stems.is_empty()
+        || args.diagnose_bearing_gt.is_some()
+        || !args.diagnose_bearing_stems.is_empty()
+        || args.gt_chirality_oracle
+        || args.gt_chirality_oracle_path.is_some()
+        || args.rematch_gt_bearing_path.is_some()
+        || args.rematch_pose_guided_gt.is_some()
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot consume GT/oracle or matching diagnostic inputs"
+                .into(),
+        );
+    }
+    if args.track_source != TrackSource::UnionFind
+        || args.confidence_ordered_tracks
+        || args.geometric_confidence_tracks
+        || args.stable_track_order
+        || args.cycle_supported_tracks
+        || args.geometry_guided_conflict_recovery
+        || args.pose_guided_track_splitting
+        || args.pose_guided_track_merging
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with alternate mapper track/recovery modes".into(),
+        );
+    }
+    if args.final_min_track_length.is_some()
+        || args.seed_pair.is_some()
+        || args.seed_trials != 12
+        || !args.final_ba
+        || args.refine_intrinsics
+        || args.refine_distortion
+        || args.final_iterative_global_refinement
+        || args.global_ba_max_refinements.is_some()
+        || args.post_refinement_registration
+        || args.structureless_registration
+        || args.pnp_max_iterations != 128
+        || args.ba_max_iterations.is_some()
+        || args.ba_huber_delta.is_some()
+        || args.ba_linear_solver.is_some()
+        || args.periodic_ba_min_registered_images != 0
+        || args.final_ba_polish_iterations != 0
+        || args.geometry_weighted_ba
+        || args.freeze_ill_conditioned_landmarks
+        || args.landmark_ba_warm_start_iterations != 0
+        || args.landmark_ba_warm_start_min_registered_images != 0
+        || args.filter_images
+        || args.min_pnp_inliers != 12
+        || args.max_mapper_matches_per_pair.is_some()
+        || args.max_reproj != 4.0
+        || args.next_image_policy != NextImagePolicy::Auto
+        || args.chirality_harden
+        || args.rotation_seed_trials != 1
+        || args.refine_global_translations
+        || args.global_independent_edge_scales
+        || args.multi_hypothesis_edges
+        || args.min_edge_inliers != 15
+        || args.min_edge_parallax_deg != 2.0
+        || args.weight_by_chirality_margin
+        || args.hybrid_filter_priors
+        || args.hybrid_drop_inconsistent_priors
+        || !args.hybrid_drop_prior_stems.is_empty()
+        || args.verify_registration_two_view
+        || args.hybrid_rotation_priors_only
+        || args.joint_global_positioning
+        || args.calibrated_view_edges_only
+        || args.pose_guided_track_splitting
+        || args.pose_guided_track_splitting_graph_support
+        || args.pose_guided_track_splitting_bridge_cuts
+        || args.pose_guided_split_max_reproj.is_some()
+        || args.pose_guided_track_splitting_iterations.is_some()
+        || args.pose_guided_track_merging
+        || args.pose_guided_merge_max_reproj.is_some()
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with mapper/refinement options"
+                .into(),
+        );
+    }
+    if args.lightglue_model.is_some()
+        || args.onnx_backend != "auto"
+        || args.lightglue_max_keypoints != 0
+    {
+        return Err(
+            "--persistent-match-worker-plan cannot be combined with learned-matcher options".into(),
+        );
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -7311,10 +7839,67 @@ fn write_verified_pair_snapshot(
     metadata_by_pair: &HashMap<(usize, usize), SnapshotPairMetadata>,
     args: &Args,
 ) -> Result<(), String> {
-    let feature_counts: Vec<u64> = features
-        .iter()
-        .map(|features| features.keypoints.len() as u64)
-        .collect();
+    write_verified_pair_snapshot_with_validation(
+        path,
+        image_names,
+        features,
+        camera,
+        pairwise,
+        metadata_by_pair,
+        args,
+        None,
+        false,
+    )
+}
+
+fn write_verified_pair_snapshot_atomic(
+    path: &Path,
+    image_names: &[String],
+    features: &[FeatureSet],
+    camera: &Camera,
+    pairwise: &[PairwiseMatches],
+    metadata_by_pair: &HashMap<(usize, usize), SnapshotPairMetadata>,
+    args: &Args,
+    feature_validation: &SnapshotFeatureValidation,
+) -> Result<(), String> {
+    write_verified_pair_snapshot_with_validation(
+        path,
+        image_names,
+        features,
+        camera,
+        pairwise,
+        metadata_by_pair,
+        args,
+        Some(feature_validation),
+        true,
+    )
+}
+
+fn write_verified_pair_snapshot_with_validation(
+    path: &Path,
+    image_names: &[String],
+    features: &[FeatureSet],
+    camera: &Camera,
+    pairwise: &[PairwiseMatches],
+    metadata_by_pair: &HashMap<(usize, usize), SnapshotPairMetadata>,
+    args: &Args,
+    feature_validation: Option<&SnapshotFeatureValidation>,
+    atomic: bool,
+) -> Result<(), String> {
+    let feature_counts: Vec<u64> = feature_validation
+        .map(|validation| {
+            validation
+                .feature_counts
+                .iter()
+                .map(|&count| count as u64)
+                .collect()
+        })
+        .unwrap_or_else(|| {
+            features
+                .iter()
+                .map(|features| features.keypoints.len() as u64)
+                .collect()
+        });
     let records: Vec<SnapshotPairRecord> = pairwise
         .iter()
         .map(|pair| {
@@ -7334,7 +7919,10 @@ fn write_verified_pair_snapshot(
         schema_version: verified_pair_snapshot::SCHEMA_VERSION,
         image_names: image_names.to_vec(),
         image_manifest_hash: snapshot_image_manifest_hash(image_names),
-        feature_manifest_hash: snapshot_feature_manifest_hash(features),
+        feature_manifest_hash: feature_validation.map_or_else(
+            || snapshot_feature_manifest_hash(features),
+            |validation| validation.feature_manifest_hash,
+        ),
         feature_counts,
         width: u64::from(camera.width),
         height: u64::from(camera.height),
@@ -7356,7 +7944,11 @@ fn write_verified_pair_snapshot(
             .sum::<usize>() as u64,
         pairs: records,
     };
-    verified_pair_snapshot::write(path, &snapshot)
+    if atomic {
+        verified_pair_snapshot::write_atomic(path, &snapshot)
+    } else {
+        verified_pair_snapshot::write(path, &snapshot)
+    }
 }
 
 fn vector_from_bits(bits: Option<[u64; 3]>) -> Option<Vector3<f64>> {
@@ -7548,6 +8140,170 @@ fn ordered_pairwise_edge_hash(pairwise: &[PairwiseMatches]) -> u64 {
         }
     }
     hash
+}
+
+/// Run a versioned, plan-driven match worker without reloading the feature
+/// bank between candidate shards.  Candidate manifests are preflighted before
+/// the first snapshot is published so a duplicate pair or metadata mismatch
+/// cannot leave a prefix that looks complete.  Verification itself remains
+/// the existing `verify_pairs` implementation and each shard's temporary
+/// result is dropped before the next shard starts.
+fn run_persistent_match_worker(
+    plan: &PersistentMatchWorkerPlan,
+    features: &[FeatureSet],
+    image_names: &[String],
+    camera: &Camera,
+    matcher: &PairMatcher,
+    args: &Args,
+    feature_validation: &SnapshotFeatureValidation,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if plan.image_names != image_names {
+        return Err("persistent match worker plan image order differs from loaded features".into());
+    }
+    let mut seen_pairs = HashSet::with_capacity(plan.pair_count);
+    let mut expected_metadata: Option<BTreeMap<String, String>> = None;
+    let mut total_pairs = 0usize;
+    for shard in &plan.shards {
+        let candidate_path = plan.root.join(&shard.candidate_path);
+        let (candidates, metadata) =
+            parse_candidate_manifest_with_metadata(&candidate_path, image_names)
+                .map_err(std::io::Error::other)?;
+        if let Some(expected) = expected_metadata.as_ref() {
+            if expected != &metadata {
+                return Err(format!(
+                    "persistent match worker candidate shard {} metadata differs from shard 0",
+                    shard.id
+                )
+                .into());
+            }
+        } else {
+            expected_metadata = Some(metadata);
+        }
+        for &pair in &candidates {
+            if !seen_pairs.insert(pair) {
+                return Err(format!(
+                    "persistent match worker candidate shards overlap at pair ({},{})",
+                    pair.0, pair.1
+                )
+                .into());
+            }
+        }
+        total_pairs = total_pairs
+            .checked_add(candidates.len())
+            .ok_or("persistent match worker candidate pair count overflow")?;
+        // This pass only validates coverage/metadata.  Do not retain any
+        // candidate vectors while the feature bank is resident; each shard is
+        // parsed again immediately before verification below.
+        drop(candidates);
+    }
+    if total_pairs != plan.pair_count {
+        return Err(format!(
+            "persistent match worker plan declares {} pairs but candidate shards contain {}",
+            plan.pair_count, total_pairs
+        )
+        .into());
+    }
+
+    let mut stdout = std::io::stdout().lock();
+    writeln!(
+        stdout,
+        "persistent-match-plan candidate_index_sha256={} feature_manifest_sha256={}",
+        plan.candidate_index_sha256, plan.feature_manifest_sha256,
+    )?;
+    stdout.flush()?;
+    for shard in &plan.shards {
+        let candidate_path = plan.root.join(&shard.candidate_path);
+        let (candidates, _candidate_metadata) =
+            parse_candidate_manifest_with_metadata(&candidate_path, image_names)
+                .map_err(std::io::Error::other)?;
+        let started = std::time::Instant::now();
+        let (mut pairwise, _stats, metadata) = verify_pairs(
+            features,
+            camera,
+            &candidates,
+            args.match_ratio,
+            args.min_matches,
+            args.verification_mode,
+            matcher,
+            true,
+            args.guided_matching,
+            args.multiple_models,
+            args.min_e_f_inlier_ratio,
+            args.calibrated_prefer_essential,
+            args.refine_uncalibrated_f_to_essential,
+            args.strict_uncalibrated_f_to_essential,
+            args.calibrated_essential_primary,
+            args.force_essential_matches,
+            args.force_essential_min_ef_ratio,
+            args.force_essential_min_e_inliers,
+            args.force_essential_uncalibrated_only,
+            None,
+            None,
+            None,
+            None,
+            args.colmap_guided_matching,
+        );
+        if pairwise.is_empty() {
+            return Err(format!(
+                "persistent match worker shard {} has no verified pair (lower --min-matches?)",
+                shard.id
+            )
+            .into());
+        }
+        let edge_hash_before = unordered_pairwise_edge_hash(&pairwise);
+        apply_union_traversal_order_with_features(
+            &mut pairwise,
+            args.union_traversal_order,
+            features,
+        );
+        let edge_hash_after = unordered_pairwise_edge_hash(&pairwise);
+        if edge_hash_before != edge_hash_after {
+            return Err(format!(
+                "persistent match worker shard {} changed the verified edge multiset: before={edge_hash_before:016x} after={edge_hash_after:016x}",
+                shard.id
+            )
+            .into());
+        }
+        let accepted = pairwise
+            .iter()
+            .map(|pair| pair.matches.len())
+            .sum::<usize>();
+        let ordered_hash = ordered_pairwise_edge_hash(&pairwise);
+        let unordered_hash = edge_hash_after;
+        let snapshot_path = plan.root.join(&shard.snapshot_path);
+        write_verified_pair_snapshot_atomic(
+            &snapshot_path,
+            image_names,
+            features,
+            camera,
+            &pairwise,
+            &metadata,
+            args,
+            feature_validation,
+        )?;
+        let elapsed = started.elapsed().as_secs_f64();
+        writeln!(
+            stdout,
+            "persistent-match-complete shard_id={} candidate_path={} snapshot_path={} candidate_sha256={} candidate_pairs={} pairs={} accepted={} ordered_edge_fnv1a64={ordered_hash:016x} unordered_edge_fnv1a64={unordered_hash:016x} elapsed_s={elapsed:.9}",
+            shard.id,
+            shard.candidate_path.display(),
+            shard.snapshot_path.display(),
+            shard.candidate_sha256,
+            candidates.len(),
+            pairwise.len(),
+            accepted,
+        )?;
+        stdout.flush()?;
+        // `pairwise`, metadata, and the candidate vector are all shard-local;
+        // dropping them at this boundary keeps the worker's result buffers
+        // bounded even when the feature bank is large.
+        drop(_candidate_metadata);
+        drop(candidates);
+        drop(metadata);
+        drop(pairwise);
+        trim_process_allocator();
+    }
+    Ok(())
 }
 
 fn verification_stats_from_snapshot(
@@ -9389,8 +10145,7 @@ fn nn_matches(
     train: &[Vec<f32>],
 ) -> Vec<DescriptorMatch> {
     if cross_check {
-        CrossCheckMatcher::new(BruteForceMatcher { ratio: Some(ratio) })
-            .match_descriptors(query, train)
+        BruteForceMatcher { ratio: Some(ratio) }.match_descriptors_cross_checked(query, train)
     } else {
         BruteForceMatcher { ratio: Some(ratio) }.match_descriptors(query, train)
     }
@@ -14576,6 +15331,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
+    if let Some(plan_path) = args.persistent_match_worker_plan.as_deref() {
+        let plan = parse_persistent_match_worker_plan(plan_path).map_err(std::io::Error::other)?;
+        // The worker returns immediately after matching and never exports a
+        // model or features. Release mapper/export-only calibration state
+        // before allocating the first shard result; on multi-camera inputs
+        // the retained native keypoint copy alone is tens of MiB.
+        drop(native_keypoints_for_export.take());
+        drop(per_image_calibration.take());
+        drop(locus_metadata);
+        drop(canonical_feature_index_map);
+        drop(initial_poses);
+        drop(imported_snapshot);
+        trim_process_allocator();
+        let feature_validation = SnapshotFeatureValidation {
+            feature_counts: features.iter().map(FeatureSet::len).collect(),
+            feature_manifest_hash: snapshot_feature_manifest_hash(&features),
+        };
+        println!(
+            "persistent match worker: {} shard(s), {} candidate pairs, feature-manifest-fnv1a64={:016x}",
+            plan.shards.len(),
+            plan.pair_count,
+            feature_validation.feature_manifest_hash,
+        );
+        run_persistent_match_worker(
+            &plan,
+            &features,
+            &image_names,
+            &args.camera,
+            &pair_matcher,
+            &args,
+            &feature_validation,
+        )?;
+        return Ok(());
+    }
+
     if let Some(path) = args.export_candidate_manifest.as_deref() {
         let generated = candidate_pairs(&features, &image_names, &args)?;
         let generated =
@@ -18412,17 +19202,47 @@ mod sift_extra_tests {
 #[cfg(test)]
 mod append_only_matcher_tests {
     use super::{
-        append_only_nn_matches, f_to_e_stability_gate, project_fundamental_to_essential,
+        append_only_nn_matches, f_to_e_stability_gate, parse_args_from,
+        parse_persistent_match_worker_plan, project_fundamental_to_essential,
         refine_uncalibrated_f_winner, select_calibrated_essential_primary,
         sequence_f_to_e_high_support_override_gate, sequence_f_to_e_stability_gate,
-        should_exclude_strict_uncalibrated_f_winner, FToECandidateDiagnostics, PairMatcher,
+        should_exclude_strict_uncalibrated_f_winner, snapshot_feature_manifest_hash,
+        write_verified_pair_snapshot, write_verified_pair_snapshot_atomic,
+        FToECandidateDiagnostics, PairMatcher, PairwiseMatches, SnapshotFeatureValidation,
+        PERSISTENT_MATCH_WORKER_PLAN_MAGIC,
     };
     use nalgebra::{Matrix3, Point2, Point3, UnitQuaternion, Vector3};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
     use visloc_rs::vision::two_view::{
         ConfigurationType, TwoViewCorrespondence, TwoViewGeometryReport,
     };
     use visloc_rs::FeatureSet;
     use visloc_rs::{Camera, CameraModel};
+
+    fn minimal_args(extra: &[&str]) -> Vec<String> {
+        let mut args = [
+            "--width",
+            "1600",
+            "--height",
+            "1066",
+            "--fx",
+            "879.4",
+            "--fy",
+            "879.4",
+            "--cx",
+            "803.4",
+            "--cy",
+            "532.6",
+            "--out-colmap",
+            "/tmp/persistent-cli-test",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+        args.extend(extra.iter().map(|arg| (*arg).to_owned()));
+        args
+    }
 
     fn features(descriptors: Vec<Vec<f32>>) -> FeatureSet {
         let keypoints = (0..descriptors.len())
@@ -18786,6 +19606,175 @@ mod append_only_matcher_tests {
         assert!(!sequence_f_to_e_high_support_override_gate(
             &poor_override_parallax
         ));
+    }
+
+    #[test]
+    fn persistent_worker_plan_parser_rejects_path_traversal_and_reuse() {
+        let root = std::env::temp_dir().join(format!(
+            "visloc_persistent_plan_parser_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let hash = "a".repeat(64);
+        let valid = format!(
+            "{PERSISTENT_MATCH_WORKER_PLAN_MAGIC}\n\
+             images 2\n\
+             image 0 left.png\n\
+             image 1 right.png\n\
+             candidate_index_sha256 {hash}\n\
+             feature_manifest_sha256 {hash}\n\
+             pairs 1\n\
+             shards 1\n\
+             shard 4 candidates/candidate-000004.txt matches/verified-000004.vps {hash}\n"
+        );
+        let path = root.join("valid.plan");
+        std::fs::write(&path, valid).unwrap();
+        let parsed = parse_persistent_match_worker_plan(&path).unwrap();
+        assert_eq!(parsed.image_names, ["left.png", "right.png"]);
+        assert_eq!(parsed.shards[0].id, 4);
+        assert_eq!(parsed.root, root);
+
+        let traversal = root.join("traversal.plan");
+        std::fs::write(
+            &traversal,
+            format!(
+                "{PERSISTENT_MATCH_WORKER_PLAN_MAGIC}\n\
+                 images 2\nimage 0 left.png\nimage 1 right.png\n\
+                 candidate_index_sha256 {hash}\nfeature_manifest_sha256 {hash}\n\
+                 pairs 1\nshards 1\n\
+                 shard 0 ../candidate.txt matches/out.vps {hash}\n"
+            ),
+        )
+        .unwrap();
+        assert!(parse_persistent_match_worker_plan(&traversal)
+            .unwrap_err()
+            .contains("relative path"));
+
+        let duplicate = root.join("duplicate.plan");
+        std::fs::write(
+            &duplicate,
+            format!(
+                "{PERSISTENT_MATCH_WORKER_PLAN_MAGIC}\n\
+                 images 2\nimage 0 left.png\nimage 1 right.png\n\
+                 candidate_index_sha256 {hash}\nfeature_manifest_sha256 {hash}\n\
+                 pairs 2\nshards 2\n\
+                 shard 0 candidates/a.txt matches/a.vps {hash}\n\
+                 shard 1 candidates/a.txt matches/b.vps {hash}\n"
+            ),
+        )
+        .unwrap();
+        assert!(parse_persistent_match_worker_plan(&duplicate)
+            .unwrap_err()
+            .contains("repeats"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persistent_worker_cli_is_opt_in_and_fail_closed() {
+        let defaults = parse_args_from(minimal_args(&[])).unwrap();
+        assert!(defaults.persistent_match_worker_plan.is_none());
+        let valid = parse_args_from(vec![
+            "--input-colmap-calibration".to_owned(),
+            "/tmp/calibration".to_owned(),
+            "--verification-mode".to_owned(),
+            "full".to_owned(),
+            "--persistent-match-worker-plan".to_owned(),
+            "/tmp/match-worker.plan".to_owned(),
+            "--out-colmap".to_owned(),
+            "/tmp/persistent-model".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(
+            valid.persistent_match_worker_plan,
+            Some(PathBuf::from("/tmp/match-worker.plan"))
+        );
+
+        for extra in [
+            vec!["--mapper", "global"],
+            vec!["--matcher", "lightglue"],
+            vec!["--verification-mode", "legacy"],
+            vec!["--guided-matching"],
+            vec!["--candidate-manifest", "/tmp/candidate.txt"],
+            vec!["--import-verified-pairs-snapshot", "/tmp/pairs.vps"],
+            vec!["--canonical-feature-order"],
+            vec!["--union-traversal-order", "reverse-both"],
+            vec!["--rematch-stems", "foo"],
+            vec!["--diagnose-bearing-gt", "/tmp/gt/images.txt"],
+            vec!["--global-ba-max-refinements", "1"],
+        ] {
+            let mut args = vec![
+                "--input-colmap-calibration".to_owned(),
+                "/tmp/calibration".to_owned(),
+                "--verification-mode".to_owned(),
+                "full".to_owned(),
+                "--persistent-match-worker-plan".to_owned(),
+                "/tmp/match-worker.plan".to_owned(),
+                "--out-colmap".to_owned(),
+                "/tmp/persistent-model".to_owned(),
+            ];
+            args.extend(extra.iter().map(|arg| (*arg).to_owned()));
+            assert!(
+                parse_args_from(args).is_err(),
+                "persistent worker accepted unsupported options: {extra:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cached_snapshot_feature_validation_is_byte_identical_to_default_writer() {
+        let root = std::env::temp_dir().join(format!(
+            "visloc_persistent_snapshot_writer_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let features = vec![
+            FeatureSet::new(vec![Point2::new(10.0, 20.0)], vec![vec![0.1, 0.2, 0.3]]).unwrap(),
+            FeatureSet::new(vec![Point2::new(30.0, 40.0)], vec![vec![0.4, 0.5, 0.6]]).unwrap(),
+        ];
+        let image_names = vec!["left.png".to_owned(), "right.png".to_owned()];
+        let pairwise = vec![PairwiseMatches::new(0, 1, vec![(0, 0)])];
+        let metadata = HashMap::new();
+        let args = parse_args_from(minimal_args(&[])).unwrap();
+        let validation = SnapshotFeatureValidation {
+            feature_counts: features.iter().map(FeatureSet::len).collect(),
+            feature_manifest_hash: snapshot_feature_manifest_hash(&features),
+        };
+        write_verified_pair_snapshot(
+            &root.join("default.vps"),
+            &image_names,
+            &features,
+            &args.camera,
+            &pairwise,
+            &metadata,
+            &args,
+        )
+        .unwrap();
+        write_verified_pair_snapshot_atomic(
+            &root.join("cached.vps"),
+            &image_names,
+            &features,
+            &args.camera,
+            &pairwise,
+            &metadata,
+            &args,
+            &validation,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read(root.join("default.vps")).unwrap(),
+            std::fs::read(root.join("cached.vps")).unwrap()
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 }
 

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import shlex
 import subprocess
@@ -35,8 +36,16 @@ CANDIDATE_MAGIC = "visloc_candidate_manifest_v1"
 CANDIDATE_INDEX_SCHEMA = "visloc_electro_candidate_shards_v1"
 MATCH_INDEX_SCHEMA = "visloc_electro_match_shards_v1"
 FEATURE_MANIFEST_SCHEMA = "visloc_electro_feature_manifest_v1"
+PERSISTENT_MATCH_WORKER_PLAN_MAGIC = "visloc_match_worker_plan_v1"
 SHA256_RE = set("0123456789abcdef")
 GNU_TIME = Path("/usr/bin/time")
+PERSISTENT_MATCH_ENV = {
+    "RAYON_NUM_THREADS": "4",
+    "MALLOC_ARENA_MAX": "1",
+}
+MEMORY_BOUNDED_MERGE_ENV = {
+    "MALLOC_ARENA_MAX": "1",
+}
 
 
 class ValidationError(RuntimeError):
@@ -68,6 +77,14 @@ def _safe_relative(value: str, label: str) -> Path:
     if path.is_absolute() or not value or any(part in ("", ".", "..") for part in path.parts):
         raise ValidationError(f"{label} must be a simple relative path: {value!r}")
     return path
+
+
+def _persistent_safe_relative(value: str, label: str) -> Path:
+    """Validate a plan/log path using the same POSIX contract as Rust."""
+
+    if "\\" in value:
+        raise ValidationError(f"{label} must use POSIX-style separators: {value!r}")
+    return _safe_relative(value, label)
 
 
 def _atomic_bytes(path: Path, payload: bytes) -> None:
@@ -595,7 +612,13 @@ def carry_forward_phase_ledger(
     if not isinstance(previous, dict):
         return current
     result = dict(current)
-    for key in ("candidate_generation", "candidate_sharding", "merge", "mapping"):
+    for key in (
+        "candidate_generation",
+        "candidate_sharding",
+        "persistent_worker",
+        "merge",
+        "mapping",
+    ):
         if result.get(key) is None and previous.get(key) is not None:
             result[key] = previous[key]
     return result
@@ -622,6 +645,7 @@ def _run_command(
     *,
     cwd: Path = REPO_ROOT,
     timing_path: Path | None = None,
+    env_overrides: dict[str, str] | None = None,
 ) -> float:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     executed = command
@@ -640,7 +664,7 @@ def _run_command(
                 stdout=log,
                 stderr=subprocess.STDOUT,
                 check=False,
-                env={**os.environ, "LC_ALL": "C"},
+                env={**os.environ, "LC_ALL": "C", **(env_overrides or {})},
             )
     except OSError as exc:
         raise ValidationError(f"cannot execute {executed[0]}: {exc}") from exc
@@ -765,6 +789,52 @@ def build_match_command(
     return command
 
 
+def build_persistent_match_command(
+    binary: Path,
+    *,
+    features_dir: Path,
+    calibration_dir: Path,
+    plan: Path,
+    feature_suffix: str = "_features.txt",
+    image_suffix: str = ".png",
+    images_dir: Path | None = None,
+    min_matches: int = 30,
+    match_ratio: float = 0.8,
+) -> list[str]:
+    """Build the single-process frozen NN/full persistent worker command."""
+
+    command = [
+        str(binary),
+        "--feature-extractor",
+        "files",
+        "--features-dir",
+        str(features_dir),
+        "--feature-suffix",
+        feature_suffix,
+        "--image-suffix",
+        image_suffix,
+        "--input-colmap-calibration",
+        str(calibration_dir),
+        "--verification-mode",
+        "full",
+        "--matcher",
+        "nn",
+        "--mapper",
+        "incremental",
+        "--min-matches",
+        str(min_matches),
+        "--match-ratio",
+        str(match_ratio),
+        "--persistent-match-worker-plan",
+        str(plan),
+        "--out-colmap",
+        str(plan.parent / "matches" / "unused-model-persistent"),
+    ]
+    if images_dir is not None:
+        command.extend(["--images-dir", str(images_dir)])
+    return command
+
+
 def build_mapping_command(
     binary: Path,
     *,
@@ -839,6 +909,245 @@ def prepare_match_index(candidate_index_path: Path, output_dir: Path) -> dict[st
     return index
 
 
+def parse_persistent_match_worker_plan(path: Path) -> dict[str, Any]:
+    """Parse the dependency-free plan consumed by the Rust persistent worker."""
+
+    lines = _noncomment_lines(path)
+    cursor = 0
+
+    def next_line(label: str) -> str:
+        nonlocal cursor
+        if cursor >= len(lines):
+            raise ValidationError(
+                f"persistent match worker plan {path} is truncated while reading {label}"
+            )
+        line = lines[cursor]
+        cursor += 1
+        return line
+
+    def count_line(label: str) -> int:
+        fields = next_line(label).split()
+        if len(fields) != 2 or fields[0] != label:
+            raise ValidationError(f"persistent match worker plan requires `{label} N`")
+        try:
+            value = int(fields[1])
+        except ValueError as exc:
+            raise ValidationError(f"persistent match worker {label} count is not numeric") from exc
+        if value < 0:
+            raise ValidationError(f"persistent match worker {label} count must be non-negative")
+        return value
+
+    if next_line("header") != PERSISTENT_MATCH_WORKER_PLAN_MAGIC:
+        raise ValidationError(
+            f"persistent match worker plan {path} has unsupported header"
+        )
+    image_count = count_line("images")
+    if image_count < 2:
+        raise ValidationError("persistent match worker plan needs at least two images")
+    image_names = []
+    for expected_index in range(image_count):
+        fields = next_line("image entry").split()
+        if len(fields) != 3 or fields[0] != "image":
+            raise ValidationError("persistent match worker image entry must be image INDEX NAME")
+        try:
+            index = int(fields[1])
+        except ValueError as exc:
+            raise ValidationError("persistent match worker image index is not numeric") from exc
+        if index != expected_index or not fields[2]:
+            raise ValidationError("persistent match worker image entries must be ordered")
+        image_names.append(fields[2])
+
+    def hash_line(label: str) -> str:
+        fields = next_line(label).split()
+        if len(fields) != 2 or fields[0] != label:
+            raise ValidationError(f"persistent match worker plan requires `{label} SHA256`")
+        return _sha256(fields[1], label)
+
+    candidate_index_sha256 = hash_line("candidate_index_sha256")
+    feature_manifest_sha256 = hash_line("feature_manifest_sha256")
+    pair_count = count_line("pairs")
+    if pair_count <= 0:
+        raise ValidationError("persistent match worker plan must contain at least one pair")
+    shard_count = count_line("shards")
+    if shard_count <= 0:
+        raise ValidationError("persistent match worker plan must contain at least one shard")
+    shards = []
+    all_paths: set[Path] = set()
+    previous_id: int | None = None
+    for expected_id in range(shard_count):
+        fields = next_line("shard entry").split()
+        if len(fields) != 5 or fields[0] != "shard":
+            raise ValidationError(
+                "persistent match worker shard entry must be shard ID CANDIDATE SNAPSHOT CANDIDATE_SHA256"
+            )
+        try:
+            shard_id = int(fields[1])
+        except ValueError as exc:
+            raise ValidationError("persistent match worker shard id is not numeric") from exc
+        if shard_id < 0:
+            raise ValidationError("persistent match worker shard id must be non-negative")
+        if previous_id is not None and shard_id <= previous_id:
+            raise ValidationError("persistent match worker shard IDs must be strictly increasing")
+        previous_id = shard_id
+        candidate_path = _persistent_safe_relative(
+            fields[2], f"persistent shard {shard_id} candidate path"
+        )
+        snapshot_path = _persistent_safe_relative(
+            fields[3], f"persistent shard {shard_id} snapshot path"
+        )
+        if candidate_path == snapshot_path:
+            raise ValidationError(
+                f"persistent match worker shard {shard_id} reuses one path for candidate and snapshot"
+            )
+        if candidate_path in all_paths or snapshot_path in all_paths:
+            raise ValidationError(
+                f"persistent match worker repeats candidate or snapshot path at shard {shard_id}"
+            )
+        all_paths.add(candidate_path)
+        all_paths.add(snapshot_path)
+        shards.append(
+            {
+                "id": shard_id,
+                "candidate_path": candidate_path.as_posix(),
+                "snapshot_path": snapshot_path.as_posix(),
+                "candidate_sha256": _sha256(fields[4], f"persistent shard {shard_id} candidate hash"),
+            }
+        )
+    if cursor != len(lines):
+        raise ValidationError(f"persistent match worker plan {path} has unexpected trailing data")
+    return {
+        "schema": PERSISTENT_MATCH_WORKER_PLAN_MAGIC,
+        "image_names": image_names,
+        "pair_count": pair_count,
+        "candidate_index_sha256": candidate_index_sha256,
+        "feature_manifest_sha256": feature_manifest_sha256,
+        "shards": shards,
+    }
+
+
+def _artifact_relative(path: Path, artifact_root: Path, label: str) -> str:
+    try:
+        relative = path.resolve().relative_to(artifact_root.resolve())
+    except ValueError as exc:
+        raise ValidationError(f"{label} is outside the artifact root: {path}") from exc
+    return _safe_relative(relative.as_posix(), label).as_posix()
+
+
+def validate_persistent_match_worker_plan(
+    plan_path: Path,
+    candidate_index_path: Path,
+    match_index_path: Path,
+    feature_manifest_path: Path,
+    *,
+    allow_completed: bool = False,
+) -> dict[str, Any]:
+    """Validate plan bindings against the candidate/match/feature artifacts."""
+
+    plan = parse_persistent_match_worker_plan(plan_path)
+    candidate = validate_candidate_shards(candidate_index_path)
+    match = validate_match_index(match_index_path, candidate_index_path)
+    artifact_root = match_index_path.resolve().parent.parent
+    if plan["image_names"] != candidate["image_names"]:
+        raise ValidationError("persistent worker plan image order differs from candidate index")
+    if plan["candidate_index_sha256"] != candidate["index_sha256"]:
+        raise ValidationError("persistent worker plan candidate index hash differs")
+    if plan["feature_manifest_sha256"] != sha256_file(feature_manifest_path):
+        raise ValidationError("persistent worker plan feature manifest hash differs")
+    candidate_prefix = _artifact_relative(
+        candidate_index_path.resolve().parent, artifact_root, "candidate index directory"
+    )
+    match_prefix = _artifact_relative(
+        match_index_path.resolve().parent, artifact_root, "match index directory"
+    )
+    pending = [entry for entry in match["index"]["shards"] if entry["status"] != "complete"]
+    if allow_completed:
+        match_by_id = {entry["id"]: entry for entry in match["index"]["shards"]}
+        expected_entries = []
+        for plan_shard in plan["shards"]:
+            entry = match_by_id.get(plan_shard["id"])
+            if entry is None:
+                raise ValidationError(
+                    f"persistent worker plan refers to unknown match shard {plan_shard['id']}"
+                )
+            expected_entries.append(entry)
+    else:
+        expected_entries = pending
+        if len(plan["shards"]) != len(pending):
+            raise ValidationError("persistent worker plan does not contain exactly the pending shards")
+    expected_pairs = 0
+    for plan_shard, match_entry in zip(plan["shards"], expected_entries):
+        candidate_entry = candidate["shards"][match_entry["id"]]
+        expected_candidate = f"{candidate_prefix}/{candidate_entry['path']}"
+        expected_snapshot = f"{match_prefix}/{match_entry['snapshot_path']}"
+        if plan_shard["id"] != match_entry["id"]:
+            raise ValidationError("persistent worker plan shard order differs from match index")
+        if plan_shard["candidate_path"] != expected_candidate:
+            raise ValidationError(f"persistent worker shard {plan_shard['id']} candidate path differs")
+        if plan_shard["snapshot_path"] != expected_snapshot:
+            raise ValidationError(f"persistent worker shard {plan_shard['id']} snapshot path differs")
+        if plan_shard["candidate_sha256"] != candidate_entry["sha256"]:
+            raise ValidationError(f"persistent worker shard {plan_shard['id']} candidate hash differs")
+        expected_pairs += int(candidate_entry["pair_count"])
+    if plan["pair_count"] != expected_pairs:
+        raise ValidationError(
+            f"persistent worker plan pair count {plan['pair_count']} differs from pending {expected_pairs}"
+        )
+    return {
+        "plan_path": str(plan_path.resolve()),
+        "plan": plan,
+        "plan_sha256": sha256_file(plan_path),
+        "candidate": candidate,
+        "match": match,
+        "pending": pending,
+    }
+
+
+def write_persistent_match_worker_plan(
+    candidate_index_path: Path,
+    match_index_path: Path,
+    feature_manifest_path: Path,
+    *,
+    output: Path | None = None,
+) -> Path | None:
+    """Write a plan for pending match shards, or return None when complete."""
+
+    candidate = validate_candidate_shards(candidate_index_path)
+    match = validate_match_index(match_index_path, candidate_index_path)
+    pending = [entry for entry in match["index"]["shards"] if entry["status"] != "complete"]
+    if not pending:
+        return None
+    artifact_root = match_index_path.resolve().parent.parent
+    candidate_prefix = _artifact_relative(
+        candidate_index_path.resolve().parent, artifact_root, "candidate index directory"
+    )
+    match_prefix = _artifact_relative(
+        match_index_path.resolve().parent, artifact_root, "match index directory"
+    )
+    feature_manifest_sha256 = sha256_file(feature_manifest_path)
+    lines = [
+        PERSISTENT_MATCH_WORKER_PLAN_MAGIC,
+        f"images {len(candidate['image_names'])}",
+        *[f"image {index} {name}" for index, name in enumerate(candidate["image_names"])],
+        f"candidate_index_sha256 {candidate['index_sha256']}",
+        f"feature_manifest_sha256 {feature_manifest_sha256}",
+        f"pairs {sum(int(candidate['shards'][entry['id']]['pair_count']) for entry in pending)}",
+        f"shards {len(pending)}",
+    ]
+    for entry in pending:
+        shard = candidate["shards"][entry["id"]]
+        candidate_path = f"{candidate_prefix}/{shard['path']}"
+        snapshot_path = f"{match_prefix}/{entry['snapshot_path']}"
+        lines.append(
+            f"shard {entry['id']} {candidate_path} {snapshot_path} {shard['sha256']}"
+        )
+    plan_path = (output or artifact_root / "match-worker.plan").resolve()
+    _atomic_bytes(plan_path, ("\n".join(lines) + "\n").encode("utf-8"))
+    validate_persistent_match_worker_plan(
+        plan_path, candidate_index_path, match_index_path, feature_manifest_path
+    )
+    return plan_path
+
+
 def validate_match_index(
     index_path: Path,
     candidate_index_path: Path,
@@ -891,8 +1200,30 @@ def run_match_shards(
     min_matches: int = 30,
     match_ratio: float = 0.8,
     resume: bool = True,
+    persistent_matcher: bool = False,
+    feature_manifest_path: Path | None = None,
 ) -> dict[str, Any]:
     """Run pending match shards, updating the index only after hash checks."""
+
+    if persistent_matcher:
+        if feature_manifest_path is None:
+            raise ValidationError(
+                "persistent matcher requires the validated feature manifest path"
+            )
+        return run_persistent_matcher(
+            candidate_index_path,
+            match_index_path,
+            binary=binary,
+            features_dir=features_dir,
+            calibration_dir=calibration_dir,
+            feature_manifest_path=feature_manifest_path,
+            images_dir=images_dir,
+            feature_suffix=feature_suffix,
+            image_suffix=image_suffix,
+            min_matches=min_matches,
+            match_ratio=match_ratio,
+            resume=resume,
+        )
 
     plan = validate_match_index(match_index_path, candidate_index_path)
     index = plan["index"]
@@ -947,6 +1278,365 @@ def run_match_shards(
     return validated
 
 
+def _parse_persistent_key_value_record(line: str, prefix: str) -> dict[str, str]:
+    if not line.startswith(prefix + " "):
+        raise ValidationError(f"persistent worker log line does not start with {prefix!r}")
+    record: dict[str, str] = {}
+    for token in line[len(prefix) + 1 :].split():
+        key, separator, value = token.partition("=")
+        if not separator or not key or not value or key in record:
+            raise ValidationError(f"malformed persistent worker record: {line!r}")
+        record[key] = value
+    return record
+
+
+def parse_persistent_match_plan_header(path: Path) -> dict[str, str]:
+    """Read the worker's flushed plan-binding line from its stdout log."""
+
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        raise ValidationError(f"cannot read persistent worker log {path}: {exc}") from exc
+    for line in lines:
+        if line.startswith("persistent-match-plan "):
+            record = _parse_persistent_key_value_record(line, "persistent-match-plan")
+            if set(record) != {"candidate_index_sha256", "feature_manifest_sha256"}:
+                raise ValidationError(
+                    "persistent worker plan-binding line has unexpected fields"
+                )
+            for key in ("candidate_index_sha256", "feature_manifest_sha256"):
+                _sha256(record.get(key), f"persistent worker {key}")
+            return record
+    raise ValidationError(f"persistent worker log {path} has no plan-binding line")
+
+
+def parse_persistent_match_completions(path: Path) -> list[dict[str, Any]]:
+    """Parse flushed per-shard completion records, including a killed prefix."""
+
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        raise ValidationError(f"cannot read persistent worker log {path}: {exc}") from exc
+    required = {
+        "shard_id",
+        "candidate_path",
+        "snapshot_path",
+        "candidate_sha256",
+        "candidate_pairs",
+        "pairs",
+        "accepted",
+        "ordered_edge_fnv1a64",
+        "unordered_edge_fnv1a64",
+        "elapsed_s",
+    }
+    completions: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for line in lines:
+        if not line.startswith("persistent-match-complete "):
+            continue
+        record = _parse_persistent_key_value_record(line, "persistent-match-complete")
+        if set(record) != required:
+            raise ValidationError(
+                f"persistent worker completion has unexpected fields: {sorted(record)}"
+            )
+        try:
+            shard_id = int(record["shard_id"])
+            candidate_pairs = int(record["candidate_pairs"])
+            pairs = int(record["pairs"])
+            accepted = int(record["accepted"])
+            elapsed_s = float(record["elapsed_s"])
+        except ValueError as exc:
+            raise ValidationError(f"persistent worker completion has invalid numeric field: {line!r}") from exc
+        if shard_id < 0 or candidate_pairs < 0 or pairs < 0 or accepted < 0:
+            raise ValidationError(f"persistent worker completion has a negative count: {line!r}")
+        if not math.isfinite(elapsed_s) or elapsed_s < 0.0:
+            raise ValidationError(f"persistent worker completion has invalid elapsed_s: {line!r}")
+        if shard_id in seen:
+            raise ValidationError(f"persistent worker repeats completion for shard {shard_id}")
+        seen.add(shard_id)
+        candidate_path = _persistent_safe_relative(
+            record["candidate_path"], f"persistent shard {shard_id} candidate path"
+        )
+        snapshot_path = _persistent_safe_relative(
+            record["snapshot_path"], f"persistent shard {shard_id} snapshot path"
+        )
+        if candidate_path == snapshot_path:
+            raise ValidationError(
+                f"persistent worker shard {shard_id} reuses one path for candidate and snapshot"
+            )
+
+        def edge_hash(value: str, label: str) -> str:
+            if len(value) != 16 or any(char not in "0123456789abcdefABCDEF" for char in value):
+                raise ValidationError(f"persistent worker {label} must be a 16-digit hexadecimal hash")
+            return value.lower()
+
+        completions.append(
+            {
+                "shard_id": shard_id,
+                "candidate_path": candidate_path.as_posix(),
+                "snapshot_path": snapshot_path.as_posix(),
+                "candidate_sha256": _sha256(
+                    record["candidate_sha256"], f"persistent shard {shard_id} candidate hash"
+                ),
+                "candidate_pairs": candidate_pairs,
+                "pairs": pairs,
+                "accepted": accepted,
+                "ordered_edge_fnv1a64": edge_hash(
+                    record["ordered_edge_fnv1a64"], "ordered edge hash"
+                ),
+                "unordered_edge_fnv1a64": edge_hash(
+                    record["unordered_edge_fnv1a64"], "unordered edge hash"
+                ),
+                "elapsed_s": elapsed_s,
+            }
+        )
+    return completions
+
+
+def _apply_persistent_match_completions(
+    index: dict[str, Any],
+    plan_validation: dict[str, Any],
+    completions: list[dict[str, Any]],
+    *,
+    worker_measurement: dict[str, Any] | None = None,
+    worker_elapsed_s: float | None = None,
+    require_all: bool,
+) -> None:
+    """Install only hash-valid completed shards into a match index."""
+
+    plan = plan_validation["plan"]
+    pending_entries = {
+        entry["id"]: entry
+        for entry in index["shards"]
+        if entry["status"] != "complete"
+    }
+    plan_entries = {entry["id"]: entry for entry in plan["shards"]}
+    seen: set[int] = set()
+    # Completion paths are relative to the plan's artifact root.  Derive that
+    # root from the validated plan path rather than trusting a log to name an
+    # arbitrary output location.
+    plan_path = plan_validation.get("plan_path")
+    if not isinstance(plan_path, str) or not plan_path:
+        raise ValidationError("persistent worker validation omitted plan path")
+    plan_root = Path(plan_path).resolve().parent
+    for completion in completions:
+        shard_id = completion["shard_id"]
+        if shard_id in seen:
+            raise ValidationError(f"persistent worker repeats completion for shard {shard_id}")
+        seen.add(shard_id)
+        entry = pending_entries.get(shard_id)
+        expected = plan_entries.get(shard_id)
+        if entry is None or expected is None:
+            raise ValidationError(f"persistent worker completed unexpected shard {shard_id}")
+        if completion["candidate_path"] != expected["candidate_path"]:
+            raise ValidationError(f"persistent worker shard {shard_id} candidate path differs")
+        if completion["snapshot_path"] != expected["snapshot_path"]:
+            raise ValidationError(f"persistent worker shard {shard_id} snapshot path differs")
+        if completion["candidate_sha256"] != expected["candidate_sha256"]:
+            raise ValidationError(f"persistent worker shard {shard_id} candidate hash differs")
+        candidate_entry = plan_validation["candidate"]["shards"][shard_id]
+        if completion["candidate_pairs"] != candidate_entry["pair_count"]:
+            raise ValidationError(f"persistent worker shard {shard_id} candidate pair count differs")
+        if completion["pairs"] > completion["candidate_pairs"]:
+            raise ValidationError(f"persistent worker shard {shard_id} verified pair count exceeds candidates")
+        snapshot_path = plan_root / completion["snapshot_path"]
+        actual_hash = sha256_file(snapshot_path)
+        entry.update(
+            {
+                "status": "complete",
+                "snapshot_sha256": actual_hash,
+                "elapsed_s": completion["elapsed_s"],
+                "ordered_edge_fnv1a64": completion["ordered_edge_fnv1a64"],
+                "unordered_edge_fnv1a64": completion["unordered_edge_fnv1a64"],
+                "accepted_correspondences": completion["accepted"],
+            }
+        )
+        if worker_measurement is not None:
+            measurement = dict(worker_measurement)
+            measurement["elapsed_s"] = completion["elapsed_s"]
+            if worker_elapsed_s is not None:
+                measurement["worker_elapsed_s"] = worker_elapsed_s
+            entry["measurement"] = measurement
+    missing = sorted(set(pending_entries) - seen)
+    if require_all and missing:
+        raise ValidationError(f"persistent worker omitted completion records for shards {missing}")
+
+
+def _recover_persistent_worker_log(
+    index: dict[str, Any],
+    match_index_path: Path,
+    candidate_index_path: Path,
+    feature_manifest_path: Path,
+) -> None:
+    """Recover flushed snapshots if the runner died before its index update."""
+
+    worker_plan = index.get("worker_plan")
+    if not isinstance(worker_plan, str) or not worker_plan:
+        return
+    plan_path = Path(worker_plan).expanduser().resolve()
+    artifact_root = match_index_path.resolve().parent.parent
+    try:
+        plan_path.relative_to(artifact_root)
+    except ValueError as exc:
+        raise ValidationError("persistent worker plan is outside the artifact root") from exc
+    log_path = match_index_path.resolve().parent / "persistent-match.log"
+    if not plan_path.is_file() or not log_path.is_file():
+        return
+    try:
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ValidationError(f"cannot read persistent worker log {log_path}: {exc}") from exc
+    if "persistent-match-" not in log_text:
+        return
+    plan_validation = validate_persistent_match_worker_plan(
+        plan_path,
+        candidate_index_path,
+        match_index_path,
+        feature_manifest_path,
+        allow_completed=True,
+    )
+    plan_validation["plan_path"] = str(plan_path)
+    header = parse_persistent_match_plan_header(log_path)
+    plan = plan_validation["plan"]
+    if header["candidate_index_sha256"] != plan["candidate_index_sha256"]:
+        raise ValidationError("persistent worker recovery candidate index binding differs")
+    if header["feature_manifest_sha256"] != plan["feature_manifest_sha256"]:
+        raise ValidationError("persistent worker recovery feature manifest binding differs")
+    completions = parse_persistent_match_completions(log_path)
+    plan_ids = {entry["id"] for entry in plan["shards"]}
+    if any(completion["shard_id"] not in plan_ids for completion in completions):
+        raise ValidationError("persistent worker recovery contains an unknown shard")
+    pending_ids = {
+        entry["id"] for entry in index["shards"] if entry["status"] != "complete"
+    }
+    # A runner that was interrupted after atomically updating the index may
+    # leave the same completion line in its log.  The index hash validation
+    # above already authenticates those completed snapshots; only apply the
+    # still-pending prefix to the current index.
+    completions = [
+        completion for completion in completions if completion["shard_id"] in pending_ids
+    ]
+    if not completions:
+        return
+    before = {
+        entry["id"]: entry.get("status") for entry in index["shards"]
+    }
+    _apply_persistent_match_completions(
+        index, plan_validation, completions, require_all=False
+    )
+    if any(before[entry["id"]] != entry.get("status") for entry in index["shards"]):
+        atomic_json(match_index_path, index)
+
+
+def run_persistent_matcher(
+    candidate_index_path: Path,
+    match_index_path: Path,
+    *,
+    binary: Path,
+    features_dir: Path,
+    calibration_dir: Path,
+    feature_manifest_path: Path,
+    images_dir: Path | None = None,
+    feature_suffix: str = "_features.txt",
+    image_suffix: str = ".png",
+    min_matches: int = 30,
+    match_ratio: float = 0.8,
+    resume: bool = True,
+) -> dict[str, Any]:
+    """Run all pending shards through one Rust feature-bank process."""
+
+    validated = validate_match_index(match_index_path, candidate_index_path)
+    index = validated["index"]
+    if not resume and any(entry["status"] == "complete" for entry in index["shards"]):
+        raise ValidationError("a persistent match shard is already complete; pass --resume")
+    _recover_persistent_worker_log(
+        index, match_index_path, candidate_index_path, feature_manifest_path
+    )
+    plan_path = write_persistent_match_worker_plan(
+        candidate_index_path, match_index_path, feature_manifest_path
+    )
+    if plan_path is None:
+        existing = index.get("persistent_worker")
+        if isinstance(existing, dict):
+            return {**validated, "persistent_worker": existing}
+        return validated
+    plan_validation = validate_persistent_match_worker_plan(
+        plan_path, candidate_index_path, match_index_path, feature_manifest_path
+    )
+    plan_validation["plan_path"] = str(plan_path.resolve())
+    pending_ids = {entry["id"] for entry in plan_validation["pending"]}
+    for entry in index["shards"]:
+        if entry["id"] in pending_ids:
+            entry["status"] = "running"
+    index["worker_mode"] = "persistent-v1"
+    index["worker_plan"] = str(plan_path.resolve())
+    atomic_json(match_index_path, index)
+    root = match_index_path.resolve().parent
+    command = build_persistent_match_command(
+        binary,
+        features_dir=features_dir,
+        calibration_dir=calibration_dir,
+        plan=plan_path,
+        feature_suffix=feature_suffix,
+        image_suffix=image_suffix,
+        images_dir=images_dir,
+        min_matches=min_matches,
+        match_ratio=match_ratio,
+    )
+    timing_path = root.parent / "timing" / "persistent-match.time.txt"
+    log_path = root / "persistent-match.log"
+    try:
+        worker_elapsed = _run_command(
+            command,
+            log_path,
+            timing_path=timing_path,
+            env_overrides=PERSISTENT_MATCH_ENV,
+        )
+    except (ValidationError, OSError):
+        # The Rust worker flushes one completion line after every atomic
+        # snapshot.  Recover that flushed prefix before marking the remainder
+        # failed, so a SIGKILL never recomputes a valid completed shard.
+        try:
+            partial = parse_persistent_match_completions(log_path)
+            _apply_persistent_match_completions(index, plan_validation, partial, require_all=False)
+        except ValidationError:
+            partial = []
+        for entry in index["shards"]:
+            if entry["id"] in pending_ids and entry["status"] != "complete":
+                entry["status"] = "failed"
+        atomic_json(match_index_path, index)
+        raise
+    header = parse_persistent_match_plan_header(log_path)
+    if header["candidate_index_sha256"] != plan_validation["plan"]["candidate_index_sha256"]:
+        raise ValidationError("persistent worker candidate index binding differs from plan")
+    if header["feature_manifest_sha256"] != plan_validation["plan"]["feature_manifest_sha256"]:
+        raise ValidationError("persistent worker feature manifest binding differs from plan")
+    completions = parse_persistent_match_completions(log_path)
+    worker_measurement = measured_phase(timing_path, worker_elapsed)
+    _apply_persistent_match_completions(
+        index,
+        plan_validation,
+        completions,
+        worker_measurement=worker_measurement,
+        worker_elapsed_s=worker_elapsed,
+        require_all=True,
+    )
+    persistent_worker = {
+        "mode": "persistent-v1",
+        "plan": str(plan_path.resolve()),
+        "plan_sha256": sha256_file(plan_path),
+        "elapsed_s": worker_elapsed,
+        "shard_elapsed_sum_s": sum(entry["elapsed_s"] for entry in completions),
+        "measurement": worker_measurement,
+        "environment": dict(PERSISTENT_MATCH_ENV),
+        "shards": len(completions),
+    }
+    index["persistent_worker"] = persistent_worker
+    atomic_json(match_index_path, index)
+    validated = validate_match_index(match_index_path, candidate_index_path)
+    return {**validated, "persistent_worker": persistent_worker}
+
+
 def build_merge_command(merge_binary: Path, output: Path, snapshots: list[Path]) -> list[str]:
     if not snapshots:
         raise ValidationError("cannot merge an empty snapshot list")
@@ -956,10 +1646,22 @@ def build_merge_command(merge_binary: Path, output: Path, snapshots: list[Path])
     return command
 
 
-def merge_match_shards(match_index_path: Path, *, merge_binary: Path, output: Path) -> dict[str, Any]:
-    index = _load_json(match_index_path, "match index")
-    if index.get("schema") != MATCH_INDEX_SCHEMA:
-        raise ValidationError("match index has unsupported schema")
+def merge_match_shards(
+    match_index_path: Path,
+    *,
+    candidate_index_path: Path | None = None,
+    merge_binary: Path,
+    output: Path,
+) -> dict[str, Any]:
+    """Merge only a hash-valid, complete match index."""
+
+    if candidate_index_path is None:
+        candidate_index_path = (
+            match_index_path.resolve().parent.parent / "candidates" / "index.json"
+        )
+    index = validate_match_index(
+        match_index_path, candidate_index_path, require_complete=True
+    )["index"]
     root = match_index_path.resolve().parent
     snapshots = []
     for entry in index.get("shards", []):
@@ -975,6 +1677,7 @@ def merge_match_shards(match_index_path: Path, *, merge_binary: Path, output: Pa
         build_merge_command(merge_binary, output, snapshots),
         root / "merge.log",
         timing_path=timing_path,
+        env_overrides=MEMORY_BOUNDED_MERGE_ENV,
     )
     return {
         "output": str(output),
@@ -1006,7 +1709,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--artifact-root", type=Path, required=True, help="external run root")
     parser.add_argument("--candidate-manifest", type=Path, help="existing generated candidate manifest")
     parser.add_argument("--feature-manifest", type=Path)
-    parser.add_argument("--pairs-per-shard", type=int, default=256)
+    parser.add_argument(
+        "--pairs-per-shard",
+        type=int,
+        help="candidate pairs per shard (default: 32 with --persistent-matcher, otherwise 256)",
+    )
     parser.add_argument("--retrieval-topk", type=int, default=32)
     parser.add_argument(
         "--pair-source",
@@ -1026,6 +1733,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--image-suffix", default=".png")
     parser.add_argument("--min-matches", type=int, default=30)
     parser.add_argument("--match-ratio", type=float, default=0.8)
+    parser.add_argument(
+        "--persistent-matcher",
+        action="store_true",
+        help="run all pending match shards in one plan-driven Rust worker (opt-in)",
+    )
     parser.add_argument("--min-pnp-inliers", type=int, default=12)
     parser.add_argument("--max-mapper-matches-per-pair", type=int)
     parser.add_argument(
@@ -1043,7 +1755,12 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     mode = "verify" if args.verify_only or not any((args.prepare, args.match, args.map, args.run)) else next(name for name, value in (("prepare", args.prepare), ("match", args.match), ("map", args.map), ("run", args.run)) if value)
+    pairs_per_shard = args.pairs_per_shard
+    if pairs_per_shard is None:
+        pairs_per_shard = 32 if args.persistent_matcher else 256
     try:
+        if args.persistent_matcher and mode not in {"match", "run"}:
+            raise ValidationError("--persistent-matcher is only valid with --match or --run")
         artifact_root = args.artifact_root.expanduser().resolve()
         if mode == "verify":
             if not artifact_root.is_dir():
@@ -1087,6 +1804,7 @@ def main(argv: list[str] | None = None) -> int:
         candidate_sharding_elapsed = None
         merge_result = None
         mapping_measurement = None
+        persistent_worker_measurement = None
         if mode in {"prepare", "run"}:
             if not candidate_source.is_file():
                 candidate_source.parent.mkdir(parents=True, exist_ok=True)
@@ -1117,7 +1835,7 @@ def main(argv: list[str] | None = None) -> int:
             split_candidate_manifest(
                 candidate_source,
                 candidate_dir,
-                args.pairs_per_shard,
+                pairs_per_shard,
                 resume=not args.no_resume,
                 retrieval_topk=args.retrieval_topk,
                 local_stem_window=(
@@ -1140,6 +1858,13 @@ def main(argv: list[str] | None = None) -> int:
         if mode in {"verify", "match", "map"} and not candidate_index_path.is_file():
             raise ValidationError(f"candidate index is missing: {candidate_index_path}; run --prepare first")
         candidate_summary = validate_candidate_shards(candidate_index_path)
+        if args.persistent_matcher and any(
+            int(shard["pair_count"]) > 32 for shard in candidate_summary["shards"]
+        ):
+            raise ValidationError(
+                "--persistent-matcher requires candidate shards with at most 32 pairs; "
+                "prepare them with --pairs-per-shard 32"
+            )
         feature_names = feature_summary.get("image_names")
         if feature_names != candidate_summary["image_names"]:
             raise ValidationError(
@@ -1154,7 +1879,7 @@ def main(argv: list[str] | None = None) -> int:
         if mode in {"match", "run"}:
             if not match_index_path.is_file() or args.no_resume:
                 prepare_match_index(candidate_index_path, match_dir)
-            run_match_shards(
+            match_result = run_match_shards(
                 candidate_index_path,
                 match_index_path,
                 binary=binary,
@@ -1166,10 +1891,16 @@ def main(argv: list[str] | None = None) -> int:
                 min_matches=args.min_matches,
                 match_ratio=args.match_ratio,
                 resume=not args.no_resume,
+                persistent_matcher=args.persistent_matcher,
+                feature_manifest_path=feature_manifest_path,
             )
+            persistent_worker_measurement = match_result.get("persistent_worker")
             merged_snapshot = artifact_root / "mapping" / "verified-merged.vps"
             merge_result = merge_match_shards(
-                match_index_path, merge_binary=merge_binary, output=merged_snapshot
+                match_index_path,
+                candidate_index_path=candidate_index_path,
+                merge_binary=merge_binary,
+                output=merged_snapshot,
             )
         else:
             merged_snapshot = artifact_root / "mapping" / "verified-merged.vps"
@@ -1215,6 +1946,7 @@ def main(argv: list[str] | None = None) -> int:
                 if candidate_sharding_elapsed is not None
                 else None
             ),
+            "persistent_worker": persistent_worker_measurement,
             "match_shards": match_measurements,
             "matching_elapsed_sum_s": sum(
                 float(entry.get("elapsed_s", 0.0)) for entry in match_measurements

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -78,6 +78,15 @@ pub struct Snapshot {
 /// uses the argument order as its deterministic pair order and recomputes the
 /// two stream-integrity hashes and accepted-match count.
 pub fn merge(snapshots: &[Snapshot]) -> Result<Snapshot, String> {
+    merge_owned(snapshots.to_vec())
+}
+
+/// Merge owned snapshot shards while moving pair payloads into the result.
+///
+/// This is the bounded-memory path for large shard sets: unlike [`merge`], it
+/// does not clone every raw/inlier/mapping vector while the decoded inputs are
+/// still resident. Envelope validation and output ordering are identical.
+pub fn merge_owned(mut snapshots: Vec<Snapshot>) -> Result<Snapshot, String> {
     let first = snapshots
         .first()
         .ok_or_else(|| "cannot merge an empty verified-pair snapshot list".to_owned())?;
@@ -109,11 +118,10 @@ pub fn merge(snapshots: &[Snapshot]) -> Result<Snapshot, String> {
                 "snapshot shard {index} camera envelope differs from shard 0"
             ));
         }
-        // `effective_config` is the complete CLI diagnostic and therefore
-        // includes shard-specific candidate/output paths.  Stream
+        // Older shards may carry a complete CLI diagnostic in
+        // `effective_config`, including candidate/output paths. Stream
         // compatibility is defined by the path-independent verifier config;
-        // retain shard 0's diagnostic envelope in the merged snapshot while
-        // the runner's index records every shard command/path separately.
+        // the merged envelope below canonicalizes old and new shards alike.
         if snapshot.verifier_config_hash != first.verifier_config_hash
             || snapshot.verifier_config != first.verifier_config
         {
@@ -123,10 +131,20 @@ pub fn merge(snapshots: &[Snapshot]) -> Result<Snapshot, String> {
         }
     }
 
-    let image_count = first.image_names.len();
-    let mut pairs = Vec::new();
+    let image_names = first.image_names.clone();
+    let image_manifest_hash = first.image_manifest_hash;
+    let feature_manifest_hash = first.feature_manifest_hash;
+    let feature_counts = first.feature_counts.clone();
+    let width = first.width;
+    let height = first.height;
+    let intrinsics_bits = first.intrinsics_bits;
+    let verifier_config_hash = first.verifier_config_hash;
+    let verifier_config = first.verifier_config.clone();
+    let image_count = image_names.len();
+    let pair_count = snapshots.iter().map(|snapshot| snapshot.pairs.len()).sum();
+    let mut pairs = Vec::with_capacity(pair_count);
     let mut seen = std::collections::HashSet::new();
-    for snapshot in snapshots {
+    for snapshot in &mut snapshots {
         for pair in &snapshot.pairs {
             let image_i = usize::try_from(pair.image_i)
                 .map_err(|_| "snapshot pair image_i does not fit usize".to_owned())?;
@@ -144,27 +162,29 @@ pub fn merge(snapshots: &[Snapshot]) -> Result<Snapshot, String> {
                     key.0, key.1
                 ));
             }
-            pairs.push(pair.clone());
         }
+        pairs.append(&mut snapshot.pairs);
     }
 
     let accepted_match_count = pairs
         .iter()
         .map(|pair| pair.matches.len() as u64)
         .sum::<u64>();
+    let effective_config = format!("verified-pair-export-v1;{verifier_config}");
+    let effective_config_hash = fnv1a64(effective_config.as_bytes());
     Ok(Snapshot {
         schema_version: SCHEMA_VERSION,
-        image_names: first.image_names.clone(),
-        image_manifest_hash: first.image_manifest_hash,
-        feature_manifest_hash: first.feature_manifest_hash,
-        feature_counts: first.feature_counts.clone(),
-        width: first.width,
-        height: first.height,
-        intrinsics_bits: first.intrinsics_bits,
-        effective_config_hash: first.effective_config_hash,
-        effective_config: first.effective_config.clone(),
-        verifier_config_hash: first.verifier_config_hash,
-        verifier_config: first.verifier_config.clone(),
+        image_names,
+        image_manifest_hash,
+        feature_manifest_hash,
+        feature_counts,
+        width,
+        height,
+        intrinsics_bits,
+        effective_config_hash,
+        effective_config,
+        verifier_config_hash,
+        verifier_config,
         pair_order_hash: ordered_pair_hash(&pairs),
         unordered_edge_hash: unordered_edge_hash(&pairs),
         accepted_match_count,
@@ -798,6 +818,14 @@ mod tests {
         assert_eq!((merged.pairs[0].image_i, merged.pairs[0].image_j), (0, 1));
         assert_eq!((merged.pairs[1].image_i, merged.pairs[1].image_j), (1, 2));
         assert_eq!(merged.accepted_match_count, 4);
+        assert_eq!(
+            merged.effective_config,
+            format!("verified-pair-export-v1;{}", first.verifier_config)
+        );
+        assert_eq!(
+            merged.effective_config_hash,
+            super::fnv1a64(merged.effective_config.as_bytes())
+        );
         assert_eq!(
             merged.pair_order_hash,
             super::ordered_pair_hash(&merged.pairs)

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -27,6 +27,38 @@ class ElectroBenchmarkTests(unittest.TestCase):
         benchmark.write_candidate_manifest(path, names, pairs)
         return path, names, pairs
 
+    def _feature_manifest(self, root: Path, names: list[str]) -> Path:
+        features = root / "features"
+        features.mkdir()
+        for name in names:
+            (features / name.replace(".png", "_features.txt")).write_text(
+                "0 0 1 2\n", encoding="utf-8"
+            )
+        path = root / "features.json"
+        benchmark.write_feature_manifest(path, benchmark.feature_manifest(features))
+        benchmark.validate_feature_manifest(path, features)
+        return path
+
+    @staticmethod
+    def _gnu_time_report(path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "\n".join(
+                [
+                    "User time (seconds): 0.01",
+                    "System time (seconds): 0.00",
+                    "Maximum resident set size (kbytes): 2048",
+                    "Major (requiring I/O) page faults: 0",
+                    "Minor (reclaiming a frame) page faults: 1",
+                    "File system inputs: 0",
+                    "File system outputs: 8",
+                    "Exit status: 0",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
     def test_candidate_shards_are_contiguous_and_hash_bound(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -289,6 +321,206 @@ class ElectroBenchmarkTests(unittest.TestCase):
             self.assertIn("64", temporal_candidate_command)
             self.assertNotIn("--local-stem-window", temporal_candidate_command)
             self.assertNotIn("--rig-local-grouping", temporal_candidate_command)
+
+    def test_persistent_plan_binds_pending_shards_and_rejects_unsafe_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, names, _ = self._candidate(root)
+            benchmark.split_candidate_manifest(source, root / "candidates", 2)
+            candidate_index = root / "candidates" / "index.json"
+            benchmark.prepare_match_index(candidate_index, root / "matches")
+            match_index = root / "matches" / "index.json"
+            feature_manifest = self._feature_manifest(root, names)
+
+            plan_path = benchmark.write_persistent_match_worker_plan(
+                candidate_index, match_index, feature_manifest
+            )
+            self.assertIsNotNone(plan_path)
+            assert plan_path is not None
+            parsed = benchmark.parse_persistent_match_worker_plan(plan_path)
+            validation = benchmark.validate_persistent_match_worker_plan(
+                plan_path, candidate_index, match_index, feature_manifest
+            )
+            self.assertEqual(parsed["image_names"], names)
+            self.assertEqual(
+                [shard["id"] for shard in parsed["shards"]], [0, 1, 2]
+            )
+            self.assertEqual(validation["plan_path"], str(plan_path.resolve()))
+
+            lines = plan_path.read_text(encoding="utf-8").splitlines()
+            shard_line = next(index for index, line in enumerate(lines) if line.startswith("shard "))
+            fields = lines[shard_line].split()
+            fields[2] = "../escape.txt"
+            unsafe = root / "unsafe.plan"
+            unsafe.write_text(
+                "\n".join(lines[:shard_line] + [" ".join(fields)] + lines[shard_line + 1 :])
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(benchmark.ValidationError, "relative path"):
+                benchmark.parse_persistent_match_worker_plan(unsafe)
+
+            duplicate = root / "duplicate.plan"
+            duplicate_lines = plan_path.read_text(encoding="utf-8").splitlines()
+            first = next(index for index, line in enumerate(duplicate_lines) if line.startswith("shard "))
+            second = first + 1
+            second_fields = duplicate_lines[second].split()
+            first_fields = duplicate_lines[first].split()
+            second_fields[3] = first_fields[3]
+            duplicate_lines[second] = " ".join(second_fields)
+            duplicate.write_text("\n".join(duplicate_lines) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "repeats"):
+                benchmark.parse_persistent_match_worker_plan(duplicate)
+
+            command = benchmark.build_persistent_match_command(
+                Path("/bin/visloc"),
+                features_dir=root / "features",
+                calibration_dir=root / "calibration",
+                plan=plan_path,
+            )
+            self.assertIn("--persistent-match-worker-plan", command)
+            self.assertIn("--verification-mode", command)
+            self.assertIn("full", command)
+            self.assertIn("--matcher", command)
+            self.assertIn("nn", command)
+            self.assertIn("--mapper", command)
+            self.assertIn("incremental", command)
+            self.assertNotIn("--gt", command)
+            self.assertNotIn("points3D.txt", command)
+
+    def test_persistent_completion_parser_rejects_corruption_and_duplicate_records(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "persistent-match.log"
+            hash_value = "a" * 64
+            line = (
+                "persistent-match-complete shard_id=0 candidate_path=candidates/a.txt "
+                "snapshot_path=matches/a.vps candidate_sha256="
+                f"{hash_value} candidate_pairs=2 pairs=1 accepted=3 "
+                "ordered_edge_fnv1a64=0123456789abcdef "
+                "unordered_edge_fnv1a64=fedcba9876543210 elapsed_s=1.25"
+            )
+            log.write_text(line + "\n", encoding="utf-8")
+            parsed = benchmark.parse_persistent_match_completions(log)
+            self.assertEqual(parsed[0]["shard_id"], 0)
+            self.assertEqual(parsed[0]["accepted"], 3)
+            self.assertEqual(parsed[0]["ordered_edge_fnv1a64"], "0123456789abcdef")
+
+            log.write_text(line + "\n" + line + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "repeats"):
+                benchmark.parse_persistent_match_completions(log)
+            log.write_text(line.replace("candidate_path=candidates/a.txt", "candidate_path=../a.txt") + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.ValidationError, "relative path"):
+                benchmark.parse_persistent_match_completions(log)
+
+    def test_persistent_matcher_recovers_flushed_prefix_and_skips_it_on_resume(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, names, _ = self._candidate(root)
+            benchmark.split_candidate_manifest(source, root / "candidates", 2)
+            candidate_index = root / "candidates" / "index.json"
+            benchmark.prepare_match_index(candidate_index, root / "matches")
+            match_index = root / "matches" / "index.json"
+            feature_manifest = self._feature_manifest(root, names)
+
+            def completion_line(shard: dict[str, object], pair_count: int) -> str:
+                return (
+                    "persistent-match-complete "
+                    f"shard_id={shard['id']} candidate_path={shard['candidate_path']} "
+                    f"snapshot_path={shard['snapshot_path']} "
+                    f"candidate_sha256={shard['candidate_sha256']} "
+                    f"candidate_pairs={pair_count} pairs=1 accepted=1 "
+                    "ordered_edge_fnv1a64=0123456789abcdef "
+                    "unordered_edge_fnv1a64=fedcba9876543210 elapsed_s=1.25"
+                )
+
+            calls: list[list[str]] = []
+
+            def killed(command, log_path, *, timing_path=None, **_kwargs):
+                calls.append(command)
+                plan = benchmark.parse_persistent_match_worker_plan(
+                    Path(command[command.index("--persistent-match-worker-plan") + 1])
+                )
+                shard = plan["shards"][0]
+                snapshot = root / shard["snapshot_path"]
+                snapshot.parent.mkdir(parents=True, exist_ok=True)
+                snapshot.write_bytes(b"snapshot-0")
+                log_path.write_text(
+                    "persistent-match-plan "
+                    f"candidate_index_sha256={plan['candidate_index_sha256']} "
+                    f"feature_manifest_sha256={plan['feature_manifest_sha256']}\n"
+                    + completion_line(shard, 2)
+                    + "\n",
+                    encoding="utf-8",
+                )
+                raise benchmark.ValidationError("injected SIGKILL")
+
+            with mock.patch.object(benchmark, "_run_command", side_effect=killed):
+                with self.assertRaisesRegex(benchmark.ValidationError, "injected SIGKILL"):
+                    benchmark.run_persistent_matcher(
+                        candidate_index,
+                        match_index,
+                        binary=Path("/bin/visloc"),
+                        features_dir=root / "features",
+                        calibration_dir=root,
+                        feature_manifest_path=feature_manifest,
+                    )
+            partial = json.loads(match_index.read_text(encoding="utf-8"))
+            self.assertEqual([entry["status"] for entry in partial["shards"]], ["complete", "failed", "failed"])
+            first_snapshot = root / "matches" / partial["shards"][0]["snapshot_path"]
+            first_bytes = first_snapshot.read_bytes()
+
+            def completed(command, log_path, *, timing_path=None, **_kwargs):
+                calls.append(command)
+                plan = benchmark.parse_persistent_match_worker_plan(
+                    Path(command[command.index("--persistent-match-worker-plan") + 1])
+                )
+                records = [
+                    "persistent-match-plan "
+                    f"candidate_index_sha256={plan['candidate_index_sha256']} "
+                    f"feature_manifest_sha256={plan['feature_manifest_sha256']}"
+                ]
+                for shard in plan["shards"]:
+                    snapshot = root / shard["snapshot_path"]
+                    snapshot.parent.mkdir(parents=True, exist_ok=True)
+                    snapshot.write_bytes(f"snapshot-{shard['id']}".encode())
+                    records.append(completion_line(shard, 2 if shard["id"] < 2 else 1))
+                log_path.write_text("\n".join(records) + "\n", encoding="utf-8")
+                assert timing_path is not None
+                self._gnu_time_report(timing_path)
+                return 2.5
+
+            with mock.patch.object(benchmark, "_run_command", side_effect=completed):
+                result = benchmark.run_persistent_matcher(
+                    candidate_index,
+                    match_index,
+                    binary=Path("/bin/visloc"),
+                    features_dir=root / "features",
+                    calibration_dir=root,
+                    feature_manifest_path=feature_manifest,
+                )
+            self.assertEqual(len(calls), 2)
+            resumed_plan = benchmark.parse_persistent_match_worker_plan(
+                Path(calls[1][calls[1].index("--persistent-match-worker-plan") + 1])
+            )
+            self.assertEqual([shard["id"] for shard in resumed_plan["shards"]], [1, 2])
+            self.assertEqual(first_snapshot.read_bytes(), first_bytes)
+            self.assertEqual(result["persistent_worker"]["shards"], 2)
+            complete = json.loads(match_index.read_text(encoding="utf-8"))
+            self.assertEqual([entry["status"] for entry in complete["shards"]], ["complete"] * 3)
+
+            with mock.patch.object(benchmark, "_run_command", side_effect=AssertionError("rerun")):
+                benchmark.run_persistent_matcher(
+                    candidate_index,
+                    match_index,
+                    binary=Path("/bin/visloc"),
+                    features_dir=root / "features",
+                    calibration_dir=root,
+                    feature_manifest_path=feature_manifest,
+                )
+            first_snapshot.write_bytes(b"corrupt")
+            with self.assertRaisesRegex(benchmark.ValidationError, "hash mismatch"):
+                benchmark.validate_match_index(match_index, candidate_index, require_complete=True)
 
     def test_temporal_candidate_policy_is_hash_bound_in_shard_index(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- add an opt-in versioned persistent matching worker with atomic resumable shards and strict recovery validation
- make exact cross-check matching use one GEMM/scan, add exact RANSAC upper-bound exits, and merge snapshots by ownership
- publish the Electro 1,200-image M4 audit and refresh the README above the fold with the measured GIF, comparison image, and COLMAP table

## Electro 1,200 results

- end-to-end: **1,649.48 s vs COLMAP 5,705.05 s (3.46x faster)**
- matching: **439.01 s**, down from 2,085.89 s (4.75x)
- owned merge peak RSS: **1.56 GiB**, down 22.3%
- quality: **1200/1200**, 0.03501 m centre RMSE
- frozen feature bank, candidate manifest, verified-pair snapshot, and final model remain exact under the documented hashes

## Validation

- `cargo test --workspace --all-targets`
- `python3 -m unittest tests.test_benchmark_electro` (15 tests)
- `cargo clippy -p visloc-vision -- -D warnings`
- `cargo clippy -p visloc-rs --lib -- -D warnings`
- `cargo clippy -p visloc-rs --example unordered_sfm_demo --example merge_verified_pair_snapshots --features image-io -- -D warnings`
- `cargo fmt --all -- --check`
- JSON validation and `git diff --check`
