### PR TITLE
perf(sfm): recover disconnected large-map components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to `visloc-rs` will be documented here.
 
 ### Added
 
+- **Bounded component-model recovery for disconnected large view graphs
+  (2026-09-02).** Added explicit `--component-model-min-images` and
+  `--component-model-max-count` controls to the unordered SfM demo and Electro
+  runner. Large verified components are ranked deterministically, mapped
+  sequentially from one feature load, and written as independent COLMAP models
+  with a `components.tsv` manifest; defaults and the ordinary single-model path
+  are unchanged. On the frozen OpenLORIS 10k snapshot, seven major components
+  register **6,791/10,000** cameras at 0.928–1.293 px mean reprojection in
+  10:44.45. The 1k control remains byte-identical at 1000/1000. The outputs are
+  explicitly independent gauges, not a connected-model claim; verified bridge
+  recovery and Sim(3) alignment remain follow-up work.
+
 - **Milestone 5 real-world scale and streaming-memory validation
   (2026-09-01).** Ran all ten ETH3D low-res many-view scenes independently:
   **9,996/10,008 cameras registered (99.88%)**, with score-only centre RMSE,

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ unregistered. Frozen hashes and negative controls are in
 | --- | ---: | ---: | ---: |
 | Legacy UnionFind | 199/10,000 | 1.301 px | **1:59.8** |
 | Confidence-ordered tracks | **3,664/10,000** | **1.140 px** | 9:02.9 |
+| Component models (7 independent gauges) | **6,791/10,000** | 0.928–1.293 px | 10:44.5 |
+
+The component run explains the remaining gap: the frozen verified view graph
+contains 313 connected components, with seven major components covering 9,682
+images. Mapping those seven sequentially recovers 85.3% more cameras than the
+single-model replay, and preserves the M6 model byte-for-byte for the largest
+component. These are still seven coordinate systems, not one connected map;
+verified bridge discovery and Sim(3) alignment are required before making that
+claim. Evidence and model hashes are in
+[`m7-component-models.json`](benchmarks/electro/m7-component-models.json).
 
 | Connected tier | Candidate / verified pairs | Registered | Total wall | Peak phase RSS |
 | --- | ---: | ---: | ---: | ---: |
@@ -254,6 +264,12 @@ scripts/benchmark_courtyard.sh --full --no-build \
 The example header documents the complete unordered-SfM option set; the
 [courtyard benchmark guide](docs/courtyard_benchmark.md) documents artifact
 validation, candidate schedules, and reproducible large-run details.
+
+For a disconnected verified snapshot, add
+`--component-model-min-images 100 --component-model-max-count 7` to write
+bounded, size-ranked independent models below `--out-colmap`, plus a
+`components.tsv` manifest. The mode is explicit because its outputs have
+independent gauges and must not be mistaken for one connected reconstruction.
 
 <p align="center">
   <img src="docs/assets/hero_euroc_mh01_slam.gif" alt="Online stereo SLAM on EuRoC MH_01: onboard camera footage beside the live map — estimated trajectory vs ground truth as stereo landmark replenishment grows the landmark map" width="820"><br>

