### PR TITLE
perf(sfm): promote conflict-aware tracks for large maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ envelope in **8:51**, versus 49:49 for exact all-image ranking. At the frozen
 versus 989/1000 for exact retrieval. The 10k mapping-quality failure below is
 still open; faster retrieval does not by itself claim to solve it.
 
+On the same frozen 10k verified snapshot, conflict-aware confidence ordering
+raises registration from 199 to **3,664 cameras** while reducing mean
+reprojection from 1.301 to **1.140 px**. It rejects only an edge whose merge
+would put two observations from one image into a track; the remaining
+1,192,223 observations stay available to mapping. This is an 18.4× recovery,
+not a completed 10k reconstruction: 63.36% of the supplied cameras remain
+unregistered. Frozen hashes and negative controls are in
+[`m6-conflict-aware-tracks.json`](benchmarks/electro/m6-conflict-aware-tracks.json).
+
+| Frozen 10k mapper replay | Registered | Mean reprojection | Mapping wall |
+| --- | ---: | ---: | ---: |
+| Legacy UnionFind | 199/10,000 | 1.301 px | **1:59.8** |
+| Confidence-ordered tracks | **3,664/10,000** | **1.140 px** | 9:02.9 |
+
 | Connected tier | Candidate / verified pairs | Registered | Total wall | Peak phase RSS |
 | --- | ---: | ---: | ---: | ---: |
 | 1,000 | 7,000 / 6,869 | **989 (98.9%)** | 2:25 | 274 MiB |
@@ -145,9 +159,11 @@ still open; faster retrieval does not by itself claim to solve it.
 <p align="center"><sub>The 10k peak is its 2,188-shard streaming merge;
 candidate generation peaks at 1.14 GiB, matching at 851 MiB, and compact
 mapping at 501 MiB. Exact VLAD ranking still scores every image pair, so ANN
-retrieval plus streamed global descriptors is the next speed/memory target.
-No OpenLORIS COLMAP run was performed. Source/license, hashes, phase ledgers,
-and honest dense/global negatives:
+retrieval plus streamed global descriptors now removes that quadratic ranking
+bottleneck; component and seed coverage remain the next quality target. No
+OpenLORIS COLMAP run was performed, so these 10k results are deliberately not
+presented as a COLMAP comparison. Source/license, hashes, phase ledgers, and
+honest dense/global negatives:
 <a href="benchmarks/electro/m5-openloris-connected-scale-validation.json">connected M5 evidence</a> ·
 <a href="docs/electro_m5_scale_validation.md">full scale report</a>.</sub></p>
 

