### PR TITLE
perf(sfm): stream descriptors with scale-aware ANN retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@
   <img src="https://img.shields.io/badge/core-no%20mandatory%20ML%20runtime-35d0ba" alt="No mandatory ML runtime">
 </p>
 
+## Measured at a glance
+
+| Real-data result | visloc-rs | COLMAP 3.9.1 CPU | Outcome |
+| --- | ---: | ---: | ---: |
+| ETH3D Electro 1,200, same-input CPU8 end to end | **27:29** | 1:35:05 | **3.46× faster** |
+| ETH3D Electro registered cameras | **1200/1200** | **1200/1200** | parity |
+| ETH3D Electro camera-centre RMSE | **3.50 cm** | 4.68 cm | **25.2% lower** |
+| ETH3D Courtyard camera-centre RMSE | **0.5379 cm** | 1.6166 cm | **66.7% lower** |
+
+The comparisons use real images and measured runs; the detailed sections below
+state where inputs or accounting differ. Separately, on the connected
+OpenLORIS 10k stress set, streamed VLAD + LSH cuts visloc-rs candidate
+generation from 49:49 to **8:51 (5.63×)**. No COLMAP 10k run has been made, so
+that number is not presented as a COLMAP comparison. The frozen measurements
+and output hashes are in
+[`m6-ann-streaming.json`](benchmarks/electro/m6-ann-streaming.json).
+
 ## 10,008-image real-world SfM scale validation
 
 <p align="center">
@@ -48,20 +65,6 @@ tunnel RMSE includes one 5.32 m outlier; its median is 2.47 cm and p95 is
   <a href="docs/assets/eth3d_10008_scale_validation.png"><img src="docs/assets/eth3d_10008_scale_validation.png" alt="Full-resolution still of ten measured ETH3D camera-centre reconstructions" width="900"></a><br>
   <sub>Full-resolution measured still · each trajectory is independently PCA-projected only for display.</sub>
 </p>
-
-### Memory stays bounded as evidence grows
-
-| Measured A/B on identical bytes | Before | Final | Change |
-| --- | ---: | ---: | ---: |
-| 730-shard snapshot merge peak | 5.35 GiB | **2.03 GiB** | **−62.0%** |
-| sand_box mapper peak | 4.03 GiB | **3.32 GiB** | **−17.7%** |
-| tunnel mapper peak | 4.47 GiB | **3.25 GiB** | **−27.4%** |
-| tunnel model identity | baseline | **3/3 files byte-identical** | exact |
-| 100k-image I/O replay | — | **33.6 MiB** | ~32N pairs, no N² matrix |
-
-The mapper-validating reader checks the full file checksum and every raw-index
-relation one pair at a time, then releases audit-only vectors before mapping.
-The on-disk snapshot format and final model bytes do not change.
 
 ## Same-input COLMAP speed comparison — Electro 1,200
 
@@ -125,6 +128,12 @@ OpenLORIS corridor inputs in **1:03:45** with a **1.78 GiB** peak. This passes
 the resource gate, not the reconstruction-quality gate: registration is strong
 at 1k, plateaus near 1.2k, then falls to 199 at the full tier. We report that
 failure instead of presenting the run as a complete 10k map.
+
+The opt-in streamed global-descriptor path now builds the same 70,000-pair
+envelope in **8:51**, versus 49:49 for exact all-image ranking. At the frozen
+1k quality gate, its scale-aware LSH schedule registers **991/1000** images,
+versus 989/1000 for exact retrieval. The 10k mapping-quality failure below is
+still open; faster retrieval does not by itself claim to solve it.
 
 | Connected tier | Candidate / verified pairs | Registered | Total wall | Peak phase RSS |
 | --- | ---: | ---: | ---: | ---: |

--- a/benchmarks/electro/m6-ann-streaming.json
+++ b/benchmarks/electro/m6-ann-streaming.json
@@ -1,0 +1,59 @@
+{
+  "schema": "visloc_m6_ann_streaming_evidence_v1",
+  "base_commit": "0609ba273dcd30e6f9bfc3cce6b0a23c5c499195",
+  "dataset": "OpenLORIS corridor1-1",
+  "candidate_policy": {
+    "pair_source": "temporal-pyramid",
+    "retrieval_topk": 32,
+    "temporal_pyramid_max_offset": 32,
+    "candidate_budget_per_image": 7,
+    "retrieval_backend": "vlad-lsh-v1",
+    "ann_tables": 8,
+    "ann_bits": "6 + floor(log2(max(image_count / 1000, 1)))",
+    "ann_probes": "6 by default; measured 10k speed gate overrides to 9"
+  },
+  "tier_1000_quality_gate": {
+    "exact": {
+      "candidate_generation_elapsed_s": 51.84,
+      "candidate_pairs": 7000,
+      "registered_images": 989,
+      "supplied_images": 1000
+    },
+    "streamed_lsh": {
+      "candidate_generation_elapsed_s": 41.10,
+      "candidate_manifest_sha256": "7ecfee4b27b73e6122c5871b4ecfabdb861b399de58329405701395b02488343",
+      "candidate_pairs": 7000,
+      "exact_manifest_pair_overlap": 6914,
+      "exact_manifest_pair_overlap_ratio": 0.9877142857142857,
+      "registered_images": 991,
+      "supplied_images": 1000,
+      "tracks": 2806,
+      "observations": 30595,
+      "mean_reprojection_px": 1.581,
+      "model_sha256": {
+        "cameras.txt": "e404161535ccb894a786448b9c9933af3e482647e314e9fa2e63b30900061a3a",
+        "images.txt": "688a4ce13dcb46c082511d11ff4ab89a32319ed78235290b4088c5a688595822",
+        "points3D.txt": "f0b8811f315bf9f55dc4ec5ad087e33d7d8d4a9eb3484a280cd54b324cfc50d5"
+      }
+    }
+  },
+  "tier_10000_speed_gate": {
+    "exact_candidate_generation_elapsed_s": 2989.03,
+    "streamed_lsh_candidate_generation_elapsed_s": 531.2827715440071,
+    "speedup": 5.626059594127787,
+    "candidate_pairs": 70000,
+    "ann_bits": 9,
+    "ann_probes_in_measured_run": 9,
+    "mean_ann_pool": 1517.0,
+    "max_ann_pool": 1910,
+    "exact_fallback_queries": 0,
+    "candidate_manifest_sha256": "96fae454555cc2632afabdd3cd1b26d530badb5bab1fe8ac24536d18bbbb6a51",
+    "parallel_vlad_manifest_matches_serial": true,
+    "quality_status": "candidate-generation-only; full 10k mapping quality remains open"
+  },
+  "claims": {
+    "colmap_10k_comparison": false,
+    "ground_truth_used_for_selection_or_mapping": false,
+    "readme_memory_before_after_table": false
+  }
+}

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -28,6 +28,10 @@
 //!      `--candidate-budget` with highest-scoring VLAD retrieval pairs.
 //!      This is deterministic and GT-free; it is useful when numeric
 //!      timestamps are irregular or have large nanosecond gaps.