--- a/benchmarks/electro/m7-component-models.json
+++ b/benchmarks/electro/m7-component-models.json
@@ -1,0 +1,137 @@
+{
+  "schema": "visloc_m7_component_models_evidence_v1",
+  "base_commit": "71b5fd0efa5ac6a48e7f146cdf8e20c30e436db1",
+  "dataset": "OpenLORIS corridor1-1",
+  "frozen_input": {
+    "supplied_images": 10000,
+    "verified_pairs": 58879,
+    "accepted_correspondences_before_mapper_cap": 3449870,
+    "mapper_match_cap_per_pair": 96,
+    "verified_snapshot_sha256": "31e99651ff7f7e6523637cd384af55eea24d53b2bd76ced5bf03ccfe43f4a4bf",
+    "ground_truth_used_for_selection_or_mapping": false
+  },
+  "verified_view_graph": {
+    "connected_components": 313,
+    "isolated_images": 298,
+    "largest_component_images": 5144,
+    "major_component_sizes": [5144, 1240, 1236, 1018, 411, 407, 226],
+    "major_component_images": 9682,
+    "decision": "map the seven major components sequentially; do not claim a connected 10k model before verified bridges or Sim(3) alignment exist"
+  },
+  "growth_only_negative_control": {
+    "models": 7,
+    "registered_images": 5174,
+    "elapsed_s": 136.97,
+    "peak_rss_kib": 643140,
+    "component_mean_reprojection_px": [26.544, 64.345, 12.584, 30.095, 31.943, 15.298, 9.969],
+    "decision": "registration-positive but rejected as a quality result because final refinement was disabled"
+  },
+  "refined_component_models": {
+    "models": 7,
+    "independent_gauges": true,
+    "registered_images": 6791,
+    "registered_fraction_of_all_inputs": 0.6791,
+    "registration_gain_over_m6_single_model": 3127,
+    "registration_ratio_over_m6_single_model": 1.853438864628821,
+    "tracks": 36062,
+    "observations": 355312,
+    "elapsed_s": 644.45,
+    "peak_rss_kib": 1343432,
+    "components": [
+      {
+        "rank": 0,
+        "supplied_images": 5144,
+        "verified_pairs": 37866,
+        "registered_images": 3664,
+        "tracks": 21761,
+        "observations": 209661,
+        "mean_reprojection_px": 1.140,
+        "images_txt_sha256": "2a07d838d0e8dd435243c9f5896280a06a909f4b352d6c3fe6e03f31da8d3849",
+        "points3D_txt_sha256": "cf03f934a677473804c7c35d99480ede96908ed9ebd7855329a8309557458050"
+      },
+      {
+        "rank": 1,
+        "supplied_images": 1240,
+        "verified_pairs": 6546,
+        "registered_images": 906,
+        "tracks": 5709,
+        "observations": 63689,
+        "mean_reprojection_px": 0.928,
+        "images_txt_sha256": "72840f7b6bcb12e9942d9d25836d275af6bacf18881dce690cc4c4586712db54",
+        "points3D_txt_sha256": "b354fbe4a7c53f9ae03224a5b539e26712b6f4d8acf59dc98c3f25734632fed5"
+      },
+      {
+        "rank": 2,
+        "supplied_images": 1236,
+        "verified_pairs": 5195,
+        "registered_images": 341,
+        "tracks": 1723,
+        "observations": 16130,
+        "mean_reprojection_px": 1.049,
+        "images_txt_sha256": "d0ac93b5c1d227e0f543afd59104187c21379de29fa243e1a855714542fc94d3",
+        "points3D_txt_sha256": "c8e76ca603c5e4a460154bf625551cb1be0a031b987f5e845b110f477d91819e"
+      },
+      {
+        "rank": 3,
+        "supplied_images": 1018,
+        "verified_pairs": 4631,
+        "registered_images": 848,
+        "tracks": 3092,
+        "observations": 26877,
+        "mean_reprojection_px": 1.293,
+        "images_txt_sha256": "dc2f3aca7f88632bcb44c14437102205d076acbc9f38d035656f18b6541a2d98",
+        "points3D_txt_sha256": "db7469f5f1e1da4f5e33e01b5458f917dc9f0aeaaecea4b107ff579179450d49"
+      },
+      {
+        "rank": 4,
+        "supplied_images": 411,
+        "verified_pairs": 1910,
+        "registered_images": 410,
+        "tracks": 1150,
+        "observations": 11608,
+        "mean_reprojection_px": 0.933,
+        "images_txt_sha256": "6a71f551eeb27f53bb6ba234dbac3a49d691b888df939b455008561b3f8a8329",
+        "points3D_txt_sha256": "c19290b6b0b71822d2388fbff8af28cd9ab0d95c0ec3bce5665df3e1eb4adb86"
+      },
+      {
+        "rank": 5,
+        "supplied_images": 407,
+        "verified_pairs": 1807,
+        "registered_images": 404,
+        "tracks": 1241,
+        "observations": 15202,
+        "mean_reprojection_px": 0.929,
+        "images_txt_sha256": "4ddd725966c27436618610b316af2532163c42dbda285501bdf2d09300a9344b",
+        "points3D_txt_sha256": "04778525408c111d40510176fded1abafb31d2c821c54d77d1f89a4578256ac3"
+      },
+      {
+        "rank": 6,
+        "supplied_images": 226,
+        "verified_pairs": 912,
+        "registered_images": 218,
+        "tracks": 1386,
+        "observations": 12145,
+        "mean_reprojection_px": 0.985,
+        "images_txt_sha256": "00da4f5a5e8d6be59c010c195fe6f810d69a64b078383cc9104dda7396a78f75",
+        "points3D_txt_sha256": "5b256eae5a041db9e8d7ffe1e60cdeb7f150e3c988bed6669d8ec05e5e2a4639"
+      }
+    ],
+    "quality_status": "all seven independent models are below 1.3 px mean reprojection; they are not yet one connected reconstruction"
+  },
+  "tier_1000_non_regression": {
+    "models": 1,
+    "registered_images": 1000,
+    "supplied_images": 1000,
+    "tracks": 4119,
+    "observations": 114870,
+    "mean_reprojection_px": 1.291997619,
+    "elapsed_s": 153.57,
+    "peak_rss_kib": 394724,
+    "byte_identical_to_m6_confidence_champion": true,
+    "model_sha256": {
+      "cameras.txt": "e404161535ccb894a786448b9c9933af3e482647e314e9fa2e63b30900061a3a",
+      "images.txt": "2ef5fdb8a3bb70dec38c898d7b0b6579c7e6d4f642434d9de861f2a2783b96ed",
+      "points3D.txt": "2152e2fad14af9fbb90939342a44a767b5a13047b28b639e8a18daf9c5f45490"
+    }
+  }
+}