--- a/benchmarks/electro/m6-conflict-aware-tracks.json
+++ b/benchmarks/electro/m6-conflict-aware-tracks.json
@@ -1,0 +1,92 @@
+{
+  "schema": "visloc_m6_conflict_aware_tracks_evidence_v1",
+  "base_commit": "4dc8508f3e0f966aad13401914e9d47e0bfd133c",
+  "dataset": "OpenLORIS corridor1-1",
+  "frozen_input": {
+    "candidate_policy": "temporal-pyramid + VLAD fill, 7N",
+    "mapper_match_cap_per_pair": 96,
+    "tier_10000_verified_pairs": 58879,
+    "tier_10000_verified_snapshot_sha256": "31e99651ff7f7e6523637cd384af55eea24d53b2bd76ced5bf03ccfe43f4a4bf",
+    "ground_truth_used_for_selection_or_mapping": false
+  },
+  "tier_1000_ab": {
+    "legacy_union_find": {
+      "registered_images": 989,
+      "supplied_images": 1000,
+      "tracks": 2586,
+      "observations": 28918,
+      "mean_reprojection_px": 1.574
+    },
+    "confidence_ordered": {
+      "registered_images": 1000,
+      "tracks": 4119,
+      "observations": 114870,
+      "mean_reprojection_px": 1.292,
+      "track_build_retained_tracks": 15688,
+      "track_build_retained_observations": 208326,
+      "rejected_conflict_edges": 38404,
+      "elapsed_s": 154.49,
+      "images_txt_sha256": "2ef5fdb8a3bb70dec38c898d7b0b6579c7e6d4f642434d9de861f2a2783b96ed"
+    },
+    "cycle_supported": {
+      "registered_images": 1000,
+      "tracks": 3377,
+      "observations": 108523,
+      "mean_reprojection_px": 1.213,
+      "elapsed_s": 218.34,
+      "decision": "quality-positive but slower and less dense than confidence-ordered"
+    },
+    "incremental_correspondence": {
+      "registered_images": 1000,
+      "tracks": 4459,
+      "observations": 118224,
+      "mean_reprojection_px": 2.253,
+      "elapsed_s": 202.69,
+      "decision": "registration-positive but reprojection regression"
+    }
+  },
+  "tier_10000_quality_gate": {
+    "legacy_union_find": {
+      "registered_images": 199,
+      "supplied_images": 10000,
+      "tracks": 873,
+      "observations": 5184,
+      "mean_reprojection_px": 1.301,
+      "mapping_elapsed_s": 119.79643308196682
+    },
+    "confidence_ordered": {
+      "registered_images": 3664,
+      "supplied_images": 10000,
+      "registered_fraction": 0.3664,
+      "registration_gain_over_legacy": 3465,
+      "registration_ratio_over_legacy": 18.412060301507537,
+      "tracks": 21761,
+      "observations": 209661,
+      "mean_reprojection_px": 1.140,
+      "track_build_retained_tracks": 108990,
+      "track_build_retained_observations": 1192223,
+      "rejected_conflict_edges": 306798,
+      "mapping_elapsed_s": 542.88,
+      "seed_pair": [355, 5305],
+      "seed_selection": "selected by the first GT-free 16-trial run, then replayed for the refinement A/B",
+      "global_ba_max_refinements": 1,
+      "model_sha256": {
+        "cameras.txt": "e404161535ccb894a786448b9c9933af3e482647e314e9fa2e63b30900061a3a",
+        "images.txt": "2a07d838d0e8dd435243c9f5896280a06a909f4b352d6c3fe6e03f31da8d3849",
+        "points3D.txt": "cf03f934a677473804c7c35d99480ede96908ed9ebd7855329a8309557458050"
+      },
+      "quality_status": "large improvement, but 10k connected reconstruction remains incomplete"
+    }
+  },
+  "negative_controls": {
+    "confidence_without_followup_refinement": {
+      "registered_images": 3664,
+      "mean_reprojection_px": 5.794,
+      "decision": "rejected: post-registration BA ended without an outlier-filter follow-up"
+    },
+    "cycle_supported_10k": {
+      "status": "stopped",
+      "reason": "track construction exceeded six minutes and was already slower than the bounded confidence builder"
+    }
+  }
+}

--- a/docs/electro_performance_roadmap.md
+++ b/docs/electro_performance_roadmap.md
@@ -376,12 +376,16 @@ gates. Image count and physical scene scale are tested separately.
 - Report per-scene quality and resource distributions; an aggregate average
   may not hide a failed scene.
 
-Measured decision: the candidate-output and 4 GiB resource gates pass, while
-the connected registered-fraction/component gate fails. The exact VLAD fill
-still performs a quadratic all-image similarity scan despite emitting only
-`7N` pairs, and UnionFind track conflicts collapse long-sequence support.
-Bounded ANN/inverted retrieval plus streamed global descriptors is the next
-performance A/B; conflict-aware track construction is the next quality A/B.
+Measured M6 decision: streamed VLAD plus deterministic scale-aware LSH reduces
+the 10k candidate phase from 2,989.03 s to 531.28 s. On the frozen 10k verified
+snapshot, confidence-ordered conflict rejection raises registration from
+199/10,000 to 3,664/10,000 while retaining 1,192,223 pre-map observations; one
+follow-up refinement holds mean reprojection to 1.140 px. This is a large
+partial recovery, not a connected-scale pass. The remaining quality work is
+component/seed coverage beyond the recovered 36.64%, without weakening the
+reprojection gate. Evidence is frozen in
+`benchmarks/electro/m6-ann-streaming.json` and
+`benchmarks/electro/m6-conflict-aware-tracks.json`.
 
 ## 9. Dependencies and risk register
 