+//!      File-backed exports can add `--stream-candidate-features` to release
+//!      local descriptors per image. `--retrieval-backend lsh` enables the
+//!      deterministic approximate index; `--ann-bits 0` scales its signature
+//!      width with the image count.
 //!    - `vocab-tree`: `visloc_rs::vision::vocab_tree`'s hierarchical-k-means
 //!      vocabulary + TF-IDF/Hamming-embedding inverted-file retrieval
 //!      (COLMAP's `VocabTreePairGenerator`-equivalent, M3 in
@@ -564,6 +568,26 @@ enum PairSource {
     /// base pass, then expands transitively for
     /// [`TRANSITIVE_ROUNDS`] rounds.
     Transitive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetrievalBackend {
+    Exact,
+    Lsh,
+}
+
+impl std::str::FromStr for RetrievalBackend {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "exact" => Ok(Self::Exact),
+            "lsh" => Ok(Self::Lsh),
+            other => Err(format!(
+                "unknown --retrieval-backend {other:?} (expected exact|lsh)"
+            )),
+        }
+    }
 }
 
 impl std::str::FromStr for PairSource {
@@ -2487,6 +2511,19 @@ struct Args {
     candidate_manifest: Option<PathBuf>,
     /// Export the generated candidate manifest and exit before matching.
     export_candidate_manifest: Option<PathBuf>,
+    /// File-backed candidate-export mode that retains only the bounded
+    /// vocabulary sample and one VLAD descriptor per image. Local descriptor
+    /// payloads are parsed in deterministic passes and released per file.
+    stream_candidate_features: bool,
+    /// Global-descriptor neighbour search used by streamed temporal-pyramid
+    /// candidate export. Exact preserves historical output; LSH is opt-in.
+    retrieval_backend: RetrievalBackend,
+    /// Number of deterministic feature-hash projection tables for LSH.
+    ann_tables: usize,
+    /// Signature width per LSH table (1..=63, or 0 for scale-aware auto).
+    ann_bits: usize,
+    /// Lowest-margin one-bit buckets probed per table.
+    ann_probes: usize,
     /// M5 (`docs/colmap_port_plan.md`): run the opt-in rescue-bridging pass
     /// after initial verification (see the file header's step 4).
     rescue_bridging: bool,
@@ -3372,8 +3409,17 @@ fn candidate_pairs_temporal_pyramid(
     max_offset: u64,
     budget: Option<usize>,
 ) -> Result<Vec<(usize, usize)>, String> {
-    let (temporal, cross_camera) = rig_temporal_pyramid_pairs(image_names, max_offset)?;
     let retrieval = candidate_pairs_vlad_scored(features, vocab_size, topk, false, false);
+    candidate_pairs_temporal_pyramid_from_retrieval(image_names, retrieval, max_offset, budget)
+}
+
+fn candidate_pairs_temporal_pyramid_from_retrieval(
+    image_names: &[String],
+    retrieval: Vec<((usize, usize), f32)>,
+    max_offset: u64,
+    budget: Option<usize>,
+) -> Result<Vec<(usize, usize)>, String> {
+    let (temporal, cross_camera) = rig_temporal_pyramid_pairs(image_names, max_offset)?;
     let mut selected = Vec::new();
     let mut seen = HashSet::<(usize, usize)>::new();
     for pair in temporal.into_iter().chain(cross_camera) {
@@ -4204,6 +4250,11 @@ where
     let mut persistent_match_worker_plan: Option<PathBuf> = None;
     let mut candidate_manifest: Option<PathBuf> = None;
     let mut export_candidate_manifest: Option<PathBuf> = None;
+    let mut stream_candidate_features = false;
+    let mut retrieval_backend = RetrievalBackend::Exact;
+    let mut ann_tables = 8usize;
+    let mut ann_bits = 0usize;
+    let mut ann_probes = 6usize;
     let mut snapshot_coordinate_override_dir: Option<PathBuf> = None;
     let mut diagnose_ba_oracle_poses_file: Option<PathBuf> = None;
     let mut diagnose_fixed_rotation_ba: Option<String> = None;
@@ -4956,6 +5007,28 @@ where
                 a.remove(i + 1);
                 export_candidate_manifest = Some(PathBuf::from(raw));
             }
+            "--stream-candidate-features" => stream_candidate_features = true,
+            "--retrieval-backend" => {
+                retrieval_backend = a.remove(i + 1).parse()?;
+            }
+            "--ann-tables" => {
+                ann_tables = a
+                    .remove(i + 1)
+                    .parse()
+                    .map_err(|error| format!("{error}"))?
+            }
+            "--ann-bits" => {
+                ann_bits = a
+                    .remove(i + 1)
+                    .parse()
+                    .map_err(|error| format!("{error}"))?
+            }
+            "--ann-probes" => {
+                ann_probes = a
+                    .remove(i + 1)
+                    .parse()
+                    .map_err(|error| format!("{error}"))?
+            }
             "--snapshot-coordinate-override-dir" => {
                 let raw = a
                     .get(i + 1)
@@ -5241,6 +5314,32 @@ where
     {
         return Err(
             "--export-candidate-manifest cannot be combined with imported pair streams".into(),
+        );
+    }
+    if stream_candidate_features
+        && (feature_extractor != FeatureExtractorKind::Files
+            || export_candidate_manifest.is_none()
+            || input_colmap_calibration.is_none()
+            || pair_source != PairSource::TemporalPyramid)
+    {
+        return Err(
+            "--stream-candidate-features currently requires --feature-extractor files, --input-colmap-calibration, --pair-source temporal-pyramid, and --export-candidate-manifest"
+                .into(),
+        );
+    }
+    if retrieval_backend != RetrievalBackend::Exact && !stream_candidate_features {
+        return Err(
+            "--retrieval-backend lsh currently requires --stream-candidate-features".into(),
+        );
+    }
+    if ann_tables == 0
+        || ann_bits > 63
+        || ann_probes > 63
+        || (ann_bits != 0 && ann_probes > ann_bits)
+    {
+        return Err(
+            "ANN settings require --ann-tables >= 1, --ann-bits auto (0) or 1..=63, and --ann-probes <= the effective bit count"
+                .into(),
         );
     }
     if diagnose_colmap_track_membership.is_some() && mapper != MapperKind::Incremental {
@@ -5688,6 +5787,11 @@ where
         pair_source,
         candidate_manifest,
         export_candidate_manifest,
+        stream_candidate_features,
+        retrieval_backend,
+        ann_tables,
+        ann_bits,
+        ann_probes,
         vocab_tree_branching,
         vocab_tree_depth,
         vocab_tree_num_images,
@@ -8945,6 +9049,127 @@ fn list_feature_files(
     Ok(files)
 }
 
+#[derive(Debug)]
+struct StreamedVladGlobals {
+    globals: Option<Vec<Vec<f32>>>,
+    total_descriptors: usize,
+    sampled_descriptors: usize,
+}
+
+fn count_feature_rows(path: &Path) -> Result<usize, Box<dyn std::error::Error>> {
+    Ok(std::fs::read_to_string(path)?
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .count())
+}
+
+fn validate_streamed_candidate_feature(
+    image: usize,
+    feature_set: &FeatureSet,
+    camera: &Camera,
+) -> Result<(), String> {
+    feature_set
+        .validate()
+        .map_err(|error| format!("candidate feature image {image} is invalid: {error}"))?;
+    for (keypoint, point) in feature_set.keypoints.iter().enumerate() {
+        if !point.x.is_finite()
+            || !point.y.is_finite()
+            || point.x < 0.0
+            || point.y < 0.0
+            || point.x >= camera.width as f64
+            || point.y >= camera.height as f64
+        {
+            return Err(format!(
+                "candidate feature image {image} keypoint {keypoint} ({}, {}) is outside {}x{}",
+                point.x, point.y, camera.width, camera.height
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Build the historical VLAD vocabulary and per-image globals without ever
+/// retaining the local descriptor bank. A cheap row-count prepass fixes the
+/// historical global stride; the following two descriptor passes collect the
+/// bounded training sample, then aggregate one image at a time.
+fn stream_vlad_globals_from_feature_files(
+    dir: &Path,
+    files: &[String],
+    rig: &PerImageCameras,
+    vocab_size: usize,
+) -> Result<StreamedVladGlobals, Box<dyn std::error::Error>> {
+    if files.len() != rig.len() {
+        return Err(format!(
+            "streamed candidate feature/calibration count mismatch: {} files vs {} cameras",
+            files.len(),
+            rig.len()
+        )
+        .into());
+    }
+    let row_counts = files
+        .iter()
+        .map(|file| count_feature_rows(&dir.join(file)))
+        .collect::<Result<Vec<_>, _>>()?;
+    let total_descriptors = row_counts.iter().sum::<usize>();
+    let stride = (total_descriptors / VLAD_VOCAB_SAMPLE).max(1);
+    let mut sample = Vec::<Vec<f32>>::with_capacity(
+        total_descriptors
+            .div_ceil(stride)
+            .min(VLAD_VOCAB_SAMPLE + 1),
+    );
+    let mut global_row = 0usize;
+    for (image, (file, &expected_rows)) in files.iter().zip(&row_counts).enumerate() {
+        let feature_set = read_feature_set(&dir.join(file))?;
+        validate_streamed_candidate_feature(image, &feature_set, rig.camera(image)?)?;
+        if feature_set.descriptors.len() != expected_rows {
+            return Err(format!(
+                "{} row-count prepass found {expected_rows}, parser found {}",
+                dir.join(file).display(),
+                feature_set.descriptors.len()
+            )
+            .into());
+        }
+        for descriptor in feature_set.descriptors {
+            if global_row % stride == 0 {
+                sample.push(descriptor);
+            }
+            global_row += 1;
+        }
+    }
+    let sample_refs = sample.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let Some(vocab) = Vocabulary::build(&sample_refs, vocab_size, 10, 0) else {
+        return Ok(StreamedVladGlobals {
+            globals: None,
+            total_descriptors,
+            sampled_descriptors: sample.len(),
+        });
+    };
+    drop(sample_refs);
+    drop(sample);
+    trim_process_allocator();
+
+    // Ordered parallel collection preserves the canonical image/global index
+    // mapping. Each worker owns only one local feature set, so peak storage is
+    // bounded by the Rayon worker count instead of the image count.
+    let globals = files
+        .par_iter()
+        .enumerate()
+        .map(|(image, file)| -> Result<Vec<f32>, String> {
+            let feature_set = read_feature_set(&dir.join(file))
+                .map_err(|error| format!("cannot read {}: {error}", dir.join(file).display()))?;
+            let camera = rig.camera(image).map_err(|error| error.to_string())?;
+            validate_streamed_candidate_feature(image, &feature_set, camera)?;
+            Ok(vlad(&feature_set.descriptors, &vocab))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(StreamedVladGlobals {
+        globals: Some(globals),
+        total_descriptors,
+        sampled_descriptors: total_descriptors.div_ceil(stride),
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SnapshotFeatureFileFingerprint {
     keypoint_hash: u64,
@@ -9514,13 +9739,14 @@ fn canonicalize_pairwise_loci(
 /// the vocab-tree: both only need a representative sample. Strides the full
 /// descriptor list down to ~`VOCAB_SAMPLE`. Shared by
 /// [`candidate_pairs_vlad`] and [`candidate_pairs_vocab_tree`] (M3).
+const VLAD_VOCAB_SAMPLE: usize = 40_000;
+
 fn sampled_training_descriptors(features: &[FeatureSet]) -> Vec<&[f32]> {
-    const VOCAB_SAMPLE: usize = 40_000;
     let all_desc: Vec<&[f32]> = features
         .iter()
         .flat_map(|f| f.descriptors.iter().map(|d| d.as_slice()))
         .collect();
-    let stride = (all_desc.len() / VOCAB_SAMPLE).max(1);
+    let stride = (all_desc.len() / VLAD_VOCAB_SAMPLE).max(1);
     all_desc.iter().step_by(stride).copied().collect()
 }
 
@@ -9534,6 +9760,150 @@ fn all_pairs(n: usize) -> Vec<(usize, usize)> {
         }
     }
     pairs
+}
+
+/// Return the exact same `(image, cosine)` top-K as a full descending sort,
+/// while retaining at most K scored rows for one query. The deterministic
+/// image-index tie break is part of the candidate-manifest contract.
+fn exact_topk_similar_images(query: usize, globals: &[Vec<f32>], topk: usize) -> Vec<(usize, f32)> {
+    if topk == 0 {
+        return Vec::new();
+    }
+    let mut best = Vec::<(usize, f32)>::with_capacity(topk.min(globals.len().saturating_sub(1)));
+    for candidate in 0..globals.len() {
+        if candidate == query {
+            continue;
+        }
+        let row = (
+            candidate,
+            cosine_similarity(&globals[query], &globals[candidate]),
+        );
+        insert_exact_topk_row(&mut best, row, topk);
+    }
+    best
+}
+
+fn insert_exact_topk_row(best: &mut Vec<(usize, f32)>, row: (usize, f32), topk: usize) {
+    let position = best.partition_point(|existing| {
+        existing
+            .1
+            .total_cmp(&row.1)
+            .reverse()
+            .then_with(|| existing.0.cmp(&row.0))
+            .is_lt()
+    });
+    if position < topk {
+        best.insert(position, row);
+        if best.len() > topk {
+            best.pop();
+        }
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e3779b97f4a7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d049bb133111eb);
+    value ^ (value >> 31)
+}
+
+fn lsh_signature(global: &[f32], table: usize, bits: usize) -> (u64, Vec<usize>) {
+    let mut projections = vec![0.0f32; bits];
+    let table_seed = (table as u64).wrapping_mul(0xd6e8feb86659fd93);
+    for (dimension, &value) in global.iter().enumerate() {
+        let hash = splitmix64((dimension as u64) ^ table_seed);
+        let bit = (hash as usize) % bits;
+        let sign = if hash & (1 << 63) == 0 { 1.0 } else { -1.0 };
+        projections[bit] += sign * value;
+    }
+    let mut signature = 0u64;
+    for (bit, &projection) in projections.iter().enumerate() {
+        if projection >= 0.0 {
+            signature |= 1u64 << bit;
+        }
+    }
+    let mut probe_bits = (0..bits).collect::<Vec<_>>();
+    probe_bits.sort_by(|&lhs, &rhs| {
+        projections[lhs]
+            .abs()
+            .total_cmp(&projections[rhs].abs())
+            .then_with(|| lhs.cmp(&rhs))
+    });
+    (signature, probe_bits)
+}
+
+/// Deterministic multi-table feature-hash LSH. Buckets propose a bounded pool;
+/// original VLAD cosine re-ranks that pool, so approximation affects only
+/// neighbour recall rather than the score ordering of retrieved images.
+fn candidate_pairs_vlad_lsh_scored(
+    globals: &[Vec<f32>],
+    topk: usize,
+    tables: usize,
+    bits: usize,
+    probes: usize,
+) -> Vec<((usize, usize), f32)> {
+    let n = globals.len();
+    if n <= topk + 1 {
+        return all_pairs(n).into_iter().map(|pair| (pair, 0.0)).collect();
+    }
+    let mut signatures = vec![vec![0u64; n]; tables];
+    let mut probe_orders = vec![vec![Vec::<usize>::new(); n]; tables];
+    let mut buckets = (0..tables)
+        .map(|_| BTreeMap::<u64, Vec<usize>>::new())
+        .collect::<Vec<_>>();
+    for table in 0..tables {
+        for (image, global) in globals.iter().enumerate() {
+            let (signature, order) = lsh_signature(global, table, bits);
+            signatures[table][image] = signature;
+            probe_orders[table][image] = order;
+            buckets[table].entry(signature).or_default().push(image);
+        }
+    }
+
+    let mut scores = BTreeMap::<(usize, usize), f32>::new();
+    let mut fallback_queries = 0usize;
+    let mut pool_sum = 0usize;
+    let mut pool_max = 0usize;
+    for query in 0..n {
+        let mut pool = HashSet::<usize>::new();
+        for table in 0..tables {
+            let signature = signatures[table][query];
+            if let Some(images) = buckets[table].get(&signature) {
+                pool.extend(images.iter().copied().filter(|&image| image != query));
+            }
+            for &bit in probe_orders[table][query].iter().take(probes) {
+                if let Some(images) = buckets[table].get(&(signature ^ (1u64 << bit))) {
+                    pool.extend(images.iter().copied().filter(|&image| image != query));
+                }
+            }
+        }
+        if pool.len() < topk {
+            fallback_queries += 1;
+            pool.extend((0..n).filter(|&image| image != query));
+        }
+        pool_sum += pool.len();
+        pool_max = pool_max.max(pool.len());
+        let mut best = Vec::<(usize, f32)>::with_capacity(topk);
+        for candidate in pool {
+            let row = (
+                candidate,
+                cosine_similarity(&globals[query], &globals[candidate]),
+            );
+            insert_exact_topk_row(&mut best, row, topk);
+        }
+        for (candidate, score) in best {
+            let pair = (query.min(candidate), query.max(candidate));
+            scores
+                .entry(pair)
+                .and_modify(|best| *best = best.max(score))
+                .or_insert(score);
+        }
+    }
+    println!(
+        "VLAD LSH: tables={tables} bits={bits} probes={probes} mean_pool={:.1} max_pool={pool_max} exact_fallback_queries={fallback_queries}",
+        pool_sum as f64 / n.max(1) as f64,
+    );
+    scores.into_iter().collect()
 }
 
 /// Candidate image pairs `(i, j)` with `i < j` from flat-VLAD top-K cosine
@@ -9561,15 +9931,20 @@ fn candidate_pairs_vlad_scored(
         .map(|f| vlad(&f.descriptors, &vocab))
         .collect();
 
+    candidate_pairs_vlad_scored_from_globals(&globals, topk, mutual)
+}
+
+fn candidate_pairs_vlad_scored_from_globals(
+    globals: &[Vec<f32>],
+    topk: usize,
+    mutual: bool,
+) -> Vec<((usize, usize), f32)> {
+    let n = globals.len();
+
     let mut scores = std::collections::BTreeMap::<(usize, usize), f32>::new();
     let mut neighbors = vec![HashSet::<usize>::new(); n];
     for i in 0..n {
-        let mut sims: Vec<(usize, f32)> = (0..n)
-            .filter(|&j| j != i)
-            .map(|j| (j, cosine_similarity(&globals[i], &globals[j])))
-            .collect();
-        sims.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-        for &(j, score) in sims.iter().take(topk) {
+        for (j, score) in exact_topk_similar_images(i, globals, topk) {
             neighbors[i].insert(j);
             let pair = (i.min(j), i.max(j));
             if !mutual || neighbors[j].contains(&i) {
@@ -9586,12 +9961,10 @@ fn candidate_pairs_vlad_scored(
         // symmetric and independent of image traversal order.
         scores.clear();
         for i in 0..n {
-            let mut sims: Vec<(usize, f32)> = (0..n)
-                .filter(|&j| j != i && neighbors[i].contains(&j) && neighbors[j].contains(&i))
-                .map(|j| (j, cosine_similarity(&globals[i], &globals[j])))
-                .collect();
-            sims.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-            for (j, score) in sims {
+            for (j, score) in exact_topk_similar_images(i, globals, topk)
+                .into_iter()
+                .filter(|(j, _)| neighbors[i].contains(j) && neighbors[*j].contains(&i))
+            {
                 let pair = (i.min(j), i.max(j));
                 scores
                     .entry(pair)
@@ -9813,7 +10186,20 @@ fn candidate_pairs(
 /// descriptive rather than used to reconstruct pairs: the image-name-bound
 /// pair list remains the authority, while this block makes an archived
 /// manifest auditable and lets sharding tools preserve the exact schedule.
-fn candidate_manifest_metadata(args: &Args) -> BTreeMap<String, String> {
+fn effective_ann_bits(requested: usize, image_count: usize) -> usize {
+    if requested != 0 {
+        return requested;
+    }
+    let mut bits = 6usize;
+    let mut scale = (image_count / 1_000).max(1);
+    while scale >= 2 && bits < 63 {
+        bits += 1;
+        scale /= 2;
+    }
+    bits
+}
+
+fn candidate_manifest_metadata(args: &Args, image_count: usize) -> BTreeMap<String, String> {
     let mut metadata = BTreeMap::new();
     let (policy, pair_source) = match args.pair_source {
         PairSource::Vlad => ("vlad-topk-v1", "vlad"),
@@ -9826,6 +10212,18 @@ fn candidate_manifest_metadata(args: &Args) -> BTreeMap<String, String> {
     metadata.insert("candidate_policy".to_owned(), policy.to_owned());
     metadata.insert("pair_source".to_owned(), pair_source.to_owned());
     metadata.insert("retrieval_topk".to_owned(), args.retrieval_topk.to_string());
+    if args.retrieval_backend == RetrievalBackend::Lsh {
+        metadata.insert("retrieval_backend".to_owned(), "vlad-lsh-v1".to_owned());
+        metadata.insert("ann_tables".to_owned(), args.ann_tables.to_string());
+        metadata.insert(
+            "ann_bits".to_owned(),
+            effective_ann_bits(args.ann_bits, image_count).to_string(),
+        );
+        if args.ann_bits == 0 {
+            metadata.insert("ann_bits_mode".to_owned(), "auto-v1".to_owned());
+        }
+        metadata.insert("ann_probes".to_owned(), args.ann_probes.to_string());
+    }
     if args.pair_source == PairSource::VladUnion {
         metadata.insert(
             "local_grouping".to_owned(),
@@ -14830,6 +15228,80 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Err("--sift-stream-export requires building with --features image-io".into());
         }
     }
+    if args.stream_candidate_features {
+        let files = list_feature_files(&args.features_dir, &args.feature_suffix)?;
+        let image_names = files
+            .iter()
+            .map(|file| image_name_for(file, &args.feature_suffix, &args.image_suffix))
+            .collect::<Vec<_>>();
+        let calibration_root = args
+            .input_colmap_calibration
+            .as_deref()
+            .ok_or("--stream-candidate-features requires --input-colmap-calibration")?;
+        let calibration = resolve_input_colmap_calibration(calibration_root, &image_names)?;
+        validate_calibration_image_dimensions(
+            &calibration.rig,
+            &image_names,
+            args.images_dir.as_deref(),
+        )?;
+        let streamed = stream_vlad_globals_from_feature_files(
+            &args.features_dir,
+            &files,
+            &calibration.rig,
+            args.vocab_size,
+        )?;
+        log_process_memory("example-after-streamed-vlad-globals");
+        let retrieval = if let Some(globals) = streamed.globals.as_deref() {
+            match args.retrieval_backend {
+                RetrievalBackend::Exact => {
+                    candidate_pairs_vlad_scored_from_globals(globals, args.retrieval_topk, false)
+                }
+                RetrievalBackend::Lsh => {
+                    let bits = effective_ann_bits(args.ann_bits, globals.len());
+                    if args.ann_probes > bits {
+                        return Err(format!(
+                            "--ann-probes {} exceeds effective --ann-bits {bits}",
+                            args.ann_probes
+                        )
+                        .into());
+                    }
+                    candidate_pairs_vlad_lsh_scored(
+                        globals,
+                        args.retrieval_topk,
+                        args.ann_tables,
+                        bits,
+                        args.ann_probes,
+                    )
+                }
+            }
+        } else {
+            all_pairs(image_names.len())
+                .into_iter()
+                .map(|pair| (pair, 0.0))
+                .collect()
+        };
+        let generated = candidate_pairs_temporal_pyramid_from_retrieval(
+            &image_names,
+            retrieval,
+            args.temporal_pyramid_max_offset,
+            args.candidate_budget,
+        )?;
+        let path = args
+            .export_candidate_manifest
+            .as_deref()
+            .ok_or("streamed candidate export lost its output path")?;
+        let metadata = candidate_manifest_metadata(&args, image_names.len());
+        write_candidate_manifest_with_metadata(path, &image_names, &generated, &metadata)?;
+        println!(
+            "streamed candidate manifest: {} pairs / {} images / {} local descriptors / {} vocabulary samples -> {}",
+            generated.len(),
+            image_names.len(),
+            streamed.total_descriptors,
+            streamed.sampled_descriptors,
+            path.display(),
+        );
+        return Ok(());
+    }
     let mut snapshot_feature_paths: Option<Vec<PathBuf>> = None;
     let mut snapshot_feature_fingerprints: Option<Vec<SnapshotFeatureFileFingerprint>> = None;
     let (
@@ -15404,7 +15876,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let generated = candidate_pairs(&features, &image_names, &args)?;
         let generated =
             filter_pairs_by_stem_window(generated, &image_names, args.pair_stem_window)?;
-        let metadata = candidate_manifest_metadata(&args);
+        let metadata = candidate_manifest_metadata(&args, image_names.len());
         write_candidate_manifest_with_metadata(path, &image_names, &generated, &metadata)?;
         println!(
             "candidate manifest: exported {} pairs for {} images to {}",
@@ -16788,10 +17260,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod diagnose_cli_tests {
     use super::{
         apply_snapshot_coordinate_override, apply_union_traversal_order,
-        apply_union_traversal_order_with_features, candidate_pairs_vlad_union,
-        canonicalize_feature_order, canonicalize_pairwise_loci, cap_mapper_pair_matches,
-        colmap_guided_geometry, colmap_guided_matches, descriptor_squared_distance,
-        effective_config_hash, effective_config_snapshot,
+        apply_union_traversal_order_with_features, candidate_pairs_vlad_lsh_scored,
+        candidate_pairs_vlad_scored, candidate_pairs_vlad_scored_from_globals,
+        candidate_pairs_vlad_union, canonicalize_feature_order, canonicalize_pairwise_loci,
+        cap_mapper_pair_matches, colmap_guided_geometry, colmap_guided_matches,
+        descriptor_squared_distance, effective_ann_bits, effective_config_hash,
+        effective_config_snapshot, exact_topk_similar_images,
         filter_imported_verified_pairs_by_stem_window, filter_pairs_by_stem_window,
         imported_reference_quality_is_strong, initial_poses_from_colmap_images_txt,
         initial_poses_from_colmap_images_txt_with_expected_cameras, load_images,
@@ -16799,10 +17273,11 @@ mod diagnose_cli_tests {
         model_cross_validation_is_held_out, model_cross_validation_is_held_out_for_pixels,
         model_cross_validation_selection_score, parse_args_from, parse_candidate_manifest,
         parse_candidate_manifest_with_metadata, parse_colmap_image_camera_assignments,
-        parse_colmap_track_membership, parse_diagnose_stems, remap_feature_keypoints_by_old_to_new,
-        replace_feature_keypoints_from_native, rig_local_pairs, rig_temporal_pyramid_pairs,
-        robust_huber_mean, snapshot_export_config, snapshot_feature_manifest_hash,
-        snapshot_feature_validation_from_files, summarize_model_cross_validation_bucket,
+        parse_colmap_track_membership, parse_diagnose_stems, read_feature_set,
+        remap_feature_keypoints_by_old_to_new, replace_feature_keypoints_from_native,
+        rig_local_pairs, rig_temporal_pyramid_pairs, robust_huber_mean, snapshot_export_config,
+        snapshot_feature_manifest_hash, snapshot_feature_validation_from_files,
+        stream_vlad_globals_from_feature_files, summarize_model_cross_validation_bucket,
         temporal_pyramid_offsets_string, translation_direction_delta_deg,
         unordered_pairwise_edge_hash, validate_diagnose_options, verified_pair_oracle_map,
         write_candidate_manifest, write_candidate_manifest_with_metadata, Camera,
@@ -16813,7 +17288,7 @@ mod diagnose_cli_tests {
     };
     use nalgebra::{Matrix3, Point2, Vector3};
     use std::cmp::Ordering as CmpOrdering;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashSet};
     use std::path::{Path, PathBuf};
     use visloc_rs::vision::features::FeatureSet;
     use visloc_rs::DescriptorMatch;
@@ -16993,6 +17468,43 @@ mod diagnose_cli_tests {
             "0",
         ]))
         .is_err());
+
+        let ann_args: Vec<String> = [
+            "--feature-extractor",
+            "files",
+            "--features-dir",
+            "/tmp/features",
+            "--input-colmap-calibration",
+            "/tmp/calibration",
+            "--pair-source",
+            "temporal-pyramid",
+            "--export-candidate-manifest",
+            "/tmp/candidates.txt",
+            "--stream-candidate-features",
+            "--retrieval-backend",
+            "lsh",
+            "--ann-tables",
+            "6",
+            "--ann-bits",
+            "14",
+            "--ann-probes",
+            "8",
+            "--out-colmap",
+            "/tmp/unused-model",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+        let ann = parse_args_from(ann_args).unwrap();
+        assert_eq!(ann.retrieval_backend, super::RetrievalBackend::Lsh);
+        assert_eq!((ann.ann_tables, ann.ann_bits, ann.ann_probes), (6, 14, 8));
+        assert_eq!(effective_ann_bits(0, 999), 6);
+        assert_eq!(effective_ann_bits(0, 1_000), 6);
+        assert_eq!(effective_ann_bits(0, 2_500), 7);
+        assert_eq!(effective_ann_bits(0, 5_000), 8);
+        assert_eq!(effective_ann_bits(0, 10_000), 9);
+        assert_eq!(effective_ann_bits(12, 10_000), 12);
+        assert!(parse_args_from(minimal_args(&["--retrieval-backend", "lsh"])).is_err());
         assert!(parse_args_from(minimal_args(&[
             "--pair-source",
             "temporal-pyramid",
@@ -17018,6 +17530,101 @@ mod diagnose_cli_tests {
         assert_eq!(first, second);
         assert!(first.len() <= 3);
         assert!(first.iter().all(|&(i, j)| i < j && j < features.len()));
+    }
+
+    #[test]
+    fn bounded_exact_topk_matches_full_sort_with_stable_ties() {
+        let globals = vec![
+            vec![1.0, 0.0],
+            vec![0.8, 0.2],
+            vec![0.8, -0.2],
+            vec![0.0, 1.0],
+            vec![-1.0, 0.0],
+        ];
+        for query in 0..globals.len() {
+            for topk in 0..=globals.len() + 1 {
+                let mut full: Vec<_> = (0..globals.len())
+                    .filter(|&candidate| candidate != query)
+                    .map(|candidate| {
+                        (
+                            candidate,
+                            super::cosine_similarity(&globals[query], &globals[candidate]),
+                        )
+                    })
+                    .collect();
+                full.sort_by(|lhs, rhs| rhs.1.total_cmp(&lhs.1).then_with(|| lhs.0.cmp(&rhs.0)));
+                full.truncate(topk);
+                assert_eq!(exact_topk_similar_images(query, &globals, topk), full);
+            }
+        }
+    }
+
+    #[test]
+    fn streamed_vlad_globals_preserve_batch_candidate_pairs() {
+        let root = std::env::temp_dir().join(format!(
+            "visloc_streamed_vlad_candidates_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let mut files = Vec::new();
+        let mut features = Vec::new();
+        for image in 0..5 {
+            let file = format!("image_{image:03}_features.txt");
+            let rows = (0..4)
+                .map(|row| {
+                    format!(
+                        "{} {} 1.0 {} {}\n",
+                        10 + row,
+                        20 + image,
+                        image as f32 + row as f32 * 0.25 + 1.0,
+                        (image + row) as f32 * 0.5 + 0.5,
+                    )
+                })
+                .collect::<String>();
+            std::fs::write(root.join(&file), rows).unwrap();
+            files.push(file.clone());
+            features.push(read_feature_set(&root.join(file)).unwrap());
+        }
+        let rig = PerImageCameras::new(
+            (0..files.len())
+                .map(|image| Camera::pinhole(image as u64, 100, 100, 50.0, 50.0, 50.0, 50.0))
+                .collect(),
+        )
+        .unwrap();
+        let streamed = stream_vlad_globals_from_feature_files(&root, &files, &rig, 3).unwrap();
+        assert_eq!(streamed.total_descriptors, 20);
+        assert_eq!(streamed.sampled_descriptors, 20);
+        let streamed_pairs = candidate_pairs_vlad_scored_from_globals(
+            streamed.globals.as_deref().unwrap(),
+            2,
+            false,
+        );
+        let batch_pairs = candidate_pairs_vlad_scored(&features, 3, 2, false, false);
+        assert_eq!(streamed_pairs, batch_pairs);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn vlad_lsh_is_deterministic_and_recovers_identical_neighbours() {
+        let mut globals = Vec::new();
+        for pair in 0..20 {
+            let descriptor = (0..64)
+                .map(|dimension| (((pair * 67 + dimension * 17) % 101) as f32 - 50.0) / 50.0)
+                .collect::<Vec<_>>();
+            globals.push(descriptor.clone());
+            globals.push(descriptor);
+        }
+        let first = candidate_pairs_vlad_lsh_scored(&globals, 1, 4, 8, 8);
+        let second = candidate_pairs_vlad_lsh_scored(&globals, 1, 4, 8, 8);
+        assert_eq!(first, second);
+        let pairs = first
+            .into_iter()
+            .map(|(pair, _)| pair)
+            .collect::<HashSet<_>>();
+        for pair in 0..20 {
+            assert!(pairs.contains(&(pair * 2, pair * 2 + 1)));
+        }
     }
 
     #[test]

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -689,6 +689,11 @@ def build_candidate_command(
     rig_local_grouping: bool = False,
     pair_source: str = "vlad-union",
     temporal_pyramid_max_offset: int = 32,
+    stream_candidate_features: bool = False,
+    retrieval_backend: str = "exact",
+    ann_tables: int = 8,
+    ann_bits: int = 0,
+    ann_probes: int = 6,
 ) -> list[str]:
     """Build the GT-free command that generates one candidate manifest."""
 
@@ -698,6 +703,19 @@ def build_candidate_command(
         )
     if temporal_pyramid_max_offset <= 0:
         raise ValidationError("temporal_pyramid_max_offset must be positive")
+    if retrieval_backend not in {"exact", "lsh"}:
+        raise ValidationError(f"unsupported retrieval_backend {retrieval_backend!r}")
+    if retrieval_backend == "lsh" and not stream_candidate_features:
+        raise ValidationError("LSH retrieval requires stream_candidate_features")
+    if (
+        ann_tables <= 0
+        or not 0 <= ann_bits <= 63
+        or not 0 <= ann_probes <= 63
+        or (ann_bits != 0 and ann_probes > ann_bits)
+    ):
+        raise ValidationError(
+            "ANN settings require ann_tables >= 1, ann_bits auto (0) or 1..=63, and ann_probes <= the effective bit count"
+        )
 
     command = [
         str(binary),
@@ -732,6 +750,21 @@ def build_candidate_command(
         command.extend(["--temporal-pyramid-max-offset", str(temporal_pyramid_max_offset)])
     if candidate_budget is not None:
         command.extend(["--candidate-budget", str(candidate_budget)])
+    if stream_candidate_features:
+        command.append("--stream-candidate-features")
+    if retrieval_backend == "lsh":
+        command.extend(
+            [
+                "--retrieval-backend",
+                "lsh",
+                "--ann-tables",
+                str(ann_tables),
+                "--ann-bits",
+                str(ann_bits),
+                "--ann-probes",
+                str(ann_probes),
+            ]
+        )
     return command
 
 
@@ -1761,6 +1794,20 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--temporal-pyramid-max-offset", type=int, default=32)
     parser.add_argument("--candidate-budget", type=int)
+    parser.add_argument(
+        "--stream-candidate-features",
+        action="store_true",
+        help="stream feature files while building global descriptors",
+    )
+    parser.add_argument(
+        "--retrieval-backend",
+        choices=("exact", "lsh"),
+        default="exact",
+        help="global-descriptor retrieval backend (LSH requires streaming)",
+    )
+    parser.add_argument("--ann-tables", type=int, default=8)
+    parser.add_argument("--ann-bits", type=int, default=0, help="LSH bits (0: scale automatically with image count)")
+    parser.add_argument("--ann-probes", type=int, default=6)
     parser.add_argument("--feature-suffix", default="_features.txt")
     parser.add_argument("--image-suffix", default=".png")
     parser.add_argument("--min-matches", type=int, default=30)
@@ -1868,6 +1915,11 @@ def main(argv: list[str] | None = None) -> int:
                         rig_local_grouping=args.rig_local_grouping,
                         pair_source=args.pair_source,
                         temporal_pyramid_max_offset=args.temporal_pyramid_max_offset,
+                        stream_candidate_features=args.stream_candidate_features,
+                        retrieval_backend=args.retrieval_backend,
+                        ann_tables=args.ann_tables,
+                        ann_bits=args.ann_bits,
+                        ann_probes=args.ann_probes,
                     ),
                     artifact_root / "candidate-generation.log",
                     timing_path=candidate_timing_path,

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -346,6 +346,38 @@ class ElectroBenchmarkTests(unittest.TestCase):
             self.assertNotIn("--local-stem-window", temporal_candidate_command)
             self.assertNotIn("--rig-local-grouping", temporal_candidate_command)
 
+            ann_candidate_command = benchmark.build_candidate_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                candidate_manifest=Path("/run/ann-candidates.txt"),
+                pair_source="temporal-pyramid",
+                stream_candidate_features=True,
+                retrieval_backend="lsh",
+                ann_tables=8,
+                ann_bits=6,
+                ann_probes=6,
+            )
+            self.assertIn("--stream-candidate-features", ann_candidate_command)
+            self.assertEqual(
+                ann_candidate_command[ann_candidate_command.index("--retrieval-backend") + 1],
+                "lsh",
+            )
+            self.assertEqual(
+                ann_candidate_command[ann_candidate_command.index("--ann-tables") + 1], "8"
+            )
+            self.assertEqual(
+                ann_candidate_command[ann_candidate_command.index("--ann-bits") + 1], "6"
+            )
+            with self.assertRaisesRegex(benchmark.ValidationError, "requires stream"):
+                benchmark.build_candidate_command(
+                    Path("/bin/visloc"),
+                    features_dir=Path("/input/features"),
+                    calibration_dir=Path("/input/calibration"),
+                    candidate_manifest=Path("/run/invalid-ann.txt"),
+                    retrieval_backend="lsh",
+                )
+
     def test_persistent_plan_binds_pending_shards_and_rejects_unsafe_paths(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary
- add exact bounded top-K and file-backed two-pass VLAD streaming
- add deterministic multi-table LSH retrieval with scale-aware signature widths
- expose ANN/streaming controls through the restartable Electro runner
- document measured COLMAP comparisons up front and archive M6 evidence

## Measured gates
- OpenLORIS 1k: 991/1000 registered with LSH vs 989/1000 exact
- OpenLORIS 10k candidate generation: 531.28s vs 2989.03s exact (5.63x)
- parallel VLAD candidate manifest is byte-identical to serial

## Validation
- cargo test --workspace --all-targets
- cargo clippy --example unordered_sfm_demo --features image-io -- -D warnings
- rustup run 1.82.0 cargo check --example unordered_sfm_demo --features image-io
- python3 -m unittest tests.test_benchmark_electro

Full all-feature Clippy still reports four pre-existing warnings in pipelines/slam/src/dpvo_vo.rs.