--- a/docs/electro_performance_roadmap.md
+++ b/docs/electro_performance_roadmap.md
@@ -387,6 +387,16 @@ reprojection gate. Evidence is frozen in
 `benchmarks/electro/m6-ann-streaming.json` and
 `benchmarks/electro/m6-conflict-aware-tracks.json`.
 
+Measured M7 component diagnosis: the frozen 10k verified graph has 313
+components; its seven major components contain 9,682 images. Sequential,
+size-ranked component mapping reuses one feature load and raises quality-gated
+coverage from the M6 single model's 3,664 images to 6,791 images across seven
+independent models. Every model reports 0.928–1.293 px mean reprojection, while
+the 1k one-component control is byte-identical to the M6 champion. This is a
+coverage pass, not a connected-scale pass: the next gate is verified bridge
+discovery followed by guarded Sim(3) alignment. Frozen results and hashes are
+in `benchmarks/electro/m7-component-models.json`.
+
 ## 9. Dependencies and risk register
 
 The default dependency chain is `M0 -> M1 -> M2 -> (M3, M4) -> M5`.

--- a/docs/large_scale_unordered_sfm_plan.md
+++ b/docs/large_scale_unordered_sfm_plan.md
@@ -494,3 +494,14 @@ recovery confirms track conflicts were a binding failure, but 36.64% remains
 below the connected-scale gate. See
 [`m6-ann-streaming.json`](../benchmarks/electro/m6-ann-streaming.json) and
 [`m6-conflict-aware-tracks.json`](../benchmarks/electro/m6-conflict-aware-tracks.json).
+
+M7 isolates the next failure boundary instead of weakening PnP or reprojection
+gates. The frozen 10k verified graph contains 313 components, including seven
+major components of 5,144, 1,240, 1,236, 1,018, 411, 407, and 226 images.
+Mapping those seven sequentially registers 6,791/10,000 cameras, with each
+independent model at 0.928–1.293 px mean reprojection. The largest model is
+byte-identical to M6 and the frozen 1k control remains byte-identical as well.
+The output manifest explicitly labels the gauges independent; bridge recovery
+and Sim(3) alignment remain mandatory before this can satisfy the connected
+10k gate. See
+[`m7-component-models.json`](../benchmarks/electro/m7-component-models.json).

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -372,6 +372,14 @@
 //! For a controlled mapper seed replay, `--seed-pair I,J` restricts the
 //! otherwise unchanged seed candidate list to that normalized image-index
 //! pair; it is default-off and intended for diagnostics.
+//! `--component-model-min-images N` instead maps every verified-view-graph
+//! component with at least `N` images, largest first, and writes independent
+//! `component-NNN` COLMAP models plus `components.tsv` below `--out-colmap`.
+//! `--component-model-max-count N` bounds the number of models (default 16).
+//! Components run sequentially from one feature load, so their reconstruction
+//! state is not retained together; the outputs have independent gauges and are
+//! not one connected model. This mode cannot be combined with a fixed seed or
+//! initial poses and is default-off.
 //! `--sequence-fallback-carry-scale` is a default-off after-post policy that
 //! carries the accepted baseline magnitude across consecutive provisional
 //! registrations; it requires the relaxed projection and after-post flags.
@@ -480,8 +488,8 @@ use visloc_rs::{
     rematch_essential_admission_ok, triangulate_two_view_left_frame,
     write_colmap_reconstruction_for_3dgs, write_colmap_reconstruction_for_3dgs_with_cameras,
     BaConfig, BruteForceMatcher, Camera, CameraModel, DescriptorMatch, FeatureSet,
-    GlobalReconstructionTuning, IncrementalSfmConfig, LinearSolver, Matcher, NextImagePolicy,
-    PairwiseMatches, PerImageCameras, Pose, RobustKernel, TrackSource, SE3,
+    GlobalReconstructionTuning, IncrementalSfmConfig, IncrementalSfmResult, LinearSolver, Matcher,
+    NextImagePolicy, PairwiseMatches, PerImageCameras, Pose, RobustKernel, TrackSource, SE3,
 };
 
 use visloc_rs::slam::incremental_sfm::log_process_memory;