--- a/docs/large_scale_unordered_sfm_plan.md
+++ b/docs/large_scale_unordered_sfm_plan.md
@@ -485,3 +485,12 @@ similarities and loads the file feature bank; the 10k candidate phase alone is
 the graph grows. Do not call this a successful connected 10k reconstruction.
 The frozen evidence and negative controls are in
 [`m5-openloris-connected-scale-validation.json`](../benchmarks/electro/m5-openloris-connected-scale-validation.json).
+
+M6 keeps that failed baseline immutable. Streamed VLAD plus scale-aware LSH
+reduces 10k candidate generation to 8:51. Replaying the same 58,879 verified
+pairs with confidence-ordered conflict rejection and one follow-up refinement
+registers 3,664/10,000 at 1.140 px mean reprojection. The 18.4× registration
+recovery confirms track conflicts were a binding failure, but 36.64% remains
+below the connected-scale gate. See
+[`m6-ann-streaming.json`](../benchmarks/electro/m6-ann-streaming.json) and
+[`m6-conflict-aware-tracks.json`](../benchmarks/electro/m6-conflict-aware-tracks.json).

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -883,11 +883,13 @@ def build_mapping_command(
     snapshot_keypoints_only: bool = False,
     periodic_ba_min_registered_images: int | None = None,
     seed_trials: int | None = None,
+    seed_pair: str | None = None,
     ba_linear_solver: str | None = None,
     ba_max_iterations: int | None = None,
     post_refinement_registration: bool = False,
     final_iterative_refinement: bool = False,
     global_ba_max_refinements: int | None = None,
+    confidence_ordered_tracks: bool = False,
     final_ba: bool = True,
 ) -> list[str]:
     command = [
@@ -931,6 +933,13 @@ def build_mapping_command(
             if value <= 0:
                 raise ValidationError(f"{option} must be positive")
             command.extend([option, str(value)])
+    if seed_pair is not None:
+        fields = seed_pair.split(",")
+        if len(fields) != 2 or any(not field.isdigit() for field in fields):
+            raise ValidationError("seed_pair must be two non-negative image indices: I,J")
+        if int(fields[0]) == int(fields[1]):
+            raise ValidationError("seed_pair image indices must differ")
+        command.extend(["--seed-pair", seed_pair])
     if ba_linear_solver is not None:
         if ba_linear_solver not in {"dense", "sparse", "auto"}:
             raise ValidationError("ba_linear_solver must be dense, sparse, or auto")
@@ -943,6 +952,8 @@ def build_mapping_command(
         if global_ba_max_refinements < 0:
             raise ValidationError("--global-ba-max-refinements must be non-negative")
         command.extend(["--global-ba-max-refinements", str(global_ba_max_refinements)])
+    if confidence_ordered_tracks:
+        command.append("--confidence-ordered-tracks")
     if not final_ba:
         command.append("--no-final-ba")
     return command
@@ -1826,11 +1837,17 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--periodic-ba-min-registered-images", type=int)
     parser.add_argument("--seed-trials", type=int)
+    parser.add_argument("--seed-pair", help="fixed mapper seed pair as I,J")
     parser.add_argument("--ba-linear-solver", choices=("dense", "sparse", "auto"))
     parser.add_argument("--ba-max-iterations", type=int)
     parser.add_argument("--post-refinement-registration", action="store_true")
     parser.add_argument("--final-iterative-refinement", action="store_true")
     parser.add_argument("--global-ba-max-refinements", type=int)
+    parser.add_argument(
+        "--confidence-ordered-tracks",
+        action="store_true",
+        help="reject only conflict-forming edges in descending verified-pair confidence",
+    )
     parser.add_argument(
         "--no-final-ba",
         action="store_true",
@@ -2020,11 +2037,13 @@ def main(argv: list[str] | None = None) -> int:
                     snapshot_keypoints_only=args.snapshot_keypoints_only,
                     periodic_ba_min_registered_images=args.periodic_ba_min_registered_images,
                     seed_trials=args.seed_trials,
+                    seed_pair=args.seed_pair,
                     ba_linear_solver=args.ba_linear_solver,
                     ba_max_iterations=args.ba_max_iterations,
                     post_refinement_registration=args.post_refinement_registration,
                     final_iterative_refinement=args.final_iterative_refinement,
                     global_ba_max_refinements=args.global_ba_max_refinements,
+                    confidence_ordered_tracks=args.confidence_ordered_tracks,
                     final_ba=not args.no_final_ba,
                 ),
                 artifact_root / "mapping.log",

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -283,11 +283,13 @@ class ElectroBenchmarkTests(unittest.TestCase):
                 snapshot_keypoints_only=True,
                 periodic_ba_min_registered_images=1201,
                 seed_trials=1,
+                seed_pair="355,5305",
                 ba_linear_solver="sparse",
                 ba_max_iterations=8,
                 post_refinement_registration=True,
                 final_iterative_refinement=True,
                 global_ba_max_refinements=0,
+                confidence_ordered_tracks=True,
             )
             for command in (candidate_command, match_command, map_command):
                 self.assertNotIn("--gt", command)
@@ -297,6 +299,8 @@ class ElectroBenchmarkTests(unittest.TestCase):
             self.assertIn("--max-mapper-matches-per-pair", map_command)
             self.assertIn("--snapshot-keypoints-only", map_command)
             self.assertIn("--post-refinement-registration", map_command)
+            self.assertIn("--confidence-ordered-tracks", map_command)
+            self.assertEqual(map_command[map_command.index("--seed-pair") + 1], "355,5305")
             self.assertIn("--final-iterative-refinement", map_command)
             self.assertEqual(map_command[map_command.index("--ba-max-iterations") + 1], "8")
             self.assertEqual(
@@ -319,6 +323,24 @@ class ElectroBenchmarkTests(unittest.TestCase):
                     merged_snapshot=Path("/run/merged.vps"),
                     output_model=Path("/run/model"),
                     ba_linear_solver="invalid",
+                )
+            with self.assertRaisesRegex(benchmark.ValidationError, "seed_pair"):
+                benchmark.build_mapping_command(
+                    Path("/bin/visloc"),
+                    features_dir=Path("/input/features"),
+                    calibration_dir=Path("/input/calibration"),
+                    merged_snapshot=Path("/run/merged.vps"),
+                    output_model=Path("/run/model"),
+                    seed_pair="355",
+                )
+            with self.assertRaisesRegex(benchmark.ValidationError, "seed_pair image indices"):
+                benchmark.build_mapping_command(
+                    Path("/bin/visloc"),
+                    features_dir=Path("/input/features"),
+                    calibration_dir=Path("/input/calibration"),
+                    merged_snapshot=Path("/run/merged.vps"),
+                    output_model=Path("/run/model"),
+                    seed_pair="01,1",
                 )
 
             rig_candidate_command = benchmark.build_candidate_command(


### PR DESCRIPTION
## Summary
- expose fixed seed-pair and confidence-ordered track controls in the reproducible Electro runner
- freeze the OpenLORIS 1k/10k A/B evidence and negative controls
- surface the 18.4x 10k registration recovery while clearly retaining the failed connected-scale status
- keep the README COLMAP comparison prominent and explicitly avoid presenting the OpenLORIS result as a COLMAP comparison

## Measured result
- 1k: 989/1000 -> 1000/1000 registered, 1.574 -> 1.292 px mean reprojection
- 10k: 199/10000 -> 3664/10000 registered, 1.301 -> 1.140 px mean reprojection
- 10k remains incomplete: 63.36% unregistered

## Verification
- `cargo test --workspace --all-targets` (220 passed, 1 ignored)
- `python3 -m unittest tests.test_benchmark_electro` (15 passed)
- `scripts/check_docs_links.sh`
- `git diff --check`