@@ -2162,6 +2170,11 @@ struct Args {
     seed_trials: usize,
     /// Optional diagnostic restriction to one seed pair (`I,J`).
     seed_pair: Option<(usize, usize)>,
+    /// Map each sufficiently large verified-view-graph component independently
+    /// and write one COLMAP model per component below `out_colmap`.
+    component_model_min_images: Option<usize>,
+    /// Bound the number of independently reconstructed components.
+    component_model_max_count: usize,
     refine_intrinsics: bool,
     refine_distortion: bool,
     colmap_style: bool,
@@ -4120,6 +4133,8 @@ where
     let mut final_min_track_length: Option<usize> = None;
     let mut seed_trials = 12usize;
     let mut seed_pair: Option<(usize, usize)> = None;
+    let mut component_model_min_images: Option<usize> = None;
+    let mut component_model_max_count = 16usize;
     let mut pair_stem_window: Option<u64> = None;
     let mut local_stem_window: Option<u64> = None;
     let mut rig_local_grouping = false;
@@ -4560,6 +4575,19 @@ where
             }
             "--seed-trials" => seed_trials = a.remove(i + 1).parse().map_err(|e| format!("{e}"))?,
             "--seed-pair" => seed_pair = Some(parse_seed_pair(&a.remove(i + 1))?),
+            "--component-model-min-images" => {
+                component_model_min_images = Some(
+                    a.remove(i + 1)
+                        .parse()
+                        .map_err(|e| format!("--component-model-min-images: {e}"))?,
+                )
+            }
+            "--component-model-max-count" => {
+                component_model_max_count = a
+                    .remove(i + 1)
+                    .parse()
+                    .map_err(|e| format!("--component-model-max-count: {e}"))?
+            }
             "--refine-intrinsics" => refine_intrinsics = true,
             "--refine-distortion" => refine_distortion = true,
             "--colmap-style" => colmap_style = true,
@@ -5214,6 +5242,32 @@ where
     if initial_poses_file.is_some() && seed_pair.is_some() {
         return Err("--initial-poses cannot be combined with --seed-pair".into());
     }
+    if component_model_min_images.is_some() && seed_pair.is_some() {
+        return Err("--component-model-min-images cannot be combined with --seed-pair".into());
+    }
+    if component_model_min_images.is_some() && initial_poses_file.is_some() {
+        return Err("--component-model-min-images cannot be combined with --initial-poses".into());
+    }
+    if component_model_min_images == Some(0) {
+        return Err("--component-model-min-images must be positive".into());
+    }
+    if component_model_max_count == 0 {
+        return Err("--component-model-max-count must be positive".into());
+    }
+    if component_model_min_images.is_some() && mapper != MapperKind::Incremental {
+        return Err("--component-model-min-images requires --mapper incremental".into());
+    }
+    if component_model_min_images.is_some()
+        && (sequence_relative_pose_fallback
+            || diagnose_colmap_track_membership.is_some()
+            || diagnose_ba_oracle_poses_file.is_some()
+            || diagnose_fixed_rotation_ba.is_some())
+    {
+        return Err(
+            "--component-model-min-images cannot be combined with sequence fallback, oracle track membership, or BA diagnostic probes"
+                .into(),
+        );
+    }
     if input_colmap_calibration.is_some() && (refine_intrinsics || refine_distortion) {
         return Err(
             "--input-colmap-calibration currently keeps per-image PINHOLE intrinsics fixed; remove --refine-intrinsics/--refine-distortion"
@@ -5673,6 +5727,8 @@ where
         final_min_track_length,
         seed_trials,
         seed_pair,
+        component_model_min_images,
+        component_model_max_count,
         refine_intrinsics,
         refine_distortion,
         colmap_style,
@@ -15160,6 +15216,199 @@ fn dump_rotation_cycle_diagnostics(
     }
 }
 
+fn export_incremental_component_model(
+    out_colmap: &Path,
+    result: &IncrementalSfmResult,
+    features: &[FeatureSet],
+    image_names: &[String],
+    fallback_camera: &Camera,
+    native_keypoints_for_export: Option<&[Vec<Point2<f64>>]>,
+    per_image_calibration: Option<&LoadedPerImageCalibration>,
+) -> Result<(usize, usize, usize), Box<dyn std::error::Error>> {
+    let registered: Vec<usize> = (0..features.len())
+        .filter(|&image| result.poses[image].is_some())
+        .collect();
+    let remap: HashMap<usize, usize> = registered
+        .iter()
+        .enumerate()
+        .map(|(new_index, &old_index)| (old_index, new_index))
+        .collect();
+    let poses_out: Vec<Pose> = registered
+        .iter()
+        .map(|&image| result.poses[image].clone().expect("registered pose"))
+        .collect();
+    let mut features_out: Vec<FeatureSet> = registered
+        .iter()
+        .map(|&image| features[image].clone())
+        .collect();
+    if let Some(native_keypoints) = native_keypoints_for_export {
+        replace_feature_keypoints_from_native(&mut features_out, &registered, native_keypoints)
+            .map_err(std::io::Error::other)?;
+    }
+    let names_out: Vec<String> = registered
+        .iter()
+        .map(|&image| image_names[image].clone())
+        .collect();
+    let landmarks_out: Vec<ExportLandmark> = result
+        .tracks
+        .iter()
+        .map(|track| {
+            let observations = track
+                .observations
+                .iter()
+                .filter_map(|&(image, keypoint, pixel)| {
+                    remap
+                        .get(&image)
+                        .map(|&new_image| (new_image, keypoint, pixel))
+                })
+                .collect();
+            (track.position, observations)
+        })
+        .collect();
+    let refined_camera = result.refined_camera.as_ref().unwrap_or(fallback_camera);
+    let summary = if let Some(calibration) = per_image_calibration {
+        let cameras_out: Vec<Camera> = registered
+            .iter()
+            .map(|&image| calibration.native_cameras[image].clone())
+            .collect();
+        write_colmap_reconstruction_for_3dgs_with_cameras(
+            out_colmap,
+            &cameras_out,
+            &poses_out,
+            &features_out,
+            &landmarks_out,
+            |index| names_out[index].clone(),
+        )?
+    } else {
+        write_colmap_reconstruction_for_3dgs(
+            out_colmap,
+            refined_camera,
+            &poses_out,
+            &features_out,
+            &landmarks_out,
+            |index| names_out[index].clone(),
+        )?
+    };
+    Ok((
+        summary.frame_count,
+        summary.landmark_count,
+        summary.observation_count,
+    ))
+}
+
+fn ranked_view_graph_components(
+    num_images: usize,
+    pairwise: &[PairwiseMatches],
+    min_images: usize,
+    max_count: usize,
+) -> Vec<Vec<usize>> {
+    let edges: Vec<(usize, usize)> = pairwise
+        .iter()
+        .map(|pair| (pair.image_i, pair.image_j))
+        .collect();
+    let mut components = connected_components(num_images, &edges);
+    components.retain(|component| component.len() >= min_images);
+    components.sort_by(|left, right| {
+        right
+            .len()
+            .cmp(&left.len())
+            .then_with(|| left[0].cmp(&right[0]))
+    });
+    components.truncate(max_count);
+    components
+}
+
+fn map_verified_view_graph_components(
+    out_root: &Path,
+    min_images: usize,
+    max_count: usize,
+    camera: &Camera,
+    features: &[FeatureSet],
+    image_names: &[String],
+    pairwise: &[PairwiseMatches],
+    config: &IncrementalSfmConfig,
+    native_keypoints_for_export: Option<&[Vec<Point2<f64>>]>,
+    per_image_calibration: Option<&LoadedPerImageCalibration>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let components = ranked_view_graph_components(features.len(), pairwise, min_images, max_count);
+    if components.is_empty() {
+        return Err(
+            format!("no verified view-graph component has at least {min_images} images").into(),
+        );
+    }
+
+    let mut total_registered = 0usize;
+    let mut total_tracks = 0usize;
+    let mut total_observations = 0usize;
+    let mut weighted_reprojection_sum = 0.0f64;
+    let mut manifest = String::from(
+        "rank\tsupplied_images\tverified_pairs\tregistered_images\ttracks\tobservations\tmean_reprojection_px\tmodel_dir\n",
+    );
+    for (rank, component) in components.iter().enumerate() {
+        let mut membership = vec![false; features.len()];
+        for &image in component {
+            membership[image] = true;
+        }
+        let component_pairs: Vec<PairwiseMatches> = pairwise
+            .iter()
+            .filter(|pair| membership[pair.image_i] && membership[pair.image_j])
+            .cloned()
+            .collect();
+        let result = incremental_sfm(camera, features, &component_pairs, config)?;
+        let component_dir = out_root.join(format!("component-{rank:03}"));
+        let (written_images, written_points, written_observations) =
+            export_incremental_component_model(
+                &component_dir,
+                &result,
+                features,
+                image_names,
+                camera,
+                native_keypoints_for_export,
+                per_image_calibration,
+            )?;
+        total_registered += written_images;
+        total_tracks += written_points;
+        total_observations += written_observations;
+        weighted_reprojection_sum += result.mean_reprojection_px * written_observations as f64;
+        manifest.push_str(&format!(
+            "{rank}\t{}\t{}\t{written_images}\t{written_points}\t{written_observations}\t{:.9}\tcomponent-{rank:03}\n",
+            component.len(),
+            component_pairs.len(),
+            result.mean_reprojection_px,
+        ));
+        println!(
+            "component-model: rank={rank} supplied={} pairs={} registered={} tracks={} observations={} mean_reproj={:.3} px out={}",
+            component.len(),
+            component_pairs.len(),
+            written_images,
+            written_points,
+            written_observations,
+            result.mean_reprojection_px,
+            component_dir.display(),
+        );
+    }
+    println!(
+        "component-model summary: models={} registered={}/{} tracks={} observations={} weighted_mean_reproj={:.3} px (independent gauges; no connected-model claim)",
+        components.len(),
+        total_registered,
+        features.len(),
+        total_tracks,
+        total_observations,
+        weighted_reprojection_sum / total_observations.max(1) as f64,
+    );
+    manifest.push_str(&format!(
+        "# independent_gauges=true models={} registered_images={} supplied_images={} tracks={} observations={} weighted_mean_reprojection_px={:.9}\n",
+        components.len(),
+        total_registered,
+        features.len(),
+        total_tracks,
+        total_observations,
+        weighted_reprojection_sum / total_observations.max(1) as f64,
+    ));
+    std::fs::write(out_root.join("components.tsv"), manifest)?;
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = match parse_args() {
         Ok(a) => a,
@@ -16504,6 +16753,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     log_process_memory("example-after-mapper-cap");
+    if let Some(min_images) = args.component_model_min_images {
+        map_verified_view_graph_components(
+            &args.out_colmap,
+            min_images,
+            args.component_model_max_count,
+            &args.camera,
+            &features,
+            &image_names,
+            &pairwise,
+            &config,
+            native_keypoints_for_export.as_deref(),
+            per_image_calibration.as_ref(),
+        )?;
+        return Ok(());
+    }
     let gt_path = args
         .gt_chirality_oracle_path
         .as_ref()
@@ -17273,18 +17537,18 @@ mod diagnose_cli_tests {
         model_cross_validation_is_held_out, model_cross_validation_is_held_out_for_pixels,
         model_cross_validation_selection_score, parse_args_from, parse_candidate_manifest,
         parse_candidate_manifest_with_metadata, parse_colmap_image_camera_assignments,
-        parse_colmap_track_membership, parse_diagnose_stems, read_feature_set,
-        remap_feature_keypoints_by_old_to_new, replace_feature_keypoints_from_native,
-        rig_local_pairs, rig_temporal_pyramid_pairs, robust_huber_mean, snapshot_export_config,
-        snapshot_feature_manifest_hash, snapshot_feature_validation_from_files,
-        stream_vlad_globals_from_feature_files, summarize_model_cross_validation_bucket,
-        temporal_pyramid_offsets_string, translation_direction_delta_deg,
-        unordered_pairwise_edge_hash, validate_diagnose_options, verified_pair_oracle_map,
-        write_candidate_manifest, write_candidate_manifest_with_metadata, Camera,
-        ColmapTrackMembership, ConfigurationType, EssentialPairQuality, FeatureLocusMetadata,
-        ImportedVerifiedPair, IncrementalSfmConfig, LinearSolver, ModelCrossValidationBucket,
-        ModelCrossValidationSummary, NextImagePolicy, PairwiseMatches, PerImageCameras,
-        RobustKernel, TwoViewGeometryReport, UnionTraversalOrder,
+        parse_colmap_track_membership, parse_diagnose_stems, ranked_view_graph_components,
+        read_feature_set, remap_feature_keypoints_by_old_to_new,
+        replace_feature_keypoints_from_native, rig_local_pairs, rig_temporal_pyramid_pairs,
+        robust_huber_mean, snapshot_export_config, snapshot_feature_manifest_hash,
+        snapshot_feature_validation_from_files, stream_vlad_globals_from_feature_files,
+        summarize_model_cross_validation_bucket, temporal_pyramid_offsets_string,
+        translation_direction_delta_deg, unordered_pairwise_edge_hash, validate_diagnose_options,
+        verified_pair_oracle_map, write_candidate_manifest, write_candidate_manifest_with_metadata,
+        Camera, ColmapTrackMembership, ConfigurationType, EssentialPairQuality,
+        FeatureLocusMetadata, ImportedVerifiedPair, IncrementalSfmConfig, LinearSolver,
+        ModelCrossValidationBucket, ModelCrossValidationSummary, NextImagePolicy, PairwiseMatches,
+        PerImageCameras, RobustKernel, TwoViewGeometryReport, UnionTraversalOrder,
     };
     use nalgebra::{Matrix3, Point2, Vector3};
     use std::cmp::Ordering as CmpOrdering;
@@ -18606,11 +18870,30 @@ mod diagnose_cli_tests {
         assert_eq!(defaults.pose_guided_split_max_reproj, None);
         assert_eq!(defaults.pose_guided_track_splitting_iterations, None);
         assert_eq!(defaults.seed_pair, None);
+        assert_eq!(defaults.component_model_min_images, None);
+        assert_eq!(defaults.component_model_max_count, 16);
 
         let seed_pair = parse_args_from(minimal_args(&["--seed-pair", "9,8"])).unwrap();
         assert_eq!(seed_pair.seed_pair, Some((8, 9)));
         assert!(parse_args_from(minimal_args(&["--seed-pair", "8,8"])).is_err());
         assert!(parse_args_from(minimal_args(&["--seed-pair", "8-9"])).is_err());
+        let components = parse_args_from(minimal_args(&[
+            "--component-model-min-images",
+            "100",
+            "--component-model-max-count",
+            "7",
+        ]))
+        .unwrap();
+        assert_eq!(components.component_model_min_images, Some(100));
+        assert_eq!(components.component_model_max_count, 7);
+        assert!(parse_args_from(minimal_args(&["--component-model-min-images", "0"])).is_err());
+        assert!(parse_args_from(minimal_args(&[
+            "--component-model-min-images",
+            "100",
+            "--seed-pair",
+            "8,9",
+        ]))
+        .is_err());
 
         let edge_scales = parse_args_from(minimal_args(&[
             "--mapper",
@@ -19116,6 +19399,24 @@ mod diagnose_cli_tests {
         assert!(parse_args_from(minimal_args(&["--sift-vlfeat-bilinear-orientations"])).is_err());
         assert!(parse_args_from(minimal_args(&["--sift-vlfeat-compatible-output-order"])).is_err());
         assert!(parse_args_from(minimal_args(&["--colmap-guided-matching"])).is_err());
+    }
+
+    #[test]
+    fn component_models_rank_large_components_deterministically() {
+        let pairwise = vec![
+            PairwiseMatches::new(4, 3, vec![(0, 0)]),
+            PairwiseMatches::new(1, 2, vec![(0, 0)]),
+            PairwiseMatches::new(0, 1, vec![(0, 0)]),
+            PairwiseMatches::new(7, 8, vec![(0, 0)]),
+        ];
+        assert_eq!(
+            ranked_view_graph_components(9, &pairwise, 2, 2),
+            vec![vec![0, 1, 2], vec![3, 4]],
+        );
+        assert_eq!(
+            ranked_view_graph_components(9, &pairwise, 2, 1),
+            vec![vec![0, 1, 2]],
+        );
     }
 
     #[test]

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -884,6 +884,8 @@ def build_mapping_command(
     periodic_ba_min_registered_images: int | None = None,
     seed_trials: int | None = None,
     seed_pair: str | None = None,
+    component_model_min_images: int | None = None,
+    component_model_max_count: int | None = None,
     ba_linear_solver: str | None = None,
     ba_max_iterations: int | None = None,
     post_refinement_registration: bool = False,
@@ -940,6 +942,20 @@ def build_mapping_command(
         if int(fields[0]) == int(fields[1]):
             raise ValidationError("seed_pair image indices must differ")
         command.extend(["--seed-pair", seed_pair])
+    if seed_pair is not None and component_model_min_images is not None:
+        raise ValidationError("seed_pair cannot be combined with component models")
+    if component_model_max_count is not None and component_model_min_images is None:
+        raise ValidationError(
+            "component_model_max_count requires component_model_min_images"
+        )
+    for option, value in (
+        ("--component-model-min-images", component_model_min_images),
+        ("--component-model-max-count", component_model_max_count),
+    ):
+        if value is not None:
+            if value <= 0:
+                raise ValidationError(f"{option} must be positive")
+            command.extend([option, str(value)])
     if ba_linear_solver is not None:
         if ba_linear_solver not in {"dense", "sparse", "auto"}:
             raise ValidationError("ba_linear_solver must be dense, sparse, or auto")
@@ -1838,6 +1854,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--periodic-ba-min-registered-images", type=int)
     parser.add_argument("--seed-trials", type=int)
     parser.add_argument("--seed-pair", help="fixed mapper seed pair as I,J")
+    parser.add_argument("--component-model-min-images", type=int)
+    parser.add_argument("--component-model-max-count", type=int)
     parser.add_argument("--ba-linear-solver", choices=("dense", "sparse", "auto"))
     parser.add_argument("--ba-max-iterations", type=int)
     parser.add_argument("--post-refinement-registration", action="store_true")
@@ -2038,6 +2056,8 @@ def main(argv: list[str] | None = None) -> int:
                     periodic_ba_min_registered_images=args.periodic_ba_min_registered_images,
                     seed_trials=args.seed_trials,
                     seed_pair=args.seed_pair,
+                    component_model_min_images=args.component_model_min_images,
+                    component_model_max_count=args.component_model_max_count,
                     ba_linear_solver=args.ba_linear_solver,
                     ba_max_iterations=args.ba_max_iterations,
                     post_refinement_registration=args.post_refinement_registration,

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -284,6 +284,8 @@ class ElectroBenchmarkTests(unittest.TestCase):
                 periodic_ba_min_registered_images=1201,
                 seed_trials=1,
                 seed_pair="355,5305",
+                component_model_min_images=None,
+                component_model_max_count=None,
                 ba_linear_solver="sparse",
                 ba_max_iterations=8,
                 post_refinement_registration=True,
@@ -341,6 +343,46 @@ class ElectroBenchmarkTests(unittest.TestCase):
                     merged_snapshot=Path("/run/merged.vps"),
                     output_model=Path("/run/model"),
                     seed_pair="01,1",
+                )
+            with self.assertRaisesRegex(benchmark.ValidationError, "component models"):
+                benchmark.build_mapping_command(
+                    Path("/bin/visloc"),
+                    features_dir=Path("/input/features"),
+                    calibration_dir=Path("/input/calibration"),
+                    merged_snapshot=Path("/run/merged.vps"),
+                    output_model=Path("/run/model"),
+                    seed_pair="355,5305",
+                    component_model_min_images=100,
+                )
+            component_command = benchmark.build_mapping_command(
+                Path("/bin/visloc"),
+                features_dir=Path("/input/features"),
+                calibration_dir=Path("/input/calibration"),
+                merged_snapshot=Path("/run/merged.vps"),
+                output_model=Path("/run/model"),
+                component_model_min_images=100,
+                component_model_max_count=7,
+            )
+            self.assertEqual(
+                component_command[
+                    component_command.index("--component-model-min-images") + 1
+                ],
+                "100",
+            )
+            self.assertEqual(
+                component_command[
+                    component_command.index("--component-model-max-count") + 1
+                ],
+                "7",
+            )
+            with self.assertRaisesRegex(benchmark.ValidationError, "requires"):
+                benchmark.build_mapping_command(
+                    Path("/bin/visloc"),
+                    features_dir=Path("/input/features"),
+                    calibration_dir=Path("/input/calibration"),
+                    merged_snapshot=Path("/run/merged.vps"),
+                    output_model=Path("/run/model"),
+                    component_model_max_count=7,
                 )
 
             rig_candidate_command = benchmark.build_candidate_command(


### PR DESCRIPTION
## Summary
- diagnose the frozen OpenLORIS 10k verified view graph and recover its large disconnected components deterministically
- map bounded components sequentially from one feature load and export independent COLMAP models plus `components.tsv`
- document the 10k result and SfM demo flags while preserving the README's prominent measured COLMAP comparison

## Measured result
- M6 single model: 3,664 / 10,000 registered
- M7 seven independent models: 6,791 / 10,000 registered (+85.3%)
- per-model mean reprojection: 0.928–1.293 px
- 1k control: 1,000 / 1,000 and byte-identical to M6

The seven outputs have independent gauges; this PR does not claim one connected 10k reconstruction or a 10k COLMAP comparison. Verified bridge discovery and guarded Sim(3) alignment remain follow-up work.

## Validation
- `cargo test --workspace --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 -m unittest tests.test_benchmark_electro` (15 passed)
- `scripts/check_docs_links.sh`
- `jq empty benchmarks/electro/m7-component-models.json`
- `git diff --check`
