### PR TITLE
bench(sfm): calibrated bounded rig-atlas diagnostics (M8 still open)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to `visloc-rs` will be documented here.
 
 ### Added
 
+- **Calibrated rig-atlas diagnostics (2026-09-07).** Added opt-in bounded
+  fixed-rotation/unit-scale seam estimators and a trajectory-only stitching
+  example with deterministic overlap ownership and sparse metric SE3 controls.
+  Camera publication composes unchanged physical sensor extrinsics after the
+  rig transform, preserving the stereo baseline. Frozen OpenLORIS 10k controls
+  reach 9,998 images but still miss COLMAP's trajectory gates; interior-window
+  ownership and equal-weight pose-graph optimization regress and are not
+  promoted. Evidence distinguishes these diagnostics from a merged landmark
+  model and from mapper/end-to-end speed claims. Defaults remain unchanged.
+
 - **Bounded component-model recovery for disconnected large view graphs
   (2026-09-02).** Added explicit `--component-model-min-images` and
   `--component-model-max-count` controls to the unordered SfM demo and Electro

--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@
 The comparisons use real images and measured runs; the detailed sections below
 state where inputs or accounting differ. Separately, on the connected
 OpenLORIS 10k stress set, streamed VLAD + LSH cuts visloc-rs candidate
-generation from 49:49 to **8:51 (5.63×)**. No COLMAP 10k run has been made, so
-that number is not presented as a COLMAP comparison. The frozen measurements
+generation from 49:49 to **8:51 (5.63×)**. That is a visloc retrieval A/B,
+not an end-to-end COLMAP comparison. The frozen measurements
 and output hashes are in
 [`m6-ann-streaming.json`](benchmarks/electro/m6-ann-streaming.json).
+
+**OpenLORIS 10k COLMAP control is now available:** its calibrated-rig run
+registers **9,998/10,000 images** with **0.3843 m ATE RMSE**, **0.6387 m p95**,
+and **0.9030 px** mean reprojection error. visloc's 10k quality work is still
+in progress; trajectory-only submap experiments do not yet establish a full
+reconstruction or a speed win at equivalent quality. See the
+[frozen COLMAP control](benchmarks/electro/m8-openloris-colmap-10k-control.json)
+and [M8–M10 comparison plan](docs/openloris_m8_m10_plan.md).
 
 ## 10,008-image real-world SfM scale validation
 
@@ -170,9 +178,9 @@ claim. Evidence and model hashes are in
 candidate generation peaks at 1.14 GiB, matching at 851 MiB, and compact
 mapping at 501 MiB. Exact VLAD ranking still scores every image pair, so ANN
 retrieval plus streamed global descriptors now removes that quadratic ranking
-bottleneck; component and seed coverage remain the next quality target. No
-OpenLORIS COLMAP run was performed, so these 10k results are deliberately not
-presented as a COLMAP comparison. Source/license, hashes, phase ledgers, and
+bottleneck. These historical M5 results predate the calibrated-rig
+<a href="benchmarks/electro/m8-openloris-colmap-10k-control.json">M8 COLMAP control</a>
+and are not a same-condition head-to-head comparison. Source/license, hashes, phase ledgers, and
 honest dense/global negatives:
 <a href="benchmarks/electro/m5-openloris-connected-scale-validation.json">connected M5 evidence</a> ·
 <a href="docs/electro_m5_scale_validation.md">full scale report</a>.</sub></p>

--- a/benchmarks/electro/m8-openloris-atlas-metric-se3-ab.json
+++ b/benchmarks/electro/m8-openloris-atlas-metric-se3-ab.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "date": "2026-09-07",
+  "final_example_source_sha256": "34233b97d933c4640f1269b90bed948260ceb94b0048f3c199c05f7b173e44cc",
+  "status": "rejected_diagnostic_not_m8_pass",
+  "input_evidence": "m8-openloris-atlas-owner-ab.json",
+  "nodes_sha256": "564f0ac7f31fcac0e3995a65cfe3fe7711ebdef100b30f28f8970c81c1cea0ce",
+  "output_root": "/tmp/visloc-m8-metric-se3-ab-SWSGIA",
+  "seam_config_arm": "L",
+  "frame_owner_policy": "newest",
+  "forest_policy": "traversal",
+  "optimizer": {
+    "model": "SE3, fixed unit scale",
+    "linear_solver": "Sparse",
+    "initial_lambda": 0.001,
+    "chordal_init": false,
+    "robust_kernel": "None",
+    "edge_weight": 1.0,
+    "maximum_iterations": 20,
+    "component_0_initial_cost": 1.118173145605,
+    "component_0_final_cost": 0.260483497520,
+    "component_0_iterations": 9,
+    "component_0_converged": true,
+    "component_1_iterations": 15,
+    "component_1_converged": false
+  },
+  "control": {
+    "registered_images": 9998,
+    "components": 2,
+    "component_weighted_rmse_m": 0.39177824798691896,
+    "component_weighted_p95_m": 0.6436978626030669,
+    "byte_identical_to_prior_l": true
+  },
+  "metric": {
+    "repeat_byte_identical_both_components": true,
+    "registered_images": 9998,
+    "components": 2,
+    "component_weighted_rmse_m": 0.4310112054956803,
+    "component_weighted_p95_m": 0.717679162606496,
+    "images_sha256": [
+      "b462a17319866b9212c721ecbe4df8b148f4f1eb20919ceb15cc4d99ce63deb9",
+      "44005eeee990cb8b1fb10f9e253d64d789e9f66b0e99502dd4e530f579f77ca0"
+    ]
+  },
+  "decision": "Reject: internal objective improves but both trajectory gates regress. No GT-informed weighting sweep.",
+  "verification": {
+    "example_tests_passed": 34,
+    "slam_library_tests_passed": 638,
+    "slam_library_tests_ignored": 7,
+    "example_clippy_warnings_denied": true,
+    "workspace_all_targets_check": true
+  },
+  "limitations": [
+    "Trajectory-only output; no merged landmark reprojection result",
+    "Development sequence repeatedly scored, not held-out validation",
+    "Concurrent trajectory-only time logs are not mapper or E2E benchmarks",
+    "Sparse Cholesky has graph-dependent fill-in; no general linear-memory guarantee"
+  ]
+}

--- a/benchmarks/electro/m8-openloris-atlas-owner-ab.json
+++ b/benchmarks/electro/m8-openloris-atlas-owner-ab.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 1,
+  "date": "2026-09-07",
+  "status": "diagnostic_only_not_m8_pass",
+  "scope": "Trajectory publication only; no merged landmarks or reprojection evaluation",
+  "selection_caveat": "Development A/B on a repeatedly scored sequence, not held-out validation. Ground truth used only by post-map scorer.",
+  "code": {
+    "base_commit": "f70ae2e9b3e6460cafde80f2cafae3e41ef84cb8",
+    "worktree_dirty": true,
+    "example_source_sha256": "a049f93ff81c698803f69aebf8bcdff94ebbdf3cfca69b94776ae5848f247b17"
+  },
+  "inputs": {
+    "nodes_tsv": "/tmp/visloc-m8-seam650-nodes-20260907.tsv",
+    "nodes_sha256": "564f0ac7f31fcac0e3995a65cfe3fe7711ebdef100b30f28f8970c81c1cea0ce",
+    "rig_manifest_sha256": "c631e5ef1c729f889fc3fa4d4e1601f2876b691b09d45171d9f077fd6fcb8943",
+    "node_count": 23,
+    "seam_config_arm": "L",
+    "forest_policy": "traversal",
+    "accepted_seams": 29,
+    "rejected_seams": 42,
+    "max_boundary_frames": 64
+  },
+  "colmap_target": {
+    "evidence": "m8-openloris-colmap-10k-control.json",
+    "registered_images_min": 9998,
+    "component_weighted_rmse_m_max": 0.3843065335437528,
+    "component_weighted_p95_m_max": 0.6386693943260212,
+    "mean_reprojection_error_px_max": 0.9030031518617252
+  },
+  "runs": [
+    {
+      "frame_owner_policy": "newest",
+      "output_root": "/tmp/visloc-m8-owner-ab-nzxeyZ/newest",
+      "registered_images": 9998,
+      "components": 2,
+      "component_weighted_rmse_m": 0.39177824798691896,
+      "component_weighted_p95_m": 0.6436978626030669,
+      "component_weighted_max_m": 1.2897666565102102,
+      "images_sha256": [
+        "a26a3a4444dd73be2e707d5c89c3ebce845fd92a34eb8c18a0d2e6833e489ed3",
+        "44005eeee990cb8b1fb10f9e253d64d789e9f66b0e99502dd4e530f579f77ca0"
+      ],
+      "byte_identical_to_prior_l": true,
+      "trajectory_gate_pass": false
+    },
+    {
+      "frame_owner_policy": "interior",
+      "output_root": "/tmp/visloc-m8-owner-ab-nzxeyZ/interior",
+      "registered_images": 9998,
+      "components": 2,
+      "component_weighted_rmse_m": 0.43193606009889973,
+      "component_weighted_p95_m": 0.7126703067449092,
+      "component_weighted_max_m": 1.1572475531719284,
+      "images_sha256": [
+        "5b25803b144fb16df686a31d490cb1138ba0a4ed5ad49550337a5406fbb51c59",
+        "4ace6d25135c0d4baa401b9a56f3f2771b44875548de49f0f0d572c2cd85d569"
+      ],
+      "trajectory_gate_pass": false,
+      "decision": "reject: RMSE and p95 regress; default remains newest"
+    }
+  ],
+  "verification": {
+    "example_tests_passed": 28,
+    "slam_library_tests_passed": 638,
+    "slam_library_tests_ignored": 7,
+    "example_clippy_warnings_denied": true,
+    "cargo_fmt_check": true
+  },
+  "not_measured": [
+    "merged_model_reprojection",
+    "mapper_only_comparative_performance",
+    "native_end_to_end_comparative_performance",
+    "three_run_performance_reproducibility"
+  ]
+}

--- a/benchmarks/electro/m8-openloris-local-window-diagnostic.json
+++ b/benchmarks/electro/m8-openloris-local-window-diagnostic.json
@@ -35,18 +35,23 @@
       "registered_frames": 500,
       "registered_images": 1000,
       "models": 1,
-      "tracks": 27557,
-      "observations": 177046,
-      "mean_reprojection_error_px": 0.674509072,
-      "mapper_seconds": 35.416736,
-      "wall_seconds": 39.197660,
-      "peak_rss_kib": 340092,
-      "ate_rmse_m": 0.18693728213282415,
-      "ate_p95_m": 0.32773987907927826,
-      "ate_max_m": 0.36219019055800994,
-      "sim3_scale": 0.9427114630633276,
-      "images_txt_sha256": "a8816b3b4b163d2c25f173929b2980bed490e79404e6767950a2b3fbfc078403",
-      "score_sha256": "7fe6dfe8ae23e92133bdbe08cc376fc51e1d8a5f9faca21565ddc40e54601c5b"
+      "tracks": 27432,
+      "observations": 180028,
+      "mean_reprojection_error_px": 0.682592997,
+      "mapper_seconds": 36.865336,
+      "peak_rss_kib": 339764,
+      "ate_rmse_m": 0.2941103770787429,
+      "ate_p95_m": 0.5497919387137824,
+      "ate_max_m": 0.635907112501902,
+      "sim3_scale": 0.960507374753806,
+      "images_txt_sha256": "826129599d9b3acba4ff39c80950a31800ee2e8484801facd8833c4031150ecb",
+      "score_sha256": "d0a0402de9cdc5b02b6e99492da468a904e4b7a5b802fe3c418e24b6874a6959",
+      "repeat_byte_identical": true,
+      "repeat_model_sha256": {
+        "cameras_txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images_txt": "826129599d9b3acba4ff39c80950a31800ee2e8484801facd8833c4031150ecb",
+        "points3D_txt": "6fb6cc666ea45ea9059c2d9eb6607f3ffd6adf5818ebe26c418f24a872a8db66"
+      }
     },
     {
       "frame_range": [3000, 3500],
@@ -94,7 +99,7 @@
       "ate_p95_m": 0.7683577784,
       "mean_reprojection_error_px": 0.681997968
     },
-    "interpretation": "Both local windows preserve complete image registration and COLMAP-beating reprojection. The second problem interval is locally 8.4x lower in RMSE and 8.8x lower in p95 than the full-map score when its two gauges are aligned independently. This local/global gap supports bounded overlapping submaps with robust shared-frame Sim(3) stitching; it does not itself pass the M8 10k gate."
+    "interpretation": "Both local windows preserve complete image registration and COLMAP-beating reprojection. The second problem interval is locally 8.4x lower in RMSE and 8.8x lower in p95 than the full-map score when its two gauges are aligned independently. The current release reproduces the first window byte-for-byte; an earlier stale-binary measurement was discarded. This local/global gap supports bounded overlapping submaps with robust shared-frame Sim(3) stitching; it does not itself pass the M8 10k gate."
   },
   "next_gate": {
     "experiment": "reconstruct overlapping bounded windows, robustly estimate adjacent Sim3 transforms only from shared registered frame centres, compose a deterministic chain, and score the published trajectory without GT in mapping",

--- a/benchmarks/electro/m8-openloris-local-window-diagnostic.json
+++ b/benchmarks/electro/m8-openloris-local-window-diagnostic.json
@@ -1,0 +1,103 @@
+{
+  "schema": "visloc_m8_openloris_local_window_diagnostic_v1",
+  "recorded_at": "2026-09-04",
+  "status": "supports_overlapping_submap_experiment",
+  "base_git_commit": "76e061c",
+  "ground_truth_used_for_mapping": false,
+  "ground_truth_usage": "post-map scoring only; never used for window selection, matching, registration, or reconstruction",
+  "method": {
+    "name": "bounded_contiguous_frame_range_replay",
+    "cli": "--frame-range-start START --frame-range-count COUNT",
+    "semantics": "read and validate the frozen base and deferred overlay, retain one contiguous frame range, deterministically remap its images, and preserve pair order plus the base/deferred boundary",
+    "state_bound": "O(source images + source verified pairs) transient filtering state and O(window observations) mapper state; no frame Cartesian or N^2 state",
+    "snapshot_serialization": false
+  },
+  "dataset": {
+    "sequence": "OpenLORIS corridor1-1",
+    "source_frames": 5000,
+    "source_images": 10000,
+    "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt",
+    "rig_manifest_sha256": "c631e5ef1c729f889fc3fa4d4e1601f2876b691b09d45171d9f077fd6fcb8943",
+    "base_snapshot": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-dense256-v1/mapping/verified-base-repair19-targeted7.vps",
+    "base_snapshot_sha256": "c9b30f7f7c29257e79dda6fe9b479924917b1e875d351085768b19af1e476857",
+    "deferred_overlay_snapshot": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps",
+    "deferred_overlay_snapshot_sha256": "02cd6475098453cb6cf93761ff990ea31acba86217b715dfaf43660f3af0f05c",
+    "tier_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-10000.json",
+    "tier_manifest_sha256": "a3458a3a2acf0978f632f50ed22f552f0683a3f23894061a5b6da85e6d64d61c",
+    "common_configuration": "the frozen 10k dense-deferred 32--128 champion, including base prefix 59961, max two models, local BA 10/40/8, two endpoint-fixed final BA passes, pair-confidence tracks, two completion passes, isolated pose repair, and two final filter refinements"
+  },
+  "windows": [
+    {
+      "frame_range": [2500, 3000],
+      "retained_images": 1000,
+      "retained_pairs": 7337,
+      "retained_base_pairs": 5890,
+      "registered_frames": 500,
+      "registered_images": 1000,
+      "models": 1,
+      "tracks": 27557,
+      "observations": 177046,
+      "mean_reprojection_error_px": 0.674509072,
+      "mapper_seconds": 35.416736,
+      "wall_seconds": 39.197660,
+      "peak_rss_kib": 340092,
+      "ate_rmse_m": 0.18693728213282415,
+      "ate_p95_m": 0.32773987907927826,
+      "ate_max_m": 0.36219019055800994,
+      "sim3_scale": 0.9427114630633276,
+      "images_txt_sha256": "a8816b3b4b163d2c25f173929b2980bed490e79404e6767950a2b3fbfc078403",
+      "score_sha256": "7fe6dfe8ae23e92133bdbe08cc376fc51e1d8a5f9faca21565ddc40e54601c5b"
+    },
+    {
+      "frame_range": [3000, 3500],
+      "retained_images": 1000,
+      "retained_pairs": 6879,
+      "retained_base_pairs": 5487,
+      "registered_frames": 500,
+      "registered_images": 1000,
+      "models": 2,
+      "model_frames": [260, 240],
+      "model_images": [520, 480],
+      "tracks": 29974,
+      "observations": 115261,
+      "mean_reprojection_error_px": 0.675275820,
+      "mapper_seconds": 16.259845,
+      "wall_seconds": 19.01,
+      "peak_rss_kib": 340060,
+      "component_weighted_ate_rmse_m": 0.04601404008474228,
+      "component_weighted_ate_p95_m": 0.08759663329529255,
+      "components": [
+        {
+          "frames": 260,
+          "images": 520,
+          "ate_rmse_m": 0.05885439340808992,
+          "ate_p95_m": 0.11409471481211032,
+          "sim3_scale": 0.9073533486789831,
+          "images_txt_sha256": "204f974062ce8bcc8c61f3d7cf35ca47efbe6a025bf2aa73913442ac937dd70b",
+          "score_sha256": "b87b0e6d1da0d5442ad65cab74c66bd8cb9ad69d70c4c1e084ffc153e41e0f58"
+        },
+        {
+          "frames": 240,
+          "images": 480,
+          "ate_rmse_m": 0.03210365731778234,
+          "ate_p95_m": 0.05889037831873996,
+          "sim3_scale": 0.9393621358427822,
+          "images_txt_sha256": "c9c66e35c1c82415fa3dd3c0bca8dc316bfdc9c83cf4eb001d14e4106dc691be",
+          "score_sha256": "cef375937faff30cc0c67450d28e4bc8e9536484d54868c649a8566a4ad40899"
+        }
+      ]
+    }
+  ],
+  "comparison": {
+    "full_10k_visloc_champion": {
+      "ate_rmse_m": 0.3875394944,
+      "ate_p95_m": 0.7683577784,
+      "mean_reprojection_error_px": 0.681997968
+    },
+    "interpretation": "Both local windows preserve complete image registration and COLMAP-beating reprojection. The second problem interval is locally 8.4x lower in RMSE and 8.8x lower in p95 than the full-map score when its two gauges are aligned independently. This local/global gap supports bounded overlapping submaps with robust shared-frame Sim(3) stitching; it does not itself pass the M8 10k gate."
+  },
+  "next_gate": {
+    "experiment": "reconstruct overlapping bounded windows, robustly estimate adjacent Sim3 transforms only from shared registered frame centres, compose a deterministic chain, and score the published trajectory without GT in mapping",
+    "promotion_requires": "9998/10000 registration, at most two output gauges, largest model at least 4494 frames, reprojection <= 0.903003 px, RMSE <= 0.384307 m, p95 <= 0.638669 m, peak RSS <= 2 GiB, deterministic output, and no N^2 state"
+  }
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,12 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 現在の引き継ぎ先（2026-09-07）:
+> [OpenLORIS M8–M10計画](openloris_m8_m10_plan.md) と
+> [rig-atlas診断記録](openloris_rig_atlas_diagnostic.md)。以下は9月1日時点の
+> 履歴です。M8は未完了で、最新の軌跡のみの診断は9,998画像、
+> RMSE 0.391778 m / p95 0.643698 m。COLMAPの精度ゲートと
+> 統合ランドマークモデルの再投影評価はまだ通過していません。
+
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`
 **ブランチ:** `perf/electro-m4-persistent-matcher`

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -580,6 +580,22 @@ anchor does not solve the problem: it regresses aggregate RMSE/p95 to
 metric-labelled tracks while freeing that anchor regresses further to
 0.5319/1.1483 m, so its temporary options were removed.
 
+A mapper-local contiguous replay now tests that conclusion without changing
+the verified input or consulting GT. The replay validates the full frozen
+snapshot and overlay, retains only one requested frame interval, remaps image
+IDs deterministically, preserves pair order and the base/deferred boundary,
+and never forms a frame Cartesian product. Frames 2,500--2,999 registered all
+1,000 images in one model at 0.67451 px and scored 0.18694/0.32774 m
+RMSE/p95. Frames 3,000--3,499 also registered all 1,000 images at 0.67528 px;
+its naturally disconnected 260/240-frame models scored a component-weighted
+0.04601/0.08760 m. Peak RSS was about 332 MiB in both runs. The sharp
+local/global gap, especially across the drifting middle interval, confirms
+that bounded local reconstruction is substantially better than the published
+long-gauge trajectory. It promotes an overlapping-window Sim(3) stitching
+experiment, not the M8 result itself. Exact inputs, hashes, commands, resource
+counters, and scores are frozen in
+[`m8-openloris-local-window-diagnostic.json`](../benchmarks/electro/m8-openloris-local-window-diagnostic.json).
+
 The GT-free cause is observable in the dense final map. It contains 352,185
 independently triangulated local stereo points and 28,092 tracks with such
 points in two frames, but robust 3D-to-3D motion at gaps 32--128 is extremely

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -1171,6 +1171,30 @@ the skipped-10k decision are frozen in
 
 ## M9 — make the quality champion faster than COLMAP
 
+The overlapping-window trajectory experiment remains below the M8 gate.
+Its September 7 audit corrected publication that inadvertently scaled the
+calibrated stereo baseline. The corrected K diagnostic preserves all supplied
+sensor extrinsics and repeats byte-for-byte, but still registers only 9,996
+images and scores 0.478844 m RMSE / 0.897779 m p95. These are trajectory-only
+outputs, without a merged landmark model or reprojection result. See the
+[rig-atlas diagnostic](openloris_rig_atlas_diagnostic.md) for the rejected
+arms, calibration audit, corrected results, and repeat hashes. A subsequent
+500-frame replay starting at 4200 recovered frame 4493 without threshold
+changes. Adding that overlapping node reaches 9,998 images and 4,494/505-frame
+components, but RMSE/p95 remain 0.481208/0.905394 m. Registration recovery is
+therefore established for the trajectory diagnostic. A further unchanged
+500-frame replay starting at 650 supplies an alternative unit-scale route
+around a scale-changing seam. Strict-metric L reaches RMSE/p95
+0.391778/0.643698 m at the same registration, still above COLMAP's
+0.384307/0.638669 m limits. Changing overlap publication to prefer window
+interiors worsens both metrics (0.431936/0.712670 m) and is not promoted.
+The M8 accuracy and merged-model gates remain open; the linked diagnostic
+records input/output hashes and the byte-identical default-policy repeat.
+Equal-weight, scale-fixed SE3 optimization on all accepted seams reduces
+its internal cost but worsens RMSE/p95 to 0.431011/0.717679 m; it also remains
+diagnostic-only. The next integration gate is a real, observation-validated
+landmark model with bounded refinement, not another score-tuned graph policy.
+
 Freeze the M8 quality champion before performance edits.
 
 ### Exact-output performance work accepted during M8 diagnosis (2026-09-03)

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -585,7 +585,7 @@ the verified input or consulting GT. The replay validates the full frozen
 snapshot and overlay, retains only one requested frame interval, remaps image
 IDs deterministically, preserves pair order and the base/deferred boundary,
 and never forms a frame Cartesian product. Frames 2,500--2,999 registered all
-1,000 images in one model at 0.67451 px and scored 0.18694/0.32774 m
+1,000 images in one model at 0.68259 px and scored 0.29411/0.54979 m
 RMSE/p95. Frames 3,000--3,499 also registered all 1,000 images at 0.67528 px;
 its naturally disconnected 260/240-frame models scored a component-weighted
 0.04601/0.08760 m. Peak RSS was about 332 MiB in both runs. The sharp
@@ -595,6 +595,8 @@ long-gauge trajectory. It promotes an overlapping-window Sim(3) stitching
 experiment, not the M8 result itself. Exact inputs, hashes, commands, resource
 counters, and scores are frozen in
 [`m8-openloris-local-window-diagnostic.json`](../benchmarks/electro/m8-openloris-local-window-diagnostic.json).
+The first window was rerun with the current release binary and reproduced all
+three model files byte-for-byte; an earlier stale-binary score was discarded.
 
 The GT-free cause is observable in the dense final map. It contains 352,185
 independently triangulated local stereo points and 28,092 tracks with such

--- a/docs/openloris_rig_atlas_diagnostic.md
+++ b/docs/openloris_rig_atlas_diagnostic.md
@@ -1,0 +1,307 @@
+# OpenLORIS rig-atlas diagnostic
+
+Status: M8 remains incomplete. These outputs contain trajectories only, with
+empty observation rows. They do not establish merged-model reprojection quality,
+mapper-only performance, or native end-to-end performance.
+
+## Frozen experiment inputs
+
+The September 4 overlap experiments use
+`/tmp/visloc-m8-hierarchical-500x250/nodes-shifted-bridges.tsv`
+(SHA-256 `4dfb8283d0cd9693768555636e433a4933b153b5bbcd6d32ecc428cc6a705366`).
+They publish 9,996 images in two components, containing 4,493 and 505 rig
+frames. Frames 4,493 and 4,494 are absent. The COLMAP target requires 9,998
+images, a largest component of at least 4,494 frames, RMSE at most 0.384307 m,
+p95 at most 0.638669 m, and mean reprojection at most 0.903003 px.
+
+Ground truth is loaded only by the post-map scorer. Window selection and seam
+estimation use reconstructed poses and shared frame identities. Nevertheless,
+the successive arms are development experiments evaluated repeatedly against
+this sequence; they are not independent held-out validation.
+
+## Retained September 4 results
+
+| Diagnostic arm | Transform graph | ATE RMSE (m) | ATE p95 (m) |
+| --- | --- | ---: | ---: |
+| H, earliest overlap sample | traversal | 0.540386 | 1.119452 |
+| H, earliest overlap sample | quality forest | 0.650178 | 1.128827 |
+| I, uniform overlap sample | quality forest | 0.717315 | 1.613746 |
+| J, relaxed mean-residual gate | traversal | 0.486770 | 0.933776 |
+| K, unit-scale fixed-rotation estimator with generic fallback | traversal | 0.478419 | 0.894231 |
+
+All arms fail registration and trajectory acceptance. Quality-forest ordering
+and uniform sampling were not promoted. H traversal was reproduced after
+restoring the explicit traversal policy. K still accepts a generic fallback
+with scale 0.775097 on the node 3 / node 21 seam, so it does not enforce unit
+scale throughout the atlas.
+
+These numbers describe the old per-camera publication rule. On September 7,
+an independent calibration audit found that this rule scales the stereo
+baseline when applying a non-unit Sim(3) to the two sensor centres separately:
+
+| Artifact, dominant component | Minimum baseline (m) | Median baseline (m) | Maximum baseline (m) |
+| --- | ---: | ---: | ---: |
+| Input window 0 | 0.063977924049 | 0.063977924051 | 0.063977924053 |
+| H traversal output | 0.044581955118 | 0.046855061714 | 0.063977924052 |
+| K traversal output | 0.049589122861 | 0.049589122893 | 0.063977924059 |
+
+The audit pairs sensor names through the rig manifest's `F` rows and computes
+each camera centre as `-R.transpose() * t`. Numeric image suffixes differ
+between the two sensors and must not be used as the pairing key.
+
+The required publication rule is to transform one rig pose into the atlas,
+then compose each unchanged, manifest-bound `sensor_from_rig` transform with
+that rig pose. This preserves the supplied physical calibration. It changes
+sensor centres relative to a naive Sim(3) of the complete local model, so any
+future landmark integration must re-evaluate observations and triangulation;
+it cannot inherit the local model's reprojection score.
+
+## Calibration-preserving publication verified (September 7)
+
+The exporter now binds each image to the manifest's fixed `sensor_from_rig`
+and composes it with the transformed rig pose. A pose-composition unit test
+covers scales 0.7 and 1.3, nontrivial rig motion, and distinct sensor rotations.
+The example suite passes all 24 tests; formatting and example clippy with
+warnings denied also pass.
+
+The same H and K inputs were replayed twice into
+`/tmp/visloc-m8-rig-calibration-20260907-xW3PlM`. Both component files were
+byte-identical across repetitions for each arm. An independent numeric audit
+checked all 4,998 sensor pairs against the manifest: maximum relative-rotation
+matrix error was below `5e-15` (Frobenius norm), relative-translation error
+below `1.7e-13 m`, and every baseline was within `1.3e-13 m` of
+`0.063977924051 m`.
+
+| Corrected arm | Images | Components | ATE RMSE (m) | ATE p95 (m) |
+| --- | ---: | ---: | ---: | ---: |
+| H traversal | 9,996 | 2 | 0.541224502 | 1.123657290 |
+| K traversal | 9,996 | 2 | 0.478844237 | 0.897778825 |
+
+The calibration defect is fixed, but trajectory and registration still fail.
+These scores supersede the old per-camera publication scores for future
+comparisons. The correction does not justify another threshold relaxation.
+
+Repeat-verified `images.txt` SHA-256 values:
+
+| Arm | Component | SHA-256 |
+| --- | --- | --- |
+| H | 000 | `f0635f72f7b120992afea84beaf50a022dc1e1d23bc56c9f951a2edff73b1967` |
+| H | 001 | `c830546d1549080aeb6536155b4aba8f54c16524b0c750c5eab628d05cd7f649` |
+| K | 000 | `5a6ec16c01ef94cb79ff2be23737b14435cdcfab53650b45d1e763ef29229322` |
+| K | 001 | `44005eeee990cb8b1fb10f9e253d64d789e9f66b0e99502dd4e530f579f77ca0` |
+
+## Further registration and seam experiments
+
+### Boundary correspondence audit (September 7)
+
+Decoding the frozen targeted7 base snapshot validates 10,000 images, 60,347
+verified pairs, and 3,352,705 accepted correspondences. Using its unchanged
+59,961-pair structure prefix and the rig manifest's image assignments gives:
+
+| Target frame / sensor | Stage | Other endpoint frame / sensor | Accepted correspondences |
+| --- | --- | --- | ---: |
+| 4493 / 1 | structure | 4491 / 1 | 18 |
+| 4493 / 1 | structure | 4492 / 1 | 21 |
+| 4493 / 1 | deferred | 4488 / 0 | 17 |
+| 4493 / 1 | deferred | 4489 / 0 | 17 |
+| 4493 / 1 | deferred | 4490 / 0 | 25 |
+| 4493 / 1 | deferred | 4490 / 1 | 15 |
+| 4494 / 0 | structure | 4495 / 0 | 15 |
+| 4494 / 0 | deferred | 4497 / 1 | 15 |
+
+These are all incident pairs in the base snapshot, before the separate dense
+overlay. Every target observation for frame 4493 is on sensor 1, so this input
+alone cannot satisfy the normal two-sensor PnP gate. The configured deferred
+one-sensor path is necessary to test next. Pair counts do not establish usable
+3-D support or successful PnP; source-track triangulation and per-target
+registration diagnostics must be inspected before assigning the failure cause.
+
+The historical strong-structure registration experiment used a direct-stereo
+PnP fallback at frame gap 2 with one sensor allowed. The current local-window
+command disables that fallback but enables deferred one-sensor registration.
+This is a measured configuration difference, not yet proof that enabling the
+old fallback will recover the frame in the current snapshot and local map.
+
+The dense overlay source has **zero** incident verified pairs for either
+4493 or 4494, before temporal-gap filtering. Dense feature volume therefore
+does not add registration support for these two frames in this frozen input.
+
+### Boundary registration recovered with a shifted window
+
+Replaying the saved window command with start 4200 and count 500, without
+changing thresholds, recovers 4493 through deferred PnP. The local model has
+499/500 frames, two components, and 0.558604912 px weighted reprojection.
+Mapper time is 22.431005 s, process wall time 24.82 s, and peak RSS
+340,056 KiB. Inputs, debug logs, model files, and the timed command are at
+`/tmp/visloc-m8-boundary-window-4200-debug.AqO1ao`.
+
+The remaining frame 4494 has zero usable deferred correspondences in the
+first component and two in the second (six required). Direct and motion
+bridge visits remain zero. This local recovery does not require reopening
+either bridge mechanism or relaxing a PnP gate.
+
+Replacing window node 18 with the new node 27 recovers registration but
+regresses atlas RMSE/p95 to 0.527112/1.097068 m. Keeping node 18 and adding
+node 27 instead preserves its existing overlap coverage and yields:
+
+| K traversal with added boundary node | Result | COLMAP gate |
+| --- | ---: | ---: |
+| Registered images | 9,998 | 9,998 |
+| Largest component, rig frames | 4,494 | 4,494 |
+| Components | 2 | at most 2 |
+| ATE RMSE | 0.481208093 m | at most 0.384307 m |
+| ATE p95 | 0.905394066 m | at most 0.638669 m |
+
+Output root: `/tmp/visloc-m8-boundary-added-atlas-20260907-vVLgiV`.
+Node manifest: `/tmp/visloc-m8-boundary-added-nodes-20260907.tsv`.
+Component 000 `images.txt` SHA-256:
+`e131fa0bde1684be822a6d10a4c23f4583534ff43e3b7ff4357d08121c27b74d`.
+Component 001 is unchanged from corrected K
+(`44005eeee990cb8b1fb10f9e253d64d789e9f66b0e99502dd4e530f579f77ca0`).
+Registration gates pass for this trajectory diagnostic; accuracy and merged
+landmark reprojection remain unproven. These variants are single decision
+runs, not the required final three-run performance comparison.
+
+### Additional overlap around the non-unit seam
+
+An accepted-edge connectivity audit identifies node 3 / node 21 as a graph
+bridge before adding any new window. Its K fixed-rotation unit-scale attempt
+rejects with 22/64 inliers; the generic fallback accepts scale 0.775097405.
+There is no alternative accepted route across that cut, so cycle-based
+optimization alone has no independent constraint to correct this edge.
+
+Replaying frames 650--1149 with the unchanged 500-frame mapper configuration
+produces 500/500 registered rig frames in one model, 0.674879864 px mean
+reprojection, 27.669512 s mapper time, 30.07 s process wall time, and
+340,020 KiB peak RSS. All frames register during normal PnP. Output:
+`/tmp/visloc-m8-window-650.hSRTGo/model/component-000`.
+
+Adding it as node 28 creates accepted unit-scale connections to nodes 1, 21,
+3, and 4. The original scale-0.775 edge is consequently no longer the only
+route. With all earlier nodes retained, K traversal improves to 0.397456745 m
+RMSE and 0.642896173 m p95 at 9,998 images / two components. Both metrics still
+miss COLMAP. K quality-forest on these same inputs is worse at
+0.451738027 / 0.714085127 m; the corresponding pre-addition quality control
+was 0.536545315 / 0.933283174 m. These paired controls distinguish new overlap
+support from changing the graph policy.
+
+The K traversal output was repeated byte-for-byte for both components:
+`/tmp/visloc-m8-seam650-atlas-mtHTsS/traversal` and
+`/tmp/visloc-m8-seam650-repeat-L6XfF4/model`. Its dominant-component
+`images.txt` SHA-256 is
+`f61c9f2eaa0deaf5a1ca7d423dd2e3a1d82a811dd9d31bb3bee07fa5cfacbb8e`;
+the tail component remains unchanged. The node manifest is
+`/tmp/visloc-m8-seam650-nodes-20260907.tsv`, SHA-256
+`564f0ac7f31fcac0e3995a65cfe3fe7711ebdef100b30f28f8970c81c1cea0ce`.
+
+## Remaining acceptance checks
+
+The strict metric L arm uses K's exact thresholds and earliest sampling, but
+disables generic scale-changing fallback. On the new overlap graph it still
+publishes 9,998 images / two components and scores 0.391778248 m RMSE /
+0.643697863 m p95. It rejects the old non-unit edge while preserving the new
+unit-scale route. Both trajectory gates remain unmet; the modest RMSE gain
+does not offset the slightly worse p95 versus K.
+
+Output: `/tmp/visloc-m8-seam650-strict-metric-8a9UaT`.
+Dominant `images.txt` SHA-256:
+`a26a3a4444dd73be2e707d5c89c3ebce845fd92a34eb8c18a0d2e6833e489ed3`.
+The parser/config tests cover L's sole configuration difference; the example
+suite passes 28 tests after the owner-policy experiment below; example clippy
+passes with warnings denied.
+
+### Overlap frame ownership control
+
+With the same 23-node manifest, L seams, and traversal transforms, the
+`--frame-owner-policy interior` diagnostic chooses the healthy window with
+the greatest distance from its first/last registered frame. Only windows
+actually containing the frame are eligible; ties use newest start and node
+ID. This uses no ground truth. The default remains `newest`.
+
+| Owner policy | Registered images | ATE RMSE (m) | ATE p95 (m) |
+| --- | ---: | ---: | ---: |
+| newest, repeat control | 9,998 | 0.391778248 | 0.643697863 |
+| interior, rejected | 9,998 | 0.431936060 | 0.712670307 |
+
+Both retain two components. Interior worsens both target metrics and is not
+promoted. Newest reproduces both strict-metric component hashes exactly.
+Outputs and post-map scores: `/tmp/visloc-m8-owner-ab-nzxeyZ/{newest,interior}`.
+Exact metrics, hashes, gates, and test results are retained in the repository's
+[owner A/B evidence](../benchmarks/electro/m8-openloris-atlas-owner-ab.json).
+Interior component 000 SHA-256:
+`5b25803b144fb16df686a31d490cb1138ba0a4ed5ad49550337a5406fbb51c59`;
+component 001:
+`4ace6d25135c0d4baa401b9a56f3f2771b44875548de49f0f0d572c2cd85d569`.
+The next control below tests whether a scale-fixed sparse pose graph can
+use the newly available redundant seams; no trajectory threshold is relaxed.
+
+### Equal-weight metric SE3 cycle optimization (rejected)
+
+The opt-in `--metric-se3` diagnostic uses all accepted L seams, one anchored
+SE3 graph per component, unit edge weights, no robust kernel, sparse Cholesky,
+LM initial damping 0.001, and no chordal initialization. Stored node poses are
+`node_from_atlas`; measurements retain `target_from_source`. Scale is fixed
+at one. The default remains unchanged, and the quality-forest combination is
+rejected because it would remove the redundant cycle constraints being tested.
+
+On the same frozen 23-node input, the dominant component's objective drops
+from 1.118173145605 to 0.260483497520 in nine iterations (converged). However,
+ATE RMSE/p95 worsen from 0.391778248/0.643697863 m to
+0.431011205/0.717679163 m. Both arms retain 9,998 images / two components.
+Thus reducing internal seam inconsistency does not establish improved scene
+accuracy; this arm is not promoted and no score-informed weight sweep follows.
+
+Output root: `/tmp/visloc-m8-metric-se3-ab-SWSGIA`, with separate `control`
+and `metric` directories, post-map `score.json`, and run/time logs. Control
+reproduces both previous L hashes. Metric component 000 SHA-256:
+`b462a17319866b9212c721ecbe4df8b148f4f1eb20919ceb15cc4d99ce63deb9`.
+Both metric components repeat byte-for-byte in `metric-repeat`. Exact metrics
+and the decision are retained in the
+[metric SE3 A/B evidence](../benchmarks/electro/m8-openloris-atlas-metric-se3-ab.json).
+The two-node tail is byte-identical to L; its numerically zero-cost solve
+reports `converged=false` after 15 iterations, so convergence is not claimed
+for the entire atlas. The time logs describe concurrent trajectory-only
+diagnostics, not a comparative mapper performance measurement.
+
+The next required work is real landmark integration and observation-based
+validation/refinement under the final calibrated rig poses. Further improvements
+must be supported by image geometry, not merely a lower pose-graph objective.
+
+Preserve the old outputs as diagnostic evidence. M8 still needs the
+trajectory gates, registration in a real merged landmark model, and its
+reprojection evaluation before performance and release closure.
+
+### Real-model integration requirements (implementation audit)
+
+The existing `generalized_rig_sfm` exporter retains each image's full
+keypoint ordering, but image IDs are local to each exported window. A future
+landmark integration must therefore join observations by manifest-bound image
+name/global ID plus original keypoint index, never by a window-local image or
+point ID. Confirm matching pixel coordinates when joining reused indices;
+different feature-bank generations must fail closed rather than merge silently.
+
+`RigSfmResult` contains poses and tracks, but the public fixed-rotation
+refinement entry point adjusts translations and landmarks of an existing
+result; it is not a bounded, fixed-pose atlas triangulation/import API. Calling
+it does not by itself establish correct integrated geometry or the memory gate.
+
+The existing COLMAP text writer emits zero in the points3D `ERROR` field.
+Consequently, a merged model's quality must be recomputed from actual camera
+projection and observation pixels, not read from those placeholder errors.
+An independent read-only projection audit of window 650 confirms this:
+40,754 points / 162,892 observations have bidirectionally consistent tracks,
+zero non-positive-depth observations, and mean error
+0.6748798644580134 px (p95 2.0428205985713275 px, maximum
+3.9951008058508584 px), matching the mapper's reported mean even though all
+exported `ERROR` fields are zero. This validates that individual window only,
+not the atlas or a merged 10k model.
+Keep physical rig extrinsics fixed, triangulate/refine using the final poses,
+validate positive depth and observation/track referential integrity, and report
+observation-weighted reprojection together with retained track/observation
+counts. Low error obtained only by discarding support is not sufficient.
+
+Plan the integration as streamed window ingestion with a sparse observation
+index and bounded local refinement. Do not load all descriptor banks or make
+an image-by-image matrix. Measure process/cgroup peak RSS for the complete
+mapper workflow, including window overlap work, integration, and export; the
+small trajectory-publication process is not a mapper performance substitute.

--- a/docs/openloris_rig_atlas_diagnostic.md
+++ b/docs/openloris_rig_atlas_diagnostic.md
@@ -280,6 +280,22 @@ name/global ID plus original keypoint index, never by a window-local image or
 point ID. Confirm matching pixel coordinates when joining reused indices;
 different feature-bank generations must fail closed rather than merge silently.
 
+A read-only audit of all 23 frozen source windows finds 21,566 image rows,
+9,998 unique image names, and 8,482 shared names (at most three occurrences).
+SHA-256 signatures of each complete ordered float64 `(x, y)` array agree for
+every repeated image: zero coordinate/ordering mismatches. The sources contain
+3,364,422 landmark observation references including overlap duplicates.
+Original window `images.txt` observation rows and sibling `cameras.txt` /
+`points3D.txt` exist; only the stitched trajectory output lacks landmarks.
+
+Naively unioning local tracks through shared observations is not safe: a
+read-only transitive-union diagnostic finds 803,676 source tracks, 1,750,273
+unique observations, and 380,669 unions, of which 833 contain multiple
+keypoints from the same image (10,611 excess same-image references). The
+largest union has 1,264 observations. This is a rejected diagnostic, not an
+accepted merge policy. Integration must detect these conflicts before mutating
+ownership and report rejected support, rather than silently combining them.
+
 `RigSfmResult` contains poses and tracks, but the public fixed-rotation
 refinement entry point adjusts translations and landmarks of an existing
 result; it is not a bounded, fixed-pose atlas triangulation/import API. Calling

--- a/examples/generalized_rig_sfm.rs
+++ b/examples/generalized_rig_sfm.rs
@@ -50,6 +50,8 @@ struct Args {
     out_colmap: PathBuf,
     max_models: usize,
     min_model_frames: usize,
+    frame_range_start: Option<usize>,
+    frame_range_count: Option<usize>,
     min_pnp_inliers: usize,
     min_pnp_sensors: usize,
     direct_stereo_pnp_max_frame_gap: usize,
@@ -141,6 +143,8 @@ fn parse_args() -> Result<Args, String> {
     let mut out_colmap = None;
     let mut max_models = 1usize;
     let mut min_model_frames = 10usize;
+    let mut frame_range_start = None;
+    let mut frame_range_count = None;
     let mut min_pnp_inliers = 8usize;
     let mut max_reprojection_error_px = 4.0;
     let mut pnp_max_iterations = 512usize;
@@ -264,6 +268,12 @@ fn parse_args() -> Result<Args, String> {
             "--max-models" => max_models = value()?.parse().map_err(|error| format!("{error}"))?,
             "--min-model-frames" => {
                 min_model_frames = value()?.parse().map_err(|error| format!("{error}"))?
+            }
+            "--frame-range-start" => {
+                frame_range_start = Some(value()?.parse().map_err(|error| format!("{error}"))?)
+            }
+            "--frame-range-count" => {
+                frame_range_count = Some(value()?.parse().map_err(|error| format!("{error}"))?)
             }
             "--min-pnp-inliers" => {
                 min_pnp_inliers = value()?.parse().map_err(|error| format!("{error}"))?
@@ -537,6 +547,7 @@ fn parse_args() -> Result<Args, String> {
                     "--deferred-overlay-max-matches-per-pair COUNT] ",
                     "--snapshot FILE [--out-colmap DIR] [--feature-suffix _features.txt] ",
                     "[--max-models 1] [--min-model-frames 10] ",
+                    "[--frame-range-start N --frame-range-count N] ",
                     "[--min-pnp-inliers 8] [--min-pnp-sensors 2] ",
                     "[--direct-stereo-pnp-max-frame-gap 0] ",
                     "[--direct-stereo-min-pnp-sensors COUNT] ",
@@ -770,6 +781,12 @@ fn parse_args() -> Result<Args, String> {
     if min_model_frames < 2 {
         return Err("--min-model-frames must be at least 2".into());
     }
+    validate_frame_range_args(frame_range_start, frame_range_count)?;
+    validate_frame_range_compatibility(
+        frame_range_start.is_some(),
+        max_track_frame_gap,
+        deferred_quadrilateral_whitelist_tsv.is_some(),
+    )?;
     if !triangulation_min_inlier_fraction.is_finite()
         || !(0.5..=1.0).contains(&triangulation_min_inlier_fraction)
     {
@@ -791,6 +808,8 @@ fn parse_args() -> Result<Args, String> {
         out_colmap: out_colmap.ok_or("--out-colmap is required")?,
         max_models,
         min_model_frames,
+        frame_range_start,
+        frame_range_count,
         min_pnp_inliers,
         min_pnp_sensors,
         direct_stereo_pnp_max_frame_gap,
@@ -1056,6 +1075,169 @@ fn build_frames(
         .into_values()
         .map(|images| RigFrame { images })
         .collect())
+}
+
+fn validate_frame_range_args(start: Option<usize>, count: Option<usize>) -> Result<(), String> {
+    match (start, count) {
+        (None, None) => Ok(()),
+        (Some(_), Some(0)) => Err("--frame-range-count must be positive".into()),
+        (Some(_), Some(_)) => Ok(()),
+        _ => Err("--frame-range-start and --frame-range-count must be provided together".into()),
+    }
+}
+
+fn validate_frame_range_compatibility(
+    enabled: bool,
+    max_track_frame_gap: Option<usize>,
+    has_quadrilateral_whitelist: bool,
+) -> Result<(), String> {
+    if !enabled {
+        return Ok(());
+    }
+    if max_track_frame_gap.is_some() {
+        return Err("frame-range replay cannot be combined with --max-track-frame-gap".into());
+    }
+    if has_quadrilateral_whitelist {
+        return Err(
+            "frame-range replay cannot be combined with --deferred-quadrilateral-whitelist-tsv"
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FrameRangeSliceStats {
+    source_frames: usize,
+    retained_frames: usize,
+    source_images: usize,
+    retained_images: usize,
+    source_pairs: usize,
+    retained_pairs: usize,
+    retained_base_pairs: Option<usize>,
+}
+
+/// Slice a validated replay in memory without materializing a frame-pair
+/// product. Pair order and the base/deferred partition are preserved exactly;
+/// only endpoints with both images in the contiguous frame range survive.
+///
+/// This derived snapshot is mapper-local and must not be serialized: envelope
+/// hashes intentionally continue to identify the validated source snapshots.
+fn slice_rig_replay_range(
+    snapshot: &mut verified_pair_snapshot::Snapshot,
+    frames: &[RigFrame],
+    start: usize,
+    count: usize,
+    deferred_pair_prefix: &mut Option<usize>,
+) -> Result<(Vec<RigFrame>, FrameRangeSliceStats), String> {
+    validate_frame_range_args(Some(start), Some(count))?;
+    let end = start
+        .checked_add(count)
+        .ok_or("frame range overflows usize")?;
+    if end > frames.len() {
+        return Err(format!(
+            "frame range [{start}, {end}) exceeds {} frames",
+            frames.len()
+        ));
+    }
+    if snapshot.image_names.len() != snapshot.feature_counts.len() {
+        return Err("snapshot image and feature-count vectors differ in length".into());
+    }
+    let source_images = snapshot.image_names.len();
+    let source_pairs = snapshot.pairs.len();
+    let original_prefix = match *deferred_pair_prefix {
+        Some(prefix) if prefix <= source_pairs => Some(prefix),
+        Some(prefix) => {
+            return Err(format!(
+                "--deferred-registration-pair-prefix {prefix} exceeds {source_pairs} pairs"
+            ));
+        }
+        None => None,
+    };
+
+    let mut selected = vec![false; source_images];
+    for frame in &frames[start..end] {
+        for image in &frame.images {
+            let slot = selected
+                .get_mut(image.image_index)
+                .ok_or_else(|| format!("frame image {} is outside snapshot", image.image_index))?;
+            if *slot {
+                return Err(format!(
+                    "snapshot image {} belongs to multiple selected frames",
+                    image.image_index
+                ));
+            }
+            *slot = true;
+        }
+    }
+    let mut old_to_new = vec![None; source_images];
+    let mut image_names = Vec::new();
+    let mut feature_counts = Vec::new();
+    for old in 0..source_images {
+        if !selected[old] {
+            continue;
+        }
+        old_to_new[old] = Some(image_names.len());
+        image_names.push(snapshot.image_names[old].clone());
+        feature_counts.push(snapshot.feature_counts[old]);
+    }
+
+    let mut sliced_frames = Vec::with_capacity(count);
+    for frame in &frames[start..end] {
+        let mut images = Vec::with_capacity(frame.images.len());
+        for image in &frame.images {
+            images.push(RigFrameImage {
+                image_index: old_to_new[image.image_index]
+                    .ok_or("selected frame image has no remapped index")?,
+                sensor_index: image.sensor_index,
+            });
+        }
+        sliced_frames.push(RigFrame { images });
+    }
+
+    let mut retained_base_pairs = 0usize;
+    let mut pairs = Vec::new();
+    for (pair_index, mut pair) in std::mem::take(&mut snapshot.pairs).into_iter().enumerate() {
+        let image_i = usize::try_from(pair.image_i)
+            .map_err(|_| "snapshot image_i does not fit usize".to_owned())?;
+        let image_j = usize::try_from(pair.image_j)
+            .map_err(|_| "snapshot image_j does not fit usize".to_owned())?;
+        if image_i >= source_images || image_j >= source_images {
+            return Err(format!(
+                "snapshot pair has image endpoint outside {source_images} images: ({image_i},{image_j})"
+            ));
+        }
+        let (Some(remapped_i), Some(remapped_j)) = (
+            old_to_new.get(image_i).copied().flatten(),
+            old_to_new.get(image_j).copied().flatten(),
+        ) else {
+            continue;
+        };
+        pair.image_i = remapped_i as u64;
+        pair.image_j = remapped_j as u64;
+        if original_prefix.is_some_and(|prefix| pair_index < prefix) {
+            retained_base_pairs += 1;
+        }
+        pairs.push(pair);
+    }
+    snapshot.image_names = image_names;
+    snapshot.feature_counts = feature_counts;
+    snapshot.accepted_match_count = pairs.iter().map(|pair| pair.matches.len() as u64).sum();
+    snapshot.pairs = pairs;
+    if original_prefix.is_some() {
+        *deferred_pair_prefix = Some(retained_base_pairs);
+    }
+
+    let stats = FrameRangeSliceStats {
+        source_frames: frames.len(),
+        retained_frames: sliced_frames.len(),
+        source_images,
+        retained_images: snapshot.image_names.len(),
+        source_pairs,
+        retained_pairs: snapshot.pairs.len(),
+        retained_base_pairs: original_prefix.map(|_| retained_base_pairs),
+    };
+    Ok((sliced_frames, stats))
 }
 
 fn convert_pairs(
@@ -2950,7 +3132,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         verified_pair_snapshot::read_mapper_compact(&args.snapshot)
     }
     .map_err(std::io::Error::other)?;
-    let frames =
+    let mut frames =
         build_frames(&manifest.frame_rows, &snapshot.image_names).map_err(std::io::Error::other)?;
     if let (Some(overlay_path), Some(max_frame_gap)) = (
         args.deferred_overlay_snapshot.as_ref(),
@@ -2979,6 +3161,27 @@ fn main() -> Result<(), Box<dyn Error>> {
             snapshot.pairs.len(),
             snapshot.pairs.iter().map(|pair| pair.matches.len()).sum::<usize>(),
             snapshot.feature_counts.iter().sum::<u64>(),
+        );
+    }
+    if let (Some(start), Some(count)) = (args.frame_range_start, args.frame_range_count) {
+        let (sliced_frames, stats) = slice_rig_replay_range(
+            &mut snapshot,
+            &frames,
+            start,
+            count,
+            &mut args.deferred_registration_pair_prefix,
+        )
+        .map_err(std::io::Error::other)?;
+        frames = sliced_frames;
+        eprintln!(
+            "rig-replay frame range: start={start} count={count} frames={}->{} images={}->{} pairs={}->{} base_pairs={:?}",
+            stats.source_frames,
+            stats.retained_frames,
+            stats.source_images,
+            stats.retained_images,
+            stats.source_pairs,
+            stats.retained_pairs,
+            stats.retained_base_pairs,
         );
     }
     let pose_priors = if args.long_pair_pose_prior_images.is_empty() {
@@ -3464,6 +3667,171 @@ mod tests {
             })),
             relative_translation_bits: None,
         }
+    }
+
+    #[test]
+    fn frame_range_arguments_require_a_positive_paired_range() {
+        assert_eq!(validate_frame_range_args(None, None), Ok(()));
+        assert_eq!(validate_frame_range_args(Some(3), Some(2)), Ok(()));
+        assert!(validate_frame_range_args(Some(3), None).is_err());
+        assert!(validate_frame_range_args(None, Some(2)).is_err());
+        assert!(validate_frame_range_args(Some(3), Some(0)).is_err());
+        assert_eq!(
+            validate_frame_range_compatibility(true, None, false),
+            Ok(())
+        );
+        assert!(validate_frame_range_compatibility(true, Some(4), false).is_err());
+        assert!(validate_frame_range_compatibility(true, None, true).is_err());
+        assert_eq!(
+            validate_frame_range_compatibility(false, Some(4), true),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn frame_range_slice_rejects_invalid_topology() {
+        let make_snapshot =
+            |pair: verified_pair_snapshot::PairRecord| verified_pair_snapshot::Snapshot {
+                schema_version: verified_pair_snapshot::SCHEMA_VERSION,
+                image_names: vec!["image-0".into(), "image-1".into()],
+                image_manifest_hash: 0,
+                feature_manifest_hash: 0,
+                feature_counts: vec![10, 10],
+                width: 1,
+                height: 1,
+                intrinsics_bits: [0; 4],
+                effective_config_hash: 0,
+                effective_config: String::new(),
+                verifier_config_hash: 0,
+                verifier_config: String::new(),
+                pair_order_hash: 0,
+                unordered_edge_hash: 0,
+                accepted_match_count: 1,
+                pairs: vec![pair],
+            };
+        let duplicate_frames = vec![
+            RigFrame {
+                images: vec![RigFrameImage {
+                    image_index: 0,
+                    sensor_index: 0,
+                }],
+            },
+            RigFrame {
+                images: vec![RigFrameImage {
+                    image_index: 0,
+                    sensor_index: 1,
+                }],
+            },
+        ];
+        let mut duplicate_snapshot =
+            make_snapshot(snapshot_pair(0, 1, 1, UnitQuaternion::identity()));
+        assert!(slice_rig_replay_range(
+            &mut duplicate_snapshot,
+            &duplicate_frames,
+            0,
+            2,
+            &mut None,
+        )
+        .is_err());
+
+        let frames = vec![RigFrame {
+            images: vec![
+                RigFrameImage {
+                    image_index: 0,
+                    sensor_index: 0,
+                },
+                RigFrameImage {
+                    image_index: 1,
+                    sensor_index: 1,
+                },
+            ],
+        }];
+        let mut invalid_pair_snapshot =
+            make_snapshot(snapshot_pair(0, 2, 1, UnitQuaternion::identity()));
+        assert!(
+            slice_rig_replay_range(&mut invalid_pair_snapshot, &frames, 0, 1, &mut None,).is_err()
+        );
+    }
+
+    #[test]
+    fn frame_range_slice_remaps_images_pairs_and_deferred_prefix() {
+        let image_names = (0..6).map(|index| format!("image-{index}")).collect();
+        let mut pairs = vec![
+            snapshot_pair(0, 1, 1, UnitQuaternion::identity()),
+            snapshot_pair(2, 3, 1, UnitQuaternion::identity()),
+            snapshot_pair(2, 4, 1, UnitQuaternion::identity()),
+            snapshot_pair(4, 5, 1, UnitQuaternion::identity()),
+            snapshot_pair(1, 2, 1, UnitQuaternion::identity()),
+        ];
+        for (index, pair) in pairs.iter_mut().enumerate() {
+            pair.matches = vec![(index as u64, index as u64)];
+        }
+        let mut snapshot = verified_pair_snapshot::Snapshot {
+            schema_version: verified_pair_snapshot::SCHEMA_VERSION,
+            image_names,
+            image_manifest_hash: 0,
+            feature_manifest_hash: 0,
+            feature_counts: vec![10, 11, 12, 13, 14, 15],
+            width: 1,
+            height: 1,
+            intrinsics_bits: [0; 4],
+            effective_config_hash: 0,
+            effective_config: String::new(),
+            verifier_config_hash: 0,
+            verifier_config: String::new(),
+            pair_order_hash: 0,
+            unordered_edge_hash: 0,
+            accepted_match_count: 5,
+            pairs,
+        };
+        let frames = (0..3)
+            .map(|frame| RigFrame {
+                images: vec![
+                    RigFrameImage {
+                        image_index: 2 * frame,
+                        sensor_index: 0,
+                    },
+                    RigFrameImage {
+                        image_index: 2 * frame + 1,
+                        sensor_index: 1,
+                    },
+                ],
+            })
+            .collect::<Vec<_>>();
+        let mut prefix = Some(3);
+
+        let (sliced, stats) =
+            slice_rig_replay_range(&mut snapshot, &frames, 1, 2, &mut prefix).unwrap();
+
+        assert_eq!(sliced.len(), 2);
+        assert_eq!(
+            sliced[0]
+                .images
+                .iter()
+                .map(|image| image.image_index)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        assert_eq!(
+            snapshot.image_names,
+            ["image-2", "image-3", "image-4", "image-5"]
+        );
+        assert_eq!(snapshot.feature_counts, [12, 13, 14, 15]);
+        assert_eq!(
+            snapshot
+                .pairs
+                .iter()
+                .map(|pair| (pair.image_i, pair.image_j))
+                .collect::<Vec<_>>(),
+            vec![(0, 1), (0, 2), (2, 3)]
+        );
+        assert_eq!(snapshot.accepted_match_count, 3);
+        assert_eq!(prefix, Some(2));
+        assert_eq!(stats.retained_base_pairs, Some(2));
+        assert_eq!(stats.retained_frames, 2);
+        assert_eq!(stats.retained_images, 4);
+        assert_eq!(stats.retained_pairs, 3);
+        assert!(slice_rig_replay_range(&mut snapshot, &sliced, 1, 2, &mut prefix).is_err());
     }
 
     #[test]

--- a/examples/stitch_rig_submap_trajectories.rs
+++ b/examples/stitch_rig_submap_trajectories.rs
@@ -1,0 +1,3876 @@
+//! Build a bounded, deterministic rig-submap trajectory atlas from COLMAP
+//! text models. Arms F through L are diagnostic-only extensions of arm E
+//! for fixed-rotation fallback/primary experiments.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::path::{Path, PathBuf};
+
+use nalgebra::{Quaternion, UnitQuaternion, Vector3};
+use visloc_rs::slam::{
+    estimate_rig_submap_sim3_constraint, LinearSolver, PoseGraph, PoseGraphEdge, PoseGraphEdgeKind,
+    PoseGraphSe3Config, RigSubmapAlignmentConfig, RigSubmapBoundarySampling, RobustKernel,
+    SubmapSim3AlignmentConfig,
+};
+use visloc_rs::{Pose, Sim3, SE3};
+
+const USAGE: &str = "usage: stitch_rig_submap_trajectories\n    --rig-manifest PATH --nodes-tsv PATH --out-dir PATH\n    [--seam-config-arm A|B|C|D|E|F|G|H|I|J|K|L]\n    [--frame-owner-policy newest|interior]\n    [--forest-policy traversal|quality]\n    [--metric-se3]";
+const MAX_RIG_CENTER_DISAGREEMENT_M: f64 = 1.0e-4;
+const MAX_RIG_ROTATION_DISAGREEMENT_DEG: f64 = 1.0e-3;
+const MAX_SEAM_START_GAP: u64 = 750;
+const HEALTHY_STEP_RATIO: f64 = 35.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeamConfigArm {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+}
+
+impl SeamConfigArm {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "A" => Ok(Self::A),
+            "B" => Ok(Self::B),
+            "C" => Ok(Self::C),
+            "D" => Ok(Self::D),
+            "E" => Ok(Self::E),
+            "F" => Ok(Self::F),
+            "G" => Ok(Self::G),
+            "H" => Ok(Self::H),
+            "I" => Ok(Self::I),
+            "J" => Ok(Self::J),
+            "K" => Ok(Self::K),
+            "L" => Ok(Self::L),
+            other => Err(format!(
+                "--seam-config-arm expects A, B, C, D, E, F, G, H, I, J, K, or L; got {other:?}"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::A => "A",
+            Self::B => "B",
+            Self::C => "C",
+            Self::D => "D",
+            Self::E => "E",
+            Self::F => "F",
+            Self::G => "G",
+            Self::H => "H",
+            Self::I => "I",
+            Self::J => "J",
+            Self::K => "K",
+            Self::L => "L",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ForestPolicy {
+    /// Use every accepted edge and the historical deterministic BFS gauge.
+    Traversal,
+    /// Use the deterministic quality-first Kruskal spanning forest.
+    Quality,
+}
+
+impl ForestPolicy {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "traversal" => Ok(Self::Traversal),
+            "quality" => Ok(Self::Quality),
+            other => Err(format!(
+                "--forest-policy expects traversal or quality; got {other:?}"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Traversal => "traversal",
+            Self::Quality => "quality",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrameOwnerPolicy {
+    /// Preserve the historical newest-window owner selection.
+    Newest,
+    /// Prefer the owner for which the frame is deepest inside its registered range.
+    Interior,
+}
+
+impl FrameOwnerPolicy {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "newest" => Ok(Self::Newest),
+            "interior" => Ok(Self::Interior),
+            other => Err(format!(
+                "--frame-owner-policy expects newest or interior; got {other:?}"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Newest => "newest",
+            Self::Interior => "interior",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Args {
+    rig_manifest: PathBuf,
+    nodes_tsv: PathBuf,
+    out_dir: PathBuf,
+    seam_config_arm: SeamConfigArm,
+    frame_owner_policy: FrameOwnerPolicy,
+    forest_policy: ForestPolicy,
+    metric_se3: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NodeSpec {
+    node_id: u64,
+    window_start: u64,
+    images_txt: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SensorSpec {
+    camera_id: u64,
+    sensor_from_rig: SE3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FrameImageAssignment {
+    frame_id: u64,
+    sensor_index: usize,
+    /// Deterministic global output id assigned by F-row appearance order.
+    global_image_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RigManifest {
+    sensors: BTreeMap<usize, SensorSpec>,
+    assignments: BTreeMap<String, FrameImageAssignment>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ColmapImage {
+    image_id: u64,
+    /// Assigned from the rig manifest; parser-only images use zero until
+    /// node extraction binds them to a manifest F row.
+    global_image_id: u64,
+    camera_id: u64,
+    name: String,
+    world_to_camera: Pose,
+    /// Fixed calibration used to recombine this sensor with its rig pose.
+    /// Parser-only images remain unbound until manifest extraction.
+    sensor_from_rig: Option<SE3>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FrameData {
+    pose: Pose,
+    images: Vec<ColmapImage>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct StepStats {
+    median_m: f64,
+    max_m: f64,
+    ratio: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct NodeData {
+    spec: NodeSpec,
+    images: Vec<ColmapImage>,
+    frames: BTreeMap<u64, FrameData>,
+    step: StepStats,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SeamDiagnostic {
+    source_node_id: u64,
+    target_node_id: u64,
+    start_gap: u64,
+    accepted: bool,
+    common_frames: usize,
+    retained_frames: usize,
+    reason: String,
+    wrapper_rejection_reason: Option<String>,
+    sim3_rejection_reason: Option<String>,
+    sim3_rejection_inlier_count: Option<usize>,
+    sim3_rejection_inlier_ratio: Option<f64>,
+    sim3_rejection_mean_residual_ratio: Option<f64>,
+    sim3_rejection_rotation_disagreement_deg: Option<f64>,
+    sim3_rejection_leave_one_out_log_scale_mad: Option<f64>,
+    alignment_method: Option<String>,
+    constraint_scale: Option<f64>,
+    constraint_rotation_angle_deg: Option<f64>,
+    constraint_translation_norm: Option<f64>,
+    constraint_inlier_ratio: Option<f64>,
+    constraint_mean_residual_ratio: Option<f64>,
+    constraint_leave_one_out_log_scale_mad: Option<f64>,
+    fallback_attempted: bool,
+    fallback_used: bool,
+    fallback_rejection_reason: Option<String>,
+    fallback_rejection_inlier_count: Option<usize>,
+    fallback_rejection_inlier_ratio: Option<f64>,
+    fallback_rejection_mean_residual_ratio: Option<f64>,
+    fallback_rejection_rotation_disagreement_deg: Option<f64>,
+    fallback_rejection_leave_one_out_log_scale_mad: Option<f64>,
+    selected_for_transform_graph: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SeamEdge {
+    source_index: usize,
+    target_index: usize,
+    target_from_source: Sim3,
+    common_frames: usize,
+    retained_frames: usize,
+    inlier_ratio: Option<f64>,
+    mean_residual_ratio: Option<f64>,
+    start_gap: u64,
+    method: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct AtlasComponent {
+    anchor_index: usize,
+    node_indices: Vec<usize>,
+    atlas_from_node: BTreeMap<usize, Sim3>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ComponentSummary {
+    component_index: usize,
+    anchor_node_id: u64,
+    node_ids: Vec<u64>,
+    frame_count: usize,
+    image_count: usize,
+    min_frame_id: Option<u64>,
+    max_frame_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct StitchResult {
+    seam_diagnostics: Vec<SeamDiagnostic>,
+    components: Vec<ComponentSummary>,
+    metric_se3: Vec<MetricSe3Summary>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct MetricSe3Summary {
+    component_index: usize,
+    node_count: usize,
+    edge_count: usize,
+    initial_cost: f64,
+    final_cost: f64,
+    iterations: usize,
+    converged: bool,
+}
+
+fn usage() -> ! {
+    eprintln!("{USAGE}");
+    std::process::exit(2);
+}
+
+fn parse_args<I>(args: I) -> Result<Args, String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut values = args.into_iter();
+    let _program = values.next();
+    let mut rig_manifest = None;
+    let mut nodes_tsv = None;
+    let mut out_dir = None;
+    let mut seam_config_arm = SeamConfigArm::A;
+    let mut seam_config_arm_seen = false;
+    let mut frame_owner_policy = FrameOwnerPolicy::Newest;
+    let mut frame_owner_policy_seen = false;
+    let mut forest_policy = ForestPolicy::Traversal;
+    let mut forest_policy_seen = false;
+    let mut metric_se3 = false;
+    let mut metric_se3_seen = false;
+    while let Some(flag) = values.next() {
+        if flag == "--seam-config-arm" {
+            if seam_config_arm_seen {
+                return Err(format!("duplicate argument {flag}\n{USAGE}"));
+            }
+            seam_config_arm_seen = true;
+            let value = values.next().ok_or_else(|| {
+                format!("{flag} requires A, B, C, D, E, F, G, H, I, J, K, or L\n{USAGE}")
+            })?;
+            if value.starts_with('-') {
+                return Err(format!(
+                    "{flag} requires A, B, C, D, E, F, G, H, I, J, K, or L, got {value:?}\n{USAGE}"
+                ));
+            }
+            seam_config_arm =
+                SeamConfigArm::parse(&value).map_err(|error| format!("{error}\n{USAGE}"))?;
+            continue;
+        }
+        if flag == "--frame-owner-policy" {
+            if frame_owner_policy_seen {
+                return Err(format!("duplicate argument {flag}\n{USAGE}"));
+            }
+            frame_owner_policy_seen = true;
+            let value = values
+                .next()
+                .ok_or_else(|| format!("{flag} requires newest or interior\n{USAGE}"))?;
+            if value.starts_with('-') {
+                return Err(format!(
+                    "{flag} requires newest or interior, got {value:?}\n{USAGE}"
+                ));
+            }
+            frame_owner_policy =
+                FrameOwnerPolicy::parse(&value).map_err(|error| format!("{error}\n{USAGE}"))?;
+            continue;
+        }
+        if flag == "--forest-policy" {
+            if forest_policy_seen {
+                return Err(format!("duplicate argument {flag}\n{USAGE}"));
+            }
+            forest_policy_seen = true;
+            let value = values
+                .next()
+                .ok_or_else(|| format!("{flag} requires traversal or quality\n{USAGE}"))?;
+            if value.starts_with('-') {
+                return Err(format!(
+                    "{flag} requires traversal or quality, got {value:?}\n{USAGE}"
+                ));
+            }
+            forest_policy =
+                ForestPolicy::parse(&value).map_err(|error| format!("{error}\n{USAGE}"))?;
+            continue;
+        }
+        if flag == "--metric-se3" {
+            if metric_se3_seen {
+                return Err(format!("duplicate argument {flag}\n{USAGE}"));
+            }
+            metric_se3_seen = true;
+            metric_se3 = true;
+            continue;
+        }
+        let slot = match flag.as_str() {
+            "--rig-manifest" => &mut rig_manifest,
+            "--nodes-tsv" => &mut nodes_tsv,
+            "--out-dir" => &mut out_dir,
+            "-h" | "--help" => return Err(USAGE.to_owned()),
+            other => return Err(format!("unknown argument {other:?}\n{USAGE}")),
+        };
+        if slot.is_some() {
+            return Err(format!("duplicate argument {flag}\n{USAGE}"));
+        }
+        let value = values
+            .next()
+            .ok_or_else(|| format!("{flag} requires PATH\n{USAGE}"))?;
+        if value.starts_with('-') {
+            return Err(format!("{flag} requires PATH, got {value:?}\n{USAGE}"));
+        }
+        *slot = Some(PathBuf::from(value));
+    }
+    Ok(Args {
+        rig_manifest: rig_manifest.ok_or_else(|| format!("--rig-manifest is required\n{USAGE}"))?,
+        nodes_tsv: nodes_tsv.ok_or_else(|| format!("--nodes-tsv is required\n{USAGE}"))?,
+        out_dir: out_dir.ok_or_else(|| format!("--out-dir is required\n{USAGE}"))?,
+        seam_config_arm,
+        frame_owner_policy,
+        forest_policy,
+        metric_se3,
+    })
+}
+
+fn parse_node_specs(path: &Path) -> Result<Vec<NodeSpec>, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("read node manifest {}: {error}", path.display()))?;
+    let mut nodes = Vec::new();
+    let mut node_ids = BTreeSet::new();
+    let mut start_and_path = BTreeSet::new();
+    for (zero_line, raw) in contents.lines().enumerate() {
+        let line = zero_line + 1;
+        let text = raw.trim();
+        if text.is_empty() || text.starts_with('#') {
+            continue;
+        }
+        let fields = text.split('\t').collect::<Vec<_>>();
+        if fields.len() != 3 {
+            return Err(format!(
+                "node manifest {}:{} requires node_id<TAB>window_start<TAB>images_txt",
+                path.display(),
+                line
+            ));
+        }
+        let node_id = fields[0].parse::<u64>().map_err(|error| {
+            format!(
+                "node manifest {}:{} has invalid node id {:?}: {error}",
+                path.display(),
+                line,
+                fields[0]
+            )
+        })?;
+        let window_start = fields[1].parse::<u64>().map_err(|error| {
+            format!(
+                "node manifest {}:{} has invalid window start {:?}: {error}",
+                path.display(),
+                line,
+                fields[1]
+            )
+        })?;
+        if fields[2].is_empty() {
+            return Err(format!(
+                "node manifest {}:{} has an empty images.txt path",
+                path.display(),
+                line
+            ));
+        }
+        let images_txt = PathBuf::from(fields[2]);
+        if !node_ids.insert(node_id) {
+            return Err(format!(
+                "node manifest {}:{} duplicates node id {node_id}",
+                path.display(),
+                line
+            ));
+        }
+        if !start_and_path.insert((window_start, images_txt.clone())) {
+            return Err(format!(
+                "node manifest {}:{} duplicates window_start/images_txt ({window_start}, {})",
+                path.display(),
+                line,
+                images_txt.display()
+            ));
+        }
+        if !images_txt.is_file() {
+            return Err(format!(
+                "node manifest {}:{} images.txt does not exist: {}",
+                path.display(),
+                line,
+                images_txt.display()
+            ));
+        }
+        nodes.push(NodeSpec {
+            node_id,
+            window_start,
+            images_txt,
+        });
+    }
+    if nodes.is_empty() {
+        return Err(format!(
+            "node manifest {} contains no nodes",
+            path.display()
+        ));
+    }
+    nodes.sort_by_key(|node| (node.window_start, node.node_id));
+    Ok(nodes)
+}
+
+fn parse_rig_manifest(path: &Path) -> Result<RigManifest, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("read rig manifest {}: {error}", path.display()))?;
+    let mut sensors = BTreeMap::new();
+    let mut frame_rows = Vec::new();
+    for (zero_line, raw) in contents.lines().enumerate() {
+        let line = zero_line + 1;
+        let text = raw.trim();
+        if text.is_empty() || text.starts_with('#') {
+            continue;
+        }
+        let fields = text.split_whitespace().collect::<Vec<_>>();
+        match fields.first().copied() {
+            Some("S") => {
+                if fields.len() != 16 {
+                    return Err(format!(
+                        "rig manifest {}:{} sensor row requires 16 fields",
+                        path.display(),
+                        line
+                    ));
+                }
+                let index = parse_usize_field(&fields, 1, path, line, "sensor index")?;
+                let camera_id = parse_u64_field(&fields, 2, path, line, "camera id")?;
+                let width = parse_usize_field(&fields, 3, path, line, "width")?;
+                let height = parse_usize_field(&fields, 4, path, line, "height")?;
+                if width == 0 || height == 0 {
+                    return Err(format!(
+                        "rig manifest {}:{} sensor dimensions must be positive",
+                        path.display(),
+                        line
+                    ));
+                }
+                for field in 5..16 {
+                    let value = parse_f64_field(&fields, field, path, line, "sensor value")?;
+                    if !value.is_finite() {
+                        return Err(format!(
+                            "rig manifest {}:{} sensor value is non-finite",
+                            path.display(),
+                            line
+                        ));
+                    }
+                }
+                let quaternion = Quaternion::new(
+                    parse_f64_field(&fields, 9, path, line, "quaternion")?,
+                    parse_f64_field(&fields, 10, path, line, "quaternion")?,
+                    parse_f64_field(&fields, 11, path, line, "quaternion")?,
+                    parse_f64_field(&fields, 12, path, line, "quaternion")?,
+                );
+                let norm = quaternion.norm();
+                if !norm.is_finite() || norm <= 1.0e-12 {
+                    return Err(format!(
+                        "rig manifest {}:{} sensor quaternion is zero or non-finite",
+                        path.display(),
+                        line
+                    ));
+                }
+                let sensor_from_rig = SE3::new(
+                    UnitQuaternion::new_normalize(quaternion),
+                    Vector3::new(
+                        parse_f64_field(&fields, 13, path, line, "translation")?,
+                        parse_f64_field(&fields, 14, path, line, "translation")?,
+                        parse_f64_field(&fields, 15, path, line, "translation")?,
+                    ),
+                );
+                if sensors
+                    .insert(
+                        index,
+                        SensorSpec {
+                            camera_id,
+                            sensor_from_rig,
+                        },
+                    )
+                    .is_some()
+                {
+                    return Err(format!(
+                        "rig manifest {}:{} duplicates sensor index {index}",
+                        path.display(),
+                        line
+                    ));
+                }
+            }
+            Some("F") => {
+                if fields.len() != 4 {
+                    return Err(format!(
+                        "rig manifest {}:{} frame row requires 4 fields",
+                        path.display(),
+                        line
+                    ));
+                }
+                let frame_id = parse_u64_field(&fields, 1, path, line, "frame id")?;
+                if fields[2].is_empty() {
+                    return Err(format!(
+                        "rig manifest {}:{} image name is empty",
+                        path.display(),
+                        line
+                    ));
+                }
+                let sensor_index = parse_usize_field(&fields, 3, path, line, "frame sensor index")?;
+                frame_rows.push((frame_id, fields[2].to_owned(), sensor_index, line));
+            }
+            Some(kind) => {
+                return Err(format!(
+                    "rig manifest {}:{} unknown row kind {kind:?}",
+                    path.display(),
+                    line
+                ));
+            }
+            None => unreachable!("empty rows are skipped above"),
+        }
+    }
+    if sensors.is_empty() {
+        return Err(format!(
+            "rig manifest {} contains no sensors",
+            path.display()
+        ));
+    }
+    if sensors
+        .keys()
+        .copied()
+        .enumerate()
+        .any(|(expected, actual)| expected != actual)
+    {
+        return Err(format!(
+            "rig manifest {} sensor indices must be contiguous from zero",
+            path.display()
+        ));
+    }
+    let mut assignments = BTreeMap::new();
+    let mut frame_sensors = BTreeSet::new();
+    for (frame_id, name, sensor_index, line) in frame_rows {
+        if !sensors.contains_key(&sensor_index) {
+            return Err(format!(
+                "rig manifest {}:{} references unknown sensor {sensor_index}",
+                path.display(),
+                line
+            ));
+        }
+        let global_image_id = assignments.len() as u64 + 1;
+        if assignments
+            .insert(
+                name.clone(),
+                FrameImageAssignment {
+                    frame_id,
+                    sensor_index,
+                    global_image_id,
+                },
+            )
+            .is_some()
+        {
+            return Err(format!(
+                "rig manifest {}:{} duplicates image assignment {name:?}",
+                path.display(),
+                line
+            ));
+        }
+        if !frame_sensors.insert((frame_id, sensor_index)) {
+            return Err(format!(
+                "rig manifest {}:{} duplicates frame {frame_id} sensor {sensor_index}",
+                path.display(),
+                line
+            ));
+        }
+    }
+    if assignments.is_empty() {
+        return Err(format!(
+            "rig manifest {} contains no frame rows",
+            path.display()
+        ));
+    }
+    Ok(RigManifest {
+        sensors,
+        assignments,
+    })
+}
+
+fn parse_u64_field(
+    fields: &[&str],
+    index: usize,
+    path: &Path,
+    line: usize,
+    label: &str,
+) -> Result<u64, String> {
+    fields
+        .get(index)
+        .ok_or_else(|| {
+            format!(
+                "rig manifest {}:{} missing {label} field {index}",
+                path.display(),
+                line
+            )
+        })?
+        .parse::<u64>()
+        .map_err(|error| {
+            format!(
+                "rig manifest {}:{} invalid {label} {:?}: {error}",
+                path.display(),
+                line,
+                fields[index]
+            )
+        })
+}
+
+fn parse_usize_field(
+    fields: &[&str],
+    index: usize,
+    path: &Path,
+    line: usize,
+    label: &str,
+) -> Result<usize, String> {
+    fields
+        .get(index)
+        .ok_or_else(|| {
+            format!(
+                "rig manifest {}:{} missing {label} field {index}",
+                path.display(),
+                line
+            )
+        })?
+        .parse::<usize>()
+        .map_err(|error| {
+            format!(
+                "rig manifest {}:{} invalid {label} {:?}: {error}",
+                path.display(),
+                line,
+                fields[index]
+            )
+        })
+}
+
+fn parse_f64_field(
+    fields: &[&str],
+    index: usize,
+    path: &Path,
+    line: usize,
+    label: &str,
+) -> Result<f64, String> {
+    fields
+        .get(index)
+        .ok_or_else(|| {
+            format!(
+                "rig manifest {}:{} missing {label} field {index}",
+                path.display(),
+                line
+            )
+        })?
+        .parse::<f64>()
+        .map_err(|error| {
+            format!(
+                "rig manifest {}:{} invalid {label} {:?}: {error}",
+                path.display(),
+                line,
+                fields[index]
+            )
+        })
+}
+
+fn parse_colmap_images(path: &Path) -> Result<Vec<ColmapImage>, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("read COLMAP images {}: {error}", path.display()))?;
+    let lines = contents.lines().collect::<Vec<_>>();
+    let mut images = Vec::new();
+    let mut image_ids = BTreeSet::new();
+    let mut image_names = BTreeSet::new();
+    let mut index = 0;
+    while index < lines.len() {
+        let line_number = index + 1;
+        let raw = lines[index];
+        index += 1;
+        let text = raw.trim();
+        if text.is_empty() || text.starts_with('#') {
+            continue;
+        }
+        let fields = text.split_whitespace().collect::<Vec<_>>();
+        if fields.len() != 10 {
+            return Err(format!(
+                "COLMAP images {}:{} pose row requires 10 fields",
+                path.display(),
+                line_number
+            ));
+        }
+        let image_id = fields[0].parse::<u64>().map_err(|error| {
+            format!(
+                "COLMAP images {}:{} invalid image id {:?}: {error}",
+                path.display(),
+                line_number,
+                fields[0]
+            )
+        })?;
+        let values = fields[1..8]
+            .iter()
+            .map(|field| {
+                field.parse::<f64>().map_err(|error| {
+                    format!(
+                        "COLMAP images {}:{} invalid pose value {:?}: {error}",
+                        path.display(),
+                        line_number,
+                        field
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if values.iter().any(|value| !value.is_finite()) {
+            return Err(format!(
+                "COLMAP images {}:{} pose contains a non-finite value",
+                path.display(),
+                line_number
+            ));
+        }
+        let camera_id = fields[8].parse::<u64>().map_err(|error| {
+            format!(
+                "COLMAP images {}:{} invalid camera id {:?}: {error}",
+                path.display(),
+                line_number,
+                fields[8]
+            )
+        })?;
+        let name = fields[9].to_owned();
+        if name.is_empty() {
+            return Err(format!(
+                "COLMAP images {}:{} image name is empty",
+                path.display(),
+                line_number
+            ));
+        }
+        if !image_ids.insert(image_id) {
+            return Err(format!(
+                "COLMAP images {}:{} duplicates image id {image_id}",
+                path.display(),
+                line_number
+            ));
+        }
+        if !image_names.insert(name.clone()) {
+            return Err(format!(
+                "COLMAP images {}:{} duplicates image name {name:?}",
+                path.display(),
+                line_number
+            ));
+        }
+        let quaternion = Quaternion::new(values[0], values[1], values[2], values[3]);
+        let norm = quaternion.norm();
+        if !norm.is_finite() || norm <= 1.0e-12 {
+            return Err(format!(
+                "COLMAP images {}:{} quaternion is zero or non-finite",
+                path.display(),
+                line_number
+            ));
+        }
+        let pose = Pose::from_world_to_camera(
+            UnitQuaternion::new_normalize(quaternion),
+            Vector3::new(values[4], values[5], values[6]),
+        );
+        if index >= lines.len() {
+            return Err(format!(
+                "COLMAP images {}:{} is missing its POINTS2D row",
+                path.display(),
+                line_number
+            ));
+        }
+        let points_line_number = index + 1;
+        let points = lines[index].trim();
+        index += 1;
+        validate_points2d_line(points, path, points_line_number)?;
+        images.push(ColmapImage {
+            image_id,
+            global_image_id: 0,
+            camera_id,
+            name,
+            world_to_camera: pose,
+            sensor_from_rig: None,
+        });
+    }
+    if images.is_empty() {
+        return Err(format!(
+            "COLMAP images {} contains no poses",
+            path.display()
+        ));
+    }
+    Ok(images)
+}
+
+fn validate_points2d_line(points: &str, path: &Path, line: usize) -> Result<(), String> {
+    if points.is_empty() {
+        return Ok(());
+    }
+    let fields = points.split_whitespace().collect::<Vec<_>>();
+    if fields.len() % 3 != 0 {
+        return Err(format!(
+            "COLMAP images {}:{} POINTS2D row must contain triples",
+            path.display(),
+            line
+        ));
+    }
+    for triple in fields.chunks_exact(3) {
+        triple[0].parse::<f64>().map_err(|error| {
+            format!(
+                "COLMAP images {}:{} invalid POINTS2D x {:?}: {error}",
+                path.display(),
+                line,
+                triple[0]
+            )
+        })?;
+        triple[1].parse::<f64>().map_err(|error| {
+            format!(
+                "COLMAP images {}:{} invalid POINTS2D y {:?}: {error}",
+                path.display(),
+                line,
+                triple[1]
+            )
+        })?;
+        triple[2].parse::<i64>().map_err(|error| {
+            format!(
+                "COLMAP images {}:{} invalid POINTS2D id {:?}: {error}",
+                path.display(),
+                line,
+                triple[2]
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn extract_node_data(spec: NodeSpec, manifest: &RigManifest) -> Result<NodeData, String> {
+    let images = parse_colmap_images(&spec.images_txt)?;
+    let mut frames = BTreeMap::<u64, FrameData>::new();
+    let mut bound_images = Vec::with_capacity(images.len());
+    for image in &images {
+        let assignment = manifest.assignments.get(&image.name).ok_or_else(|| {
+            format!(
+                "node {} image {:?} is absent from rig manifest",
+                spec.node_id, image.name
+            )
+        })?;
+        let sensor = manifest
+            .sensors
+            .get(&assignment.sensor_index)
+            .expect("manifest assignments are validated against sensors");
+        if image.camera_id != sensor.camera_id {
+            return Err(format!(
+                "node {} image {:?} camera {} disagrees with manifest sensor {} camera {}",
+                spec.node_id,
+                image.name,
+                image.camera_id,
+                assignment.sensor_index,
+                sensor.camera_id
+            ));
+        }
+        let mut bound_image = image.clone();
+        bound_image.global_image_id = assignment.global_image_id;
+        bound_image.sensor_from_rig = Some(sensor.sensor_from_rig.clone());
+        let rig_pose = Pose {
+            world_to_camera: sensor
+                .sensor_from_rig
+                .inverse()
+                .compose(&image.world_to_camera.world_to_camera),
+        };
+        validate_pose(
+            &rig_pose,
+            &format!("node {} frame {}", spec.node_id, assignment.frame_id),
+        )?;
+        let frame = frames
+            .entry(assignment.frame_id)
+            .or_insert_with(|| FrameData {
+                pose: rig_pose.clone(),
+                images: Vec::new(),
+            });
+        if frame
+            .images
+            .iter()
+            .any(|row| row.name == bound_image.name || row.camera_id == bound_image.camera_id)
+        {
+            return Err(format!(
+                "node {} contains duplicate image/frame assignment for frame {}",
+                spec.node_id, assignment.frame_id
+            ));
+        }
+        let centre_error =
+            (frame.pose.camera_center_world() - rig_pose.camera_center_world()).norm();
+        let rotation_error = frame
+            .pose
+            .world_to_camera
+            .rotation
+            .rotation_to(&rig_pose.world_to_camera.rotation)
+            .angle()
+            .to_degrees();
+        if !centre_error.is_finite()
+            || !rotation_error.is_finite()
+            || centre_error > MAX_RIG_CENTER_DISAGREEMENT_M
+            || rotation_error > MAX_RIG_ROTATION_DISAGREEMENT_DEG
+        {
+            return Err(format!(
+                "node {} frame {} sensor poses disagree: centre={centre_error:.9}m rotation={rotation_error:.9}deg",
+                spec.node_id, assignment.frame_id
+            ));
+        }
+        frame.images.push(bound_image.clone());
+        bound_images.push(bound_image);
+    }
+    for frame in frames.values_mut() {
+        frame
+            .images
+            .sort_by_key(|image| (image.camera_id, image.image_id));
+    }
+    let step = compute_step_stats(&frames);
+    Ok(NodeData {
+        spec,
+        images: bound_images,
+        frames,
+        step,
+    })
+}
+
+fn validate_pose(pose: &Pose, context: &str) -> Result<(), String> {
+    if !pose
+        .world_to_camera
+        .rotation
+        .coords
+        .iter()
+        .all(|value| value.is_finite())
+        || !pose
+            .world_to_camera
+            .translation
+            .iter()
+            .all(|value| value.is_finite())
+    {
+        return Err(format!("{context} pose contains a non-finite value"));
+    }
+    let centre = pose.camera_center_world();
+    if !centre.coords.iter().all(|value| value.is_finite()) {
+        return Err(format!(
+            "{context} camera centre contains a non-finite value"
+        ));
+    }
+    Ok(())
+}
+
+fn compute_step_stats(frames: &BTreeMap<u64, FrameData>) -> StepStats {
+    let centres = frames
+        .values()
+        .map(|frame| frame.pose.camera_center_world())
+        .collect::<Vec<_>>();
+    let mut steps = centres
+        .windows(2)
+        .map(|pair| (pair[1] - pair[0]).norm())
+        .collect::<Vec<_>>();
+    steps.retain(|step| step.is_finite());
+    steps.sort_by(f64::total_cmp);
+    let median_m = median(&steps).unwrap_or(0.0);
+    let max_m = steps.last().copied().unwrap_or(0.0);
+    let ratio = if median_m > 0.0 {
+        max_m / median_m
+    } else if max_m == 0.0 {
+        0.0
+    } else {
+        f64::INFINITY
+    };
+    StepStats {
+        median_m,
+        max_m,
+        ratio,
+    }
+}
+
+fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let middle = values.len() / 2;
+    Some(if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) / 2.0
+    } else {
+        values[middle]
+    })
+}
+
+#[cfg(test)]
+fn seam_alignment_config() -> RigSubmapAlignmentConfig {
+    seam_alignment_config_for_arm(SeamConfigArm::A)
+}
+
+fn seam_alignment_config_for_arm(arm: SeamConfigArm) -> RigSubmapAlignmentConfig {
+    let mut alignment = SubmapSim3AlignmentConfig {
+        min_correspondences: 8,
+        min_inliers: 8,
+        ..SubmapSim3AlignmentConfig::default()
+    };
+    match arm {
+        SeamConfigArm::A => {}
+        SeamConfigArm::B => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+        }
+        SeamConfigArm::C => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.05;
+        }
+        SeamConfigArm::D => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.05;
+            alignment.min_inlier_ratio = 0.5;
+        }
+        // Arm E is diagnostic-only for exact shared-frame identities.  The
+        // measured gates are singular=0, residual=.10/.06, inlier=.35, and
+        // local rotation disagreement=60 degrees; arm A remains the
+        // production default.
+        SeamConfigArm::E => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.06;
+            alignment.min_inlier_ratio = 0.35;
+            alignment.max_rotation_disagreement_deg = 60.0;
+        }
+        // Arm F is exactly arm E plus the wrapper-only, fixed-consensus
+        // orientation fallback.  No residual, ratio, or rotation gate is
+        // relaxed beyond the measured diagnostic arm E.
+        SeamConfigArm::F => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.06;
+            alignment.min_inlier_ratio = 0.35;
+            alignment.max_rotation_disagreement_deg = 60.0;
+        }
+        // Arm G is exactly arm E with fixed-consensus orientation selected as
+        // the primary estimator. It intentionally has no generic fallback.
+        SeamConfigArm::G => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.06;
+            alignment.min_inlier_ratio = 0.35;
+            alignment.max_rotation_disagreement_deg = 60.0;
+        }
+        // Arm H is exactly arm G plus a diagnostic generic fallback after a
+        // fixed-primary rejection. It does not change any quality threshold.
+        // Arm I is H with uniform overlap sampling instead of earliest ids.
+        SeamConfigArm::H | SeamConfigArm::I => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.06;
+            alignment.min_inlier_ratio = 0.35;
+            alignment.max_rotation_disagreement_deg = 60.0;
+        }
+        // Arm J is H with only the fixed-rotation mean-residual diagnostic
+        // gate widened to the measured 0.07 value.  It remains diagnostic
+        // and does not alter arms A through I.
+        SeamConfigArm::J => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.07;
+            alignment.min_inlier_ratio = 0.35;
+            alignment.max_rotation_disagreement_deg = 60.0;
+        }
+        // Arm K is J with unit scale forced in the fixed-rotation estimator.
+        // Arm L is identical to K except that generic fallback is disabled.
+        SeamConfigArm::K | SeamConfigArm::L => {
+            alignment.min_second_to_first_singular_ratio = 0.0;
+            alignment.max_inlier_residual_ratio = 0.10;
+            alignment.max_mean_residual_ratio = 0.07;
+            alignment.min_inlier_ratio = 0.35;
+            alignment.max_rotation_disagreement_deg = 60.0;
+        }
+    }
+    RigSubmapAlignmentConfig {
+        max_boundary_frames: 64,
+        boundary_sampling: if arm == SeamConfigArm::I {
+            RigSubmapBoundarySampling::UniformAcrossOverlap
+        } else {
+            RigSubmapBoundarySampling::Earliest
+        },
+        rotation_consensus_deg: if matches!(
+            arm,
+            SeamConfigArm::E
+                | SeamConfigArm::F
+                | SeamConfigArm::G
+                | SeamConfigArm::H
+                | SeamConfigArm::I
+                | SeamConfigArm::J
+                | SeamConfigArm::K
+                | SeamConfigArm::L
+        ) {
+            60.0
+        } else {
+            5.0
+        },
+        min_rotation_consensus_ratio: if matches!(
+            arm,
+            SeamConfigArm::E
+                | SeamConfigArm::F
+                | SeamConfigArm::G
+                | SeamConfigArm::H
+                | SeamConfigArm::I
+                | SeamConfigArm::J
+                | SeamConfigArm::K
+                | SeamConfigArm::L
+        ) {
+            0.35
+        } else {
+            0.6
+        },
+        alignment,
+        allow_fixed_rotation_fallback: arm == SeamConfigArm::F,
+        prefer_fixed_rotation_alignment: matches!(
+            arm,
+            SeamConfigArm::G
+                | SeamConfigArm::H
+                | SeamConfigArm::I
+                | SeamConfigArm::J
+                | SeamConfigArm::K
+                | SeamConfigArm::L
+        ),
+        allow_generic_fallback_after_fixed_rotation: matches!(
+            arm,
+            SeamConfigArm::H | SeamConfigArm::I | SeamConfigArm::J | SeamConfigArm::K
+        ),
+        force_fixed_rotation_unit_scale: matches!(arm, SeamConfigArm::K | SeamConfigArm::L),
+    }
+}
+
+#[cfg(test)]
+fn build_seam_graph(nodes: &[NodeData]) -> (Vec<SeamEdge>, Vec<SeamDiagnostic>) {
+    build_seam_graph_with_config(nodes, &seam_alignment_config())
+}
+
+fn build_seam_graph_with_config(
+    nodes: &[NodeData],
+    config: &RigSubmapAlignmentConfig,
+) -> (Vec<SeamEdge>, Vec<SeamDiagnostic>) {
+    let frame_poses = nodes
+        .iter()
+        .map(|node| {
+            node.frames
+                .iter()
+                .map(|(frame_id, frame)| (*frame_id, frame.pose.clone()))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut start_groups = BTreeMap::<u64, Vec<usize>>::new();
+    for (node_index, node) in nodes.iter().enumerate() {
+        start_groups
+            .entry(node.spec.window_start)
+            .or_default()
+            .push(node_index);
+    }
+    for node_indices in start_groups.values_mut() {
+        node_indices.sort_by_key(|index| nodes[*index].spec.node_id);
+    }
+
+    let mut edges = Vec::new();
+    let mut diagnostics = Vec::new();
+    for source_index in 0..nodes.len() {
+        let source = &nodes[source_index];
+        let lower_start = source.spec.window_start.saturating_sub(MAX_SEAM_START_GAP);
+        for (target_start, target_indices) in
+            start_groups.range(lower_start..source.spec.window_start)
+        {
+            let start_gap = source.spec.window_start - *target_start;
+            for target_index in target_indices {
+                let target = &nodes[*target_index];
+                match estimate_rig_submap_sim3_constraint(
+                    source.spec.node_id,
+                    target.spec.node_id,
+                    &frame_poses[source_index],
+                    &frame_poses[*target_index],
+                    config,
+                ) {
+                    Ok(result) => {
+                        // Keep the primary rejection visible for fixed-primary
+                        // H, while retaining the generic-primary field for F
+                        // and the default path.
+                        let sim3_rejection = result
+                            .diagnostics
+                            .fixed_rotation_rejection
+                            .as_ref()
+                            .or(result.diagnostics.generic_sim3_rejection.as_ref());
+                        let constraint = &result.constraint;
+                        let target_from_source = constraint.target_from_source.clone();
+                        diagnostics.push(SeamDiagnostic {
+                            source_node_id: source.spec.node_id,
+                            target_node_id: target.spec.node_id,
+                            start_gap,
+                            accepted: true,
+                            common_frames: result.diagnostics.common_frame_count,
+                            retained_frames: result.diagnostics.retained_frame_count,
+                            reason: "accepted".to_owned(),
+                            wrapper_rejection_reason: None,
+                            sim3_rejection_reason: sim3_rejection
+                                .map(|rejection| format!("{:?}", rejection.reason)),
+                            sim3_rejection_inlier_count: sim3_rejection
+                                .map(|rejection| rejection.inlier_count),
+                            sim3_rejection_inlier_ratio: sim3_rejection
+                                .map(|rejection| rejection.inlier_ratio),
+                            sim3_rejection_mean_residual_ratio: sim3_rejection
+                                .and_then(|rejection| rejection.mean_residual_ratio),
+                            sim3_rejection_rotation_disagreement_deg: sim3_rejection
+                                .and_then(|rejection| rejection.rotation_disagreement_deg),
+                            sim3_rejection_leave_one_out_log_scale_mad: sim3_rejection
+                                .and_then(|rejection| rejection.leave_one_out_log_scale_mad),
+                            alignment_method: result
+                                .diagnostics
+                                .alignment_method
+                                .map(|method| method.as_str().to_owned()),
+                            constraint_scale: Some(constraint.target_from_source.scale),
+                            constraint_rotation_angle_deg: Some(
+                                constraint.target_from_source.rotation.angle().to_degrees(),
+                            ),
+                            constraint_translation_norm: Some(
+                                constraint.target_from_source.translation.norm(),
+                            ),
+                            constraint_inlier_ratio: Some(constraint.inlier_ratio),
+                            constraint_mean_residual_ratio: Some(constraint.mean_residual_ratio),
+                            constraint_leave_one_out_log_scale_mad: Some(
+                                constraint.leave_one_out_log_scale_mad,
+                            ),
+                            fallback_attempted: result.diagnostics.fallback_attempted,
+                            fallback_used: result.diagnostics.fallback_used,
+                            fallback_rejection_reason: None,
+                            fallback_rejection_inlier_count: None,
+                            fallback_rejection_inlier_ratio: None,
+                            fallback_rejection_mean_residual_ratio: None,
+                            fallback_rejection_rotation_disagreement_deg: None,
+                            fallback_rejection_leave_one_out_log_scale_mad: None,
+                            selected_for_transform_graph: false,
+                        });
+                        edges.push(SeamEdge {
+                            source_index,
+                            target_index: *target_index,
+                            target_from_source,
+                            common_frames: result.diagnostics.common_frame_count,
+                            retained_frames: result.diagnostics.retained_frame_count,
+                            inlier_ratio: Some(constraint.inlier_ratio),
+                            mean_residual_ratio: Some(constraint.mean_residual_ratio),
+                            start_gap,
+                            method: result
+                                .diagnostics
+                                .alignment_method
+                                .map(|method| method.as_str().to_owned()),
+                        });
+                    }
+                    Err(rejection) => {
+                        let sim3_rejection = rejection.sim3_rejection.as_ref();
+                        let fallback_rejection = rejection.fallback_rejection.as_ref();
+                        diagnostics.push(SeamDiagnostic {
+                            source_node_id: source.spec.node_id,
+                            target_node_id: target.spec.node_id,
+                            start_gap,
+                            accepted: false,
+                            common_frames: rejection.diagnostics.common_frame_count,
+                            retained_frames: rejection.diagnostics.retained_frame_count,
+                            reason: format!("{:?}", rejection.reason),
+                            wrapper_rejection_reason: Some(format!("{:?}", rejection.reason)),
+                            sim3_rejection_reason: sim3_rejection
+                                .map(|rejection| format!("{:?}", rejection.reason)),
+                            sim3_rejection_inlier_count: sim3_rejection
+                                .map(|rejection| rejection.inlier_count),
+                            sim3_rejection_inlier_ratio: sim3_rejection
+                                .map(|rejection| rejection.inlier_ratio),
+                            sim3_rejection_mean_residual_ratio: sim3_rejection
+                                .and_then(|rejection| rejection.mean_residual_ratio),
+                            sim3_rejection_rotation_disagreement_deg: sim3_rejection
+                                .and_then(|rejection| rejection.rotation_disagreement_deg),
+                            sim3_rejection_leave_one_out_log_scale_mad: sim3_rejection
+                                .and_then(|rejection| rejection.leave_one_out_log_scale_mad),
+                            alignment_method: rejection
+                                .diagnostics
+                                .alignment_method
+                                .map(|method| method.as_str().to_owned()),
+                            constraint_scale: None,
+                            constraint_rotation_angle_deg: None,
+                            constraint_translation_norm: None,
+                            constraint_inlier_ratio: None,
+                            constraint_mean_residual_ratio: None,
+                            constraint_leave_one_out_log_scale_mad: None,
+                            fallback_attempted: rejection.diagnostics.fallback_attempted,
+                            fallback_used: rejection.diagnostics.fallback_used,
+                            fallback_rejection_reason: fallback_rejection
+                                .map(|rejection| format!("{:?}", rejection.reason)),
+                            fallback_rejection_inlier_count: fallback_rejection
+                                .map(|rejection| rejection.inlier_count),
+                            fallback_rejection_inlier_ratio: fallback_rejection
+                                .map(|rejection| rejection.inlier_ratio),
+                            fallback_rejection_mean_residual_ratio: fallback_rejection
+                                .and_then(|rejection| rejection.mean_residual_ratio),
+                            fallback_rejection_rotation_disagreement_deg: fallback_rejection
+                                .and_then(|rejection| rejection.rotation_disagreement_deg),
+                            fallback_rejection_leave_one_out_log_scale_mad: fallback_rejection
+                                .and_then(|rejection| rejection.leave_one_out_log_scale_mad),
+                            selected_for_transform_graph: false,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    diagnostics.sort_by_key(|diagnostic| {
+        (
+            diagnostic.source_node_id,
+            diagnostic.target_node_id,
+            diagnostic.start_gap,
+        )
+    });
+    edges.sort_by_key(|edge| {
+        (
+            nodes[edge.source_index].spec.node_id,
+            nodes[edge.target_index].spec.node_id,
+        )
+    });
+    // The candidate graph is already bounded by the predecessor start-group
+    // scan above. Keep every accepted candidate here; the caller chooses the
+    // traversal or quality transform graph explicitly.
+    (edges, diagnostics)
+}
+
+/// Select a deterministic spanning forest from accepted seam candidates.
+/// Higher-support seams are preferred before residual quality, inlier support,
+/// temporal gap, and node-id tie breakers. The input candidate list may be in
+/// any order; all ordering that affects the result is explicit here.
+fn select_quality_forest(nodes: &[NodeData], edges: &[SeamEdge]) -> Vec<SeamEdge> {
+    let mut ordered = edges.to_vec();
+    ordered.sort_by(|left, right| compare_edge_quality(nodes, left, right));
+    let mut union_find = UnionFind::new(nodes.len());
+    let mut forest = Vec::with_capacity(nodes.len().saturating_sub(1));
+    for edge in ordered {
+        debug_assert!(edge.method.is_some());
+        if union_find.union(edge.source_index, edge.target_index) {
+            forest.push(edge);
+        }
+    }
+    forest
+}
+
+fn compare_edge_quality(nodes: &[NodeData], left: &SeamEdge, right: &SeamEdge) -> Ordering {
+    right
+        .common_frames
+        .cmp(&left.common_frames)
+        .then_with(|| right.retained_frames.cmp(&left.retained_frames))
+        .then_with(|| {
+            compare_optional_f64_ascending(left.mean_residual_ratio, right.mean_residual_ratio)
+        })
+        .then_with(|| compare_optional_f64_descending(left.inlier_ratio, right.inlier_ratio))
+        .then_with(|| left.start_gap.cmp(&right.start_gap))
+        .then_with(|| {
+            nodes[left.source_index]
+                .spec
+                .node_id
+                .cmp(&nodes[right.source_index].spec.node_id)
+        })
+        .then_with(|| {
+            nodes[left.target_index]
+                .spec
+                .node_id
+                .cmp(&nodes[right.target_index].spec.node_id)
+        })
+}
+
+fn compare_optional_f64_ascending(left: Option<f64>, right: Option<f64>) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => left.total_cmp(&right),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn compare_optional_f64_descending(left: Option<f64>, right: Option<f64>) -> Ordering {
+    compare_optional_f64_ascending(right, left)
+}
+
+struct UnionFind {
+    parent: Vec<usize>,
+    rank: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(size: usize) -> Self {
+        Self {
+            parent: (0..size).collect(),
+            rank: vec![0; size],
+        }
+    }
+
+    fn find(&mut self, node: usize) -> usize {
+        if self.parent[node] != node {
+            let root = self.find(self.parent[node]);
+            self.parent[node] = root;
+        }
+        self.parent[node]
+    }
+
+    fn union(&mut self, left: usize, right: usize) -> bool {
+        let mut left_root = self.find(left);
+        let mut right_root = self.find(right);
+        if left_root == right_root {
+            return false;
+        }
+        if self.rank[left_root] < self.rank[right_root]
+            || (self.rank[left_root] == self.rank[right_root] && left_root > right_root)
+        {
+            std::mem::swap(&mut left_root, &mut right_root);
+        }
+        self.parent[right_root] = left_root;
+        if self.rank[left_root] == self.rank[right_root] {
+            self.rank[left_root] += 1;
+        }
+        true
+    }
+}
+
+fn connected_components(node_count: usize, edges: &[SeamEdge]) -> Vec<AtlasComponent> {
+    let mut adjacency = vec![Vec::<(usize, Sim3)>::new(); node_count];
+    for edge in edges {
+        adjacency[edge.source_index].push((edge.target_index, edge.target_from_source.inverse()));
+        adjacency[edge.target_index].push((edge.source_index, edge.target_from_source.clone()));
+    }
+    for neighbours in &mut adjacency {
+        neighbours.sort_by_key(|(node_index, _)| *node_index);
+    }
+
+    let mut remaining = (0..node_count).collect::<BTreeSet<_>>();
+    let mut components = Vec::new();
+    while let Some(anchor) = remaining.iter().next().copied() {
+        remaining.remove(&anchor);
+        let mut atlas_from_node = BTreeMap::new();
+        atlas_from_node.insert(anchor, Sim3::identity());
+        let mut queue = VecDeque::from([anchor]);
+        while let Some(current) = queue.pop_front() {
+            let atlas_from_current = atlas_from_node
+                .get(&current)
+                .expect("BFS queue contains an assigned node")
+                .clone();
+            for (neighbour, neighbour_from_current) in &adjacency[current] {
+                if atlas_from_node.contains_key(neighbour) {
+                    continue;
+                }
+                let atlas_from_neighbour = atlas_from_current.compose(neighbour_from_current);
+                atlas_from_node.insert(*neighbour, atlas_from_neighbour);
+                remaining.remove(neighbour);
+                queue.push_back(*neighbour);
+            }
+        }
+        let node_indices = atlas_from_node.keys().copied().collect::<Vec<_>>();
+        components.push(AtlasComponent {
+            anchor_index: anchor,
+            node_indices,
+            atlas_from_node,
+        });
+    }
+    components
+}
+
+fn healthy_node(node: &NodeData) -> bool {
+    node.step.ratio.is_finite() && node.step.ratio <= HEALTHY_STEP_RATIO
+}
+
+fn select_frame_owners(
+    nodes: &[NodeData],
+    component: &AtlasComponent,
+    policy: FrameOwnerPolicy,
+) -> BTreeMap<u64, usize> {
+    match policy {
+        FrameOwnerPolicy::Newest => {
+            let mut owners = BTreeMap::<u64, usize>::new();
+            for node_index in &component.node_indices {
+                let node = &nodes[*node_index];
+                if !healthy_node(node) {
+                    continue;
+                }
+                for frame_id in node.frames.keys().copied() {
+                    let replace = match owners.get(&frame_id) {
+                        Some(previous_index) => {
+                            prefers_newer_owner(nodes, *node_index, *previous_index)
+                        }
+                        None => true,
+                    };
+                    if replace {
+                        owners.insert(frame_id, *node_index);
+                    }
+                }
+            }
+            owners
+        }
+        FrameOwnerPolicy::Interior => {
+            let mut scored_owners = BTreeMap::<u64, (usize, u64)>::new();
+            for node_index in &component.node_indices {
+                let node = &nodes[*node_index];
+                if !healthy_node(node) {
+                    continue;
+                }
+                let (Some(&min_frame), Some(&max_frame)) =
+                    (node.frames.keys().next(), node.frames.keys().next_back())
+                else {
+                    continue;
+                };
+                for frame_id in node.frames.keys().copied() {
+                    let interior_depth = (frame_id - min_frame).min(max_frame - frame_id);
+                    let replace = match scored_owners.get(&frame_id) {
+                        Some((previous_index, previous_depth)) => {
+                            interior_depth > *previous_depth
+                                || (interior_depth == *previous_depth
+                                    && prefers_newer_owner(nodes, *node_index, *previous_index))
+                        }
+                        None => true,
+                    };
+                    if replace {
+                        scored_owners.insert(frame_id, (*node_index, interior_depth));
+                    }
+                }
+            }
+            scored_owners
+                .into_iter()
+                .map(|(frame_id, (node_index, _))| (frame_id, node_index))
+                .collect()
+        }
+    }
+}
+
+fn prefers_newer_owner(nodes: &[NodeData], candidate_index: usize, previous_index: usize) -> bool {
+    let candidate = &nodes[candidate_index];
+    let previous = &nodes[previous_index];
+    (candidate.spec.window_start, candidate.spec.node_id)
+        > (previous.spec.window_start, previous.spec.node_id)
+}
+
+const UNIT_SCALE_TOLERANCE: f64 = 1.0e-12;
+
+fn unit_scale_se3(transform: &Sim3, context: &str) -> Result<SE3, String> {
+    if !transform.scale.is_finite() || (transform.scale - 1.0).abs() > UNIT_SCALE_TOLERANCE {
+        return Err(format!(
+            "{context} has non-unit scale {:.17}",
+            transform.scale
+        ));
+    }
+    let rotation_norm = transform.rotation.coords.norm();
+    if !transform.translation.iter().all(|value| value.is_finite())
+        || !transform
+            .rotation
+            .coords
+            .iter()
+            .all(|value| value.is_finite())
+        || !rotation_norm.is_finite()
+        || (rotation_norm - 1.0).abs() > UNIT_SCALE_TOLERANCE
+    {
+        return Err(format!(
+            "{context} contains an invalid rotation or non-finite transform"
+        ));
+    }
+    Ok(SE3::new(transform.rotation, transform.translation))
+}
+
+fn se3_is_finite(transform: &SE3) -> bool {
+    transform.translation.iter().all(|value| value.is_finite())
+        && transform
+            .rotation
+            .coords
+            .iter()
+            .all(|value| value.is_finite())
+}
+
+// Reconcile an already-built unit-scale atlas with all accepted L seams.
+//
+// The initial poses are node_from_atlas = atlas_from_node.inverse(), matching
+// PoseGraph's world-to-camera convention. Each accepted edge stores
+// target_from_source, so it is inserted as from=source, to=target without
+// inversion. This is deliberately opt-in: the historical traversal atlas
+// remains byte-identical when --metric-se3 is absent.
+//
+// The graph is solved one connected component at a time. Candidate edges are
+// already bounded by the predecessor scan; sparse factorization can still
+// incur graph-dependent fill-in, so this function makes no linear-memory claim.
+fn optimize_metric_se3_components(
+    nodes: &[NodeData],
+    accepted_edges: &[SeamEdge],
+    components: &mut [AtlasComponent],
+) -> Result<Vec<MetricSe3Summary>, String> {
+    let config = PoseGraphSe3Config {
+        robust_kernel: RobustKernel::None,
+        initial_lambda: Some(1.0e-3),
+        linear_solver: LinearSolver::Sparse,
+        chordal_init: false,
+        ..PoseGraphSe3Config::default()
+    };
+    let mut summaries = Vec::with_capacity(components.len());
+
+    for (component_index, component) in components.iter_mut().enumerate() {
+        let component_nodes = component
+            .node_indices
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let anchor_node_id = nodes[component.anchor_index].spec.node_id;
+        let mut graph = PoseGraph::new();
+        let mut initial_poses = BTreeMap::<u64, SE3>::new();
+        for node_index in &component.node_indices {
+            let node_id = nodes[*node_index].spec.node_id;
+            let atlas_from_node = component
+                .atlas_from_node
+                .get(node_index)
+                .ok_or_else(|| format!("component {component_index} is missing node transform"))?;
+            let atlas_from_node = unit_scale_se3(
+                atlas_from_node,
+                &format!("component {component_index} node {node_id} atlas transform"),
+            )?;
+            let node_from_atlas = atlas_from_node.inverse();
+            if !se3_is_finite(&node_from_atlas) {
+                return Err(format!(
+                    "component {component_index} node {node_id} initial pose is non-finite"
+                ));
+            }
+            graph.add_pose(
+                node_id,
+                Pose {
+                    world_to_camera: node_from_atlas.clone(),
+                },
+            );
+            initial_poses.insert(node_id, node_from_atlas);
+        }
+        graph.anchor(anchor_node_id);
+
+        let mut edge_count = 0;
+        for edge in accepted_edges.iter().filter(|edge| {
+            component_nodes.contains(&edge.source_index)
+                && component_nodes.contains(&edge.target_index)
+        }) {
+            let source_id = nodes[edge.source_index].spec.node_id;
+            let target_id = nodes[edge.target_index].spec.node_id;
+            let measurement = unit_scale_se3(
+                &edge.target_from_source,
+                &format!("component {component_index} seam {target_id}<-{source_id}"),
+            )?;
+            graph.edges.push(PoseGraphEdge {
+                from: source_id,
+                to: target_id,
+                measurement,
+                kind: PoseGraphEdgeKind::LoopClosure,
+                weight: 1.0,
+                information: None,
+            });
+            edge_count += 1;
+        }
+
+        if edge_count == 0 {
+            summaries.push(MetricSe3Summary {
+                component_index,
+                node_count: component.node_indices.len(),
+                edge_count,
+                initial_cost: 0.0,
+                final_cost: 0.0,
+                iterations: 0,
+                converged: true,
+            });
+            continue;
+        }
+
+        let initial_cost = graph.se3_cost();
+        if !initial_cost.is_finite() {
+            return Err(format!(
+                "component {component_index} metric SE3 initial cost is non-finite"
+            ));
+        }
+        let result = graph
+            .optimize_se3_iterative(&config)
+            .map_err(|error| format!("component {component_index} metric SE3 failed: {error}"))?;
+        if !result.initial_cost.is_finite() || !result.final_cost.is_finite() {
+            return Err(format!(
+                "component {component_index} metric SE3 returned a non-finite cost"
+            ));
+        }
+        let tolerance = 1.0e-10 * result.initial_cost.abs().max(1.0);
+        if result.final_cost > result.initial_cost + tolerance {
+            return Err(format!(
+                "component {component_index} metric SE3 increased cost {:.17} -> {:.17}",
+                result.initial_cost, result.final_cost
+            ));
+        }
+        let mut previous_accepted_cost = result.initial_cost;
+        for iteration in &result.iterations {
+            if !iteration.cost_before.is_finite()
+                || !iteration.cost_after.is_finite()
+                || !iteration.max_step_norm.is_finite()
+            {
+                return Err(format!(
+                    "component {component_index} metric SE3 iteration {} is non-finite",
+                    iteration.iteration
+                ));
+            }
+            if iteration.step_accepted {
+                let tolerance = 1.0e-10 * iteration.cost_before.abs().max(1.0);
+                if iteration.cost_after > iteration.cost_before + tolerance
+                    || iteration.cost_after > previous_accepted_cost + tolerance
+                {
+                    return Err(format!(
+                        "component {component_index} metric SE3 accepted a non-monotone step {}",
+                        iteration.iteration
+                    ));
+                }
+                previous_accepted_cost = iteration.cost_after;
+            }
+        }
+        let final_cost = graph.se3_cost();
+        if !final_cost.is_finite() || final_cost > initial_cost + tolerance {
+            return Err(format!(
+                "component {component_index} metric SE3 final graph cost is invalid: {final_cost:.17}"
+            ));
+        }
+
+        let anchor_pose = graph
+            .poses
+            .get(&anchor_node_id)
+            .ok_or_else(|| format!("component {component_index} lost its anchor pose"))?;
+        let initial_anchor = initial_poses
+            .get(&anchor_node_id)
+            .expect("anchor was inserted with every component pose");
+        if (anchor_pose.world_to_camera.translation - initial_anchor.translation).norm() > 1.0e-10
+            || anchor_pose
+                .world_to_camera
+                .rotation
+                .rotation_to(&initial_anchor.rotation)
+                .angle()
+                > 1.0e-10
+        {
+            return Err(format!(
+                "component {component_index} metric SE3 moved its anchor"
+            ));
+        }
+
+        for node_index in &component.node_indices {
+            let node_id = nodes[*node_index].spec.node_id;
+            let node_from_atlas = graph
+                .poses
+                .get(&node_id)
+                .ok_or_else(|| format!("component {component_index} lost node {node_id}"))?
+                .world_to_camera
+                .clone();
+            if !se3_is_finite(&node_from_atlas) {
+                return Err(format!(
+                    "component {component_index} optimized node {node_id} pose is non-finite"
+                ));
+            }
+            let atlas_from_node = node_from_atlas.inverse();
+            if !se3_is_finite(&atlas_from_node) {
+                return Err(format!(
+                    "component {component_index} optimized node {node_id} atlas pose is non-finite"
+                ));
+            }
+            component.atlas_from_node.insert(
+                *node_index,
+                Sim3::new(atlas_from_node.rotation, atlas_from_node.translation, 1.0),
+            );
+        }
+        summaries.push(MetricSe3Summary {
+            component_index,
+            node_count: component.node_indices.len(),
+            edge_count,
+            initial_cost: result.initial_cost,
+            final_cost,
+            iterations: result.iterations.len(),
+            converged: result.converged,
+        });
+    }
+    Ok(summaries)
+}
+
+fn transform_pose_to_atlas(atlas_from_node: &Sim3, pose: &Pose) -> Result<Pose, String> {
+    if !atlas_from_node.scale.is_finite() || atlas_from_node.scale <= 0.0 {
+        return Err("atlas Sim3 has a non-positive or non-finite scale".to_owned());
+    }
+    if !atlas_from_node
+        .translation
+        .iter()
+        .all(|value| value.is_finite())
+        || !atlas_from_node
+            .rotation
+            .coords
+            .iter()
+            .all(|value| value.is_finite())
+    {
+        return Err("atlas Sim3 contains a non-finite value".to_owned());
+    }
+    let centre_atlas = atlas_from_node.transform_point(&pose.camera_center_world());
+    let rotation = pose.world_to_camera.rotation * atlas_from_node.rotation.inverse();
+    let translation = -rotation.transform_vector(&centre_atlas.coords);
+    let transformed = Pose::from_world_to_camera(rotation, translation);
+    validate_pose(&transformed, "transformed component pose")?;
+    Ok(transformed)
+}
+
+fn compose_camera_pose_from_rig(
+    sensor_from_rig: &SE3,
+    rig_world_to_camera: &Pose,
+) -> Result<Pose, String> {
+    let camera_pose = Pose {
+        world_to_camera: sensor_from_rig.compose(&rig_world_to_camera.world_to_camera),
+    };
+    validate_pose(&camera_pose, "recomposed atlas camera pose")?;
+    Ok(camera_pose)
+}
+
+fn publish_component(
+    component_index: usize,
+    nodes: &[NodeData],
+    component: &AtlasComponent,
+    out_dir: &Path,
+    output_image_ids: &mut BTreeSet<u64>,
+    owner_policy: FrameOwnerPolicy,
+) -> Result<ComponentSummary, String> {
+    let owners = select_frame_owners(nodes, component, owner_policy);
+    let mut output = String::from(
+        "# IMAGE_ID QW QX QY QZ TX TY TZ CAMERA_ID NAME\n# POINTS2D[] as X Y POINT3D_ID\n",
+    );
+    let mut image_count = 0;
+    for (frame_id, node_index) in &owners {
+        let node = &nodes[*node_index];
+        let atlas_from_node = component
+            .atlas_from_node
+            .get(node_index)
+            .expect("component owner has a BFS transform");
+        let frame = node
+            .frames
+            .get(frame_id)
+            .expect("owner frame came from the node frame map");
+        let atlas_rig_pose = transform_pose_to_atlas(atlas_from_node, &frame.pose)?;
+        for image in &frame.images {
+            if image.global_image_id == 0 {
+                return Err(format!(
+                    "component {component_index} image {:?} has no manifest global image id",
+                    image.name
+                ));
+            }
+            if !output_image_ids.insert(image.global_image_id) {
+                return Err(format!(
+                    "component {component_index} duplicates global image id {}",
+                    image.global_image_id
+                ));
+            }
+            let sensor_from_rig = image.sensor_from_rig.as_ref().ok_or_else(|| {
+                format!(
+                    "component {component_index} image {:?} has no bound sensor calibration",
+                    image.name
+                )
+            })?;
+            let pose = compose_camera_pose_from_rig(sensor_from_rig, &atlas_rig_pose)?;
+            let quaternion = pose.world_to_camera.rotation.quaternion();
+            let translation = pose.world_to_camera.translation;
+            output.push_str(&format!(
+                "{} {:.15} {:.15} {:.15} {:.15} {:.15} {:.15} {:.15} {} {}\n\n",
+                image.global_image_id,
+                quaternion.w,
+                quaternion.i,
+                quaternion.j,
+                quaternion.k,
+                translation.x,
+                translation.y,
+                translation.z,
+                image.camera_id,
+                image.name
+            ));
+            image_count += 1;
+        }
+    }
+    let component_dir = out_dir.join(format!("component-{component_index:03}"));
+    std::fs::create_dir_all(&component_dir).map_err(|error| {
+        format!(
+            "create component output directory {}: {error}",
+            component_dir.display()
+        )
+    })?;
+    let images_path = component_dir.join("images.txt");
+    std::fs::write(&images_path, output)
+        .map_err(|error| format!("write {}: {error}", images_path.display()))?;
+
+    let node_ids = component
+        .node_indices
+        .iter()
+        .map(|index| nodes[*index].spec.node_id)
+        .collect::<Vec<_>>();
+    Ok(ComponentSummary {
+        component_index,
+        anchor_node_id: nodes[component.anchor_index].spec.node_id,
+        node_ids,
+        frame_count: owners.len(),
+        image_count,
+        min_frame_id: owners.keys().next().copied(),
+        max_frame_id: owners.keys().next_back().copied(),
+    })
+}
+
+#[cfg(test)]
+fn stitch_nodes(nodes: &[NodeData], out_dir: &Path) -> Result<StitchResult, String> {
+    stitch_nodes_with_config(nodes, out_dir, &seam_alignment_config())
+}
+
+#[cfg(test)]
+fn stitch_nodes_with_config(
+    nodes: &[NodeData],
+    out_dir: &Path,
+    config: &RigSubmapAlignmentConfig,
+) -> Result<StitchResult, String> {
+    stitch_nodes_with_policy(
+        nodes,
+        out_dir,
+        config,
+        ForestPolicy::Traversal,
+        FrameOwnerPolicy::Newest,
+        false,
+    )
+}
+
+fn stitch_nodes_with_policy(
+    nodes: &[NodeData],
+    out_dir: &Path,
+    config: &RigSubmapAlignmentConfig,
+    forest_policy: ForestPolicy,
+    owner_policy: FrameOwnerPolicy,
+    metric_se3: bool,
+) -> Result<StitchResult, String> {
+    if nodes.is_empty() {
+        return Err("cannot stitch an empty node set".to_owned());
+    }
+    if metric_se3 && forest_policy == ForestPolicy::Quality {
+        return Err("--metric-se3 requires --forest-policy traversal".to_owned());
+    }
+    let (accepted_edges, mut seam_diagnostics) = build_seam_graph_with_config(nodes, config);
+    let transform_edges = match forest_policy {
+        ForestPolicy::Traversal => accepted_edges.clone(),
+        ForestPolicy::Quality => select_quality_forest(nodes, &accepted_edges),
+    };
+    let selected_keys = transform_edges
+        .iter()
+        .map(|edge| {
+            (
+                nodes[edge.source_index].spec.node_id,
+                nodes[edge.target_index].spec.node_id,
+                edge.start_gap,
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    for diagnostic in &mut seam_diagnostics {
+        diagnostic.selected_for_transform_graph = diagnostic.accepted
+            && selected_keys.contains(&(
+                diagnostic.source_node_id,
+                diagnostic.target_node_id,
+                diagnostic.start_gap,
+            ));
+    }
+    let mut components = connected_components(nodes.len(), &transform_edges);
+    components.sort_by_key(|component| {
+        let min_frame_id = component
+            .node_indices
+            .iter()
+            .flat_map(|index| nodes[*index].frames.keys().copied())
+            .min()
+            .unwrap_or(u64::MAX);
+        (
+            min_frame_id,
+            component
+                .node_indices
+                .first()
+                .copied()
+                .unwrap_or(usize::MAX),
+        )
+    });
+    let metric_se3_summaries = if metric_se3 {
+        optimize_metric_se3_components(nodes, &accepted_edges, &mut components)?
+    } else {
+        Vec::new()
+    };
+    std::fs::create_dir_all(out_dir)
+        .map_err(|error| format!("create output directory {}: {error}", out_dir.display()))?;
+    let mut output_image_ids = BTreeSet::new();
+    let summaries = components
+        .iter()
+        .enumerate()
+        .map(|(component_index, component)| {
+            publish_component(
+                component_index,
+                nodes,
+                component,
+                out_dir,
+                &mut output_image_ids,
+                owner_policy,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(StitchResult {
+        seam_diagnostics,
+        components: summaries,
+        metric_se3: metric_se3_summaries,
+    })
+}
+
+fn main() {
+    let args = match parse_args(std::env::args()) {
+        Ok(args) => args,
+        Err(error) => {
+            eprintln!("{error}");
+            usage();
+        }
+    };
+    let manifest = parse_rig_manifest(&args.rig_manifest).unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    });
+    let nodes = parse_node_specs(&args.nodes_tsv).unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    });
+    println!(
+        "parsed rig_manifest={} nodes={} out_dir={} seam_config_arm={} frame_owner_policy={} forest_policy={}",
+        args.rig_manifest.display(),
+        nodes.len(),
+        args.out_dir.display(),
+        args.seam_config_arm.as_str(),
+        args.frame_owner_policy.as_str(),
+        args.forest_policy.as_str()
+    );
+    if args.metric_se3 {
+        println!("metric_se3=enabled");
+    }
+    let node_data = nodes
+        .into_iter()
+        .map(|spec| extract_node_data(spec, &manifest))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|error| {
+            eprintln!("error: {error}");
+            std::process::exit(1);
+        });
+    for node in &node_data {
+        println!(
+            "node id={} window_start={} images={} frames={} step_median_m={:.9} step_max_m={:.9} step_ratio={:.6}",
+            node.spec.node_id,
+            node.spec.window_start,
+            node.images.len(),
+            node.frames.len(),
+            node.step.median_m,
+            node.step.max_m,
+            node.step.ratio
+        );
+    }
+    let seam_config = seam_alignment_config_for_arm(args.seam_config_arm);
+    let stitched = stitch_nodes_with_policy(
+        &node_data,
+        &args.out_dir,
+        &seam_config,
+        args.forest_policy,
+        args.frame_owner_policy,
+        args.metric_se3,
+    )
+    .unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    });
+    for diagnostic in &stitched.seam_diagnostics {
+        println!(
+            "seam source={} target={} start_gap={} verdict={} selected_for_transform_graph={} common_frames={} retained_frames={} reason={} method={:?} constraint_scale={:?} constraint_rotation_angle_deg={:?} constraint_translation_norm={:?} constraint_inlier_ratio={:?} constraint_mean_residual_ratio={:?} constraint_leave_one_out_log_scale_mad={:?} wrapper_reason={:?} primary_rejection_reason={:?} primary_rejection_inlier_count={:?} primary_rejection_inlier_ratio={:?} primary_rejection_mean_residual_ratio={:?} primary_rejection_rotation_disagreement_deg={:?} primary_rejection_leave_one_out_log_scale_mad={:?} fallback_attempted={} fallback_used={} fallback_rejection_reason={:?} fallback_rejection_inlier_count={:?} fallback_rejection_inlier_ratio={:?} fallback_rejection_mean_residual_ratio={:?} fallback_rejection_rotation_disagreement_deg={:?} fallback_rejection_leave_one_out_log_scale_mad={:?}",
+            diagnostic.source_node_id,
+            diagnostic.target_node_id,
+            diagnostic.start_gap,
+            if diagnostic.accepted {
+                "accepted"
+            } else {
+                "rejected"
+            },
+            diagnostic.selected_for_transform_graph,
+            diagnostic.common_frames,
+            diagnostic.retained_frames,
+            diagnostic.reason,
+            diagnostic.alignment_method,
+            diagnostic.constraint_scale,
+            diagnostic.constraint_rotation_angle_deg,
+            diagnostic.constraint_translation_norm,
+            diagnostic.constraint_inlier_ratio,
+            diagnostic.constraint_mean_residual_ratio,
+            diagnostic.constraint_leave_one_out_log_scale_mad,
+            diagnostic.wrapper_rejection_reason,
+            diagnostic.sim3_rejection_reason,
+            diagnostic.sim3_rejection_inlier_count,
+            diagnostic.sim3_rejection_inlier_ratio,
+            diagnostic.sim3_rejection_mean_residual_ratio,
+            diagnostic.sim3_rejection_rotation_disagreement_deg,
+            diagnostic.sim3_rejection_leave_one_out_log_scale_mad,
+            diagnostic.fallback_attempted,
+            diagnostic.fallback_used,
+            diagnostic.fallback_rejection_reason,
+            diagnostic.fallback_rejection_inlier_count,
+            diagnostic.fallback_rejection_inlier_ratio,
+            diagnostic.fallback_rejection_mean_residual_ratio,
+            diagnostic.fallback_rejection_rotation_disagreement_deg,
+            diagnostic.fallback_rejection_leave_one_out_log_scale_mad
+        );
+    }
+    let accepted_count = stitched
+        .seam_diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.accepted)
+        .count();
+    let rejected_count = stitched
+        .seam_diagnostics
+        .iter()
+        .filter(|diagnostic| !diagnostic.accepted)
+        .count();
+    println!(
+        "summary accepted_seams={} rejected_seams={} components={}",
+        accepted_count,
+        rejected_count,
+        stitched.components.len()
+    );
+    for component in &stitched.components {
+        let frame_range = match (component.min_frame_id, component.max_frame_id) {
+            (Some(min_frame_id), Some(max_frame_id)) => {
+                format!("{min_frame_id}..{max_frame_id}")
+            }
+            _ => "empty".to_owned(),
+        };
+        println!(
+            "component index={} anchor_node={} nodes={:?} frames={} images={} frame_range={}",
+            component.component_index,
+            component.anchor_node_id,
+            component.node_ids,
+            component.frame_count,
+            component.image_count,
+            frame_range
+        );
+    }
+    for metric in &stitched.metric_se3 {
+        println!(
+            "metric_se3 component={} nodes={} edges={} initial_cost={:.12} final_cost={:.12} iterations={} converged={}",
+            metric.component_index,
+            metric.node_count,
+            metric.edge_count,
+            metric.initial_cost,
+            metric.final_cost,
+            metric.iterations,
+            metric.converged
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Point3;
+    use std::fs;
+
+    fn fixture_root(test_name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "visloc_stitch_rig_submap_{test_name}_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_fixture(root: &Path, contents: &str) -> PathBuf {
+        let images = root.join("model").join("images.txt");
+        fs::create_dir_all(images.parent().unwrap()).unwrap();
+        fs::write(&images, "# empty fixture\n").unwrap();
+        let nodes = root.join("nodes.tsv");
+        fs::write(&nodes, contents).unwrap();
+        nodes
+    }
+
+    #[test]
+    fn parses_required_arguments() {
+        let args = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(args.rig_manifest, PathBuf::from("rig.txt"));
+        assert_eq!(args.nodes_tsv, PathBuf::from("nodes.tsv"));
+        assert_eq!(args.out_dir, PathBuf::from("out"));
+        assert_eq!(args.seam_config_arm, SeamConfigArm::A);
+        assert_eq!(args.frame_owner_policy, FrameOwnerPolicy::Newest);
+        assert_eq!(args.forest_policy, ForestPolicy::Traversal);
+        assert!(!args.metric_se3);
+    }
+
+    #[test]
+    fn parses_frame_owner_policy_and_rejects_unknown_or_duplicate_values() {
+        assert_eq!(
+            FrameOwnerPolicy::parse("newest"),
+            Ok(FrameOwnerPolicy::Newest)
+        );
+        assert_eq!(
+            FrameOwnerPolicy::parse("interior"),
+            Ok(FrameOwnerPolicy::Interior)
+        );
+        assert!(FrameOwnerPolicy::parse("other")
+            .unwrap_err()
+            .contains("expects newest or interior"));
+
+        let args = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--frame-owner-policy",
+                "interior",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(args.frame_owner_policy, FrameOwnerPolicy::Interior);
+        assert!(USAGE.contains("[--frame-owner-policy newest|interior]"));
+
+        let unknown = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--frame-owner-policy",
+                "other",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(unknown.contains("expects newest or interior"));
+
+        let duplicate = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--frame-owner-policy",
+                "newest",
+                "--frame-owner-policy",
+                "interior",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(duplicate.contains("duplicate argument --frame-owner-policy"));
+    }
+
+    #[test]
+    fn parses_quality_forest_policy_and_rejects_unknown_values() {
+        assert_eq!(
+            ForestPolicy::parse("traversal"),
+            Ok(ForestPolicy::Traversal)
+        );
+        assert_eq!(ForestPolicy::parse("quality"), Ok(ForestPolicy::Quality));
+        assert!(ForestPolicy::parse("other")
+            .unwrap_err()
+            .contains("expects traversal or quality"));
+
+        let args = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--forest-policy",
+                "quality",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(args.forest_policy, ForestPolicy::Quality);
+
+        let duplicate = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--forest-policy",
+                "traversal",
+                "--forest-policy",
+                "quality",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(duplicate.contains("duplicate argument --forest-policy"));
+    }
+
+    #[test]
+    fn parses_metric_se3_opt_in_and_rejects_duplicates() {
+        let args = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--metric-se3",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert!(args.metric_se3);
+        assert!(USAGE.contains("[--metric-se3]"));
+
+        let duplicate = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--metric-se3",
+                "--metric-se3",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(duplicate.contains("duplicate argument --metric-se3"));
+    }
+
+    #[test]
+    fn parses_and_applies_selected_seam_config_arm() {
+        let args = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--seam-config-arm",
+                "D",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(args.seam_config_arm, SeamConfigArm::D);
+        assert_eq!(SeamConfigArm::parse("E"), Ok(SeamConfigArm::E));
+        let config = seam_alignment_config_for_arm(args.seam_config_arm);
+        assert_eq!(config.max_boundary_frames, 64);
+        assert_eq!(config.alignment.min_correspondences, 8);
+        assert_eq!(config.alignment.min_inliers, 8);
+        assert_eq!(config.rotation_consensus_deg, 5.0);
+        assert_eq!(config.min_rotation_consensus_ratio, 0.6);
+        assert_eq!(config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(config.alignment.max_mean_residual_ratio, 0.05);
+        assert_eq!(config.alignment.min_inlier_ratio, 0.5);
+
+        let e_config = seam_alignment_config_for_arm(SeamConfigArm::E);
+        assert_eq!(e_config.max_boundary_frames, 64);
+        assert_eq!(e_config.alignment.min_correspondences, 8);
+        assert_eq!(e_config.alignment.min_inliers, 8);
+        assert_eq!(e_config.rotation_consensus_deg, 60.0);
+        assert_eq!(e_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(e_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(e_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(e_config.alignment.max_mean_residual_ratio, 0.06);
+        assert_eq!(e_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(e_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(!e_config.allow_fixed_rotation_fallback);
+        assert!(!e_config.prefer_fixed_rotation_alignment);
+        assert!(!e_config.allow_generic_fallback_after_fixed_rotation);
+
+        assert_eq!(SeamConfigArm::parse("F"), Ok(SeamConfigArm::F));
+        let f_config = seam_alignment_config_for_arm(SeamConfigArm::F);
+        assert_eq!(f_config.rotation_consensus_deg, 60.0);
+        assert_eq!(f_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(f_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(f_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(f_config.alignment.max_mean_residual_ratio, 0.06);
+        assert_eq!(f_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(f_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(f_config.allow_fixed_rotation_fallback);
+        assert!(!f_config.prefer_fixed_rotation_alignment);
+        assert!(!f_config.allow_generic_fallback_after_fixed_rotation);
+
+        assert_eq!(SeamConfigArm::parse("G"), Ok(SeamConfigArm::G));
+        let g_config = seam_alignment_config_for_arm(SeamConfigArm::G);
+        assert_eq!(g_config.rotation_consensus_deg, 60.0);
+        assert_eq!(g_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(g_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(g_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(g_config.alignment.max_mean_residual_ratio, 0.06);
+        assert_eq!(g_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(g_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(!g_config.allow_fixed_rotation_fallback);
+        assert!(g_config.prefer_fixed_rotation_alignment);
+        assert!(!g_config.allow_generic_fallback_after_fixed_rotation);
+
+        assert_eq!(SeamConfigArm::parse("H"), Ok(SeamConfigArm::H));
+        let h_config = seam_alignment_config_for_arm(SeamConfigArm::H);
+        assert_eq!(h_config.rotation_consensus_deg, 60.0);
+        assert_eq!(h_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(h_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(h_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(h_config.alignment.max_mean_residual_ratio, 0.06);
+        assert_eq!(h_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(h_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(!h_config.allow_fixed_rotation_fallback);
+        assert!(h_config.prefer_fixed_rotation_alignment);
+        assert!(h_config.allow_generic_fallback_after_fixed_rotation);
+
+        assert_eq!(SeamConfigArm::parse("I"), Ok(SeamConfigArm::I));
+        let i_config = seam_alignment_config_for_arm(SeamConfigArm::I);
+        assert_eq!(
+            i_config.boundary_sampling,
+            RigSubmapBoundarySampling::UniformAcrossOverlap
+        );
+        assert_eq!(i_config.rotation_consensus_deg, 60.0);
+        assert_eq!(i_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(i_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(i_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(i_config.alignment.max_mean_residual_ratio, 0.06);
+        assert_eq!(i_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(i_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(!i_config.allow_fixed_rotation_fallback);
+        assert!(i_config.prefer_fixed_rotation_alignment);
+        assert!(i_config.allow_generic_fallback_after_fixed_rotation);
+
+        assert_eq!(SeamConfigArm::parse("J"), Ok(SeamConfigArm::J));
+        let j_config = seam_alignment_config_for_arm(SeamConfigArm::J);
+        assert_eq!(
+            j_config.boundary_sampling,
+            RigSubmapBoundarySampling::Earliest
+        );
+        assert_eq!(j_config.rotation_consensus_deg, 60.0);
+        assert_eq!(j_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(j_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(j_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(j_config.alignment.max_mean_residual_ratio, 0.07);
+        assert_eq!(j_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(j_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(!j_config.allow_fixed_rotation_fallback);
+        assert!(j_config.prefer_fixed_rotation_alignment);
+        assert!(j_config.allow_generic_fallback_after_fixed_rotation);
+
+        assert_eq!(SeamConfigArm::parse("K"), Ok(SeamConfigArm::K));
+        let k_config = seam_alignment_config_for_arm(SeamConfigArm::K);
+        assert_eq!(
+            k_config.boundary_sampling,
+            RigSubmapBoundarySampling::Earliest
+        );
+        assert_eq!(k_config.rotation_consensus_deg, 60.0);
+        assert_eq!(k_config.min_rotation_consensus_ratio, 0.35);
+        assert_eq!(k_config.alignment.min_second_to_first_singular_ratio, 0.0);
+        assert_eq!(k_config.alignment.max_inlier_residual_ratio, 0.10);
+        assert_eq!(k_config.alignment.max_mean_residual_ratio, 0.07);
+        assert_eq!(k_config.alignment.min_inlier_ratio, 0.35);
+        assert_eq!(k_config.alignment.max_rotation_disagreement_deg, 60.0);
+        assert!(!k_config.allow_fixed_rotation_fallback);
+        assert!(k_config.prefer_fixed_rotation_alignment);
+        assert!(k_config.allow_generic_fallback_after_fixed_rotation);
+        assert!(k_config.force_fixed_rotation_unit_scale);
+
+        assert_eq!(SeamConfigArm::parse("L"), Ok(SeamConfigArm::L));
+        let l_config = seam_alignment_config_for_arm(SeamConfigArm::L);
+        assert_eq!(
+            l_config.boundary_sampling,
+            RigSubmapBoundarySampling::Earliest
+        );
+        assert_eq!(
+            l_config.rotation_consensus_deg,
+            k_config.rotation_consensus_deg
+        );
+        assert_eq!(
+            l_config.min_rotation_consensus_ratio,
+            k_config.min_rotation_consensus_ratio
+        );
+        assert_eq!(l_config.alignment, k_config.alignment);
+        assert!(!l_config.allow_fixed_rotation_fallback);
+        assert!(l_config.prefer_fixed_rotation_alignment);
+        assert!(!l_config.allow_generic_fallback_after_fixed_rotation);
+        assert!(l_config.force_fixed_rotation_unit_scale);
+        assert!(USAGE.contains("[--seam-config-arm A|B|C|D|E|F|G|H|I|J|K|L]"));
+    }
+
+    #[test]
+    fn rejects_unknown_or_duplicate_seam_config_arm() {
+        let unknown = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--seam-config-arm",
+                "Z",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(unknown.contains("expects A, B, C, D, E, F, G, H, I, J, K, or L"));
+
+        let duplicate = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+                "--out-dir",
+                "out",
+                "--seam-config-arm",
+                "B",
+                "--seam-config-arm",
+                "C",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(duplicate.contains("duplicate argument --seam-config-arm"));
+    }
+
+    #[test]
+    fn rejects_missing_required_argument() {
+        let error = parse_args(
+            [
+                "stitch_rig_submap_trajectories",
+                "--rig-manifest",
+                "rig.txt",
+                "--nodes-tsv",
+                "nodes.tsv",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(error.contains("--out-dir is required"));
+    }
+
+    #[test]
+    fn parses_and_sorts_nodes_by_start_then_id() {
+        let root = fixture_root("sort");
+        let image_a = root.join("a-images.txt");
+        let image_b = root.join("b-images.txt");
+        fs::write(&image_a, "# a\n").unwrap();
+        fs::write(&image_b, "# b\n").unwrap();
+        let nodes_path = root.join("nodes.tsv");
+        fs::write(
+            &nodes_path,
+            format!(
+                "# node_id\twindow_start\timages_txt\n2\t250\t{}\n1\t250\t{}\n",
+                image_b.display(),
+                image_a.display()
+            ),
+        )
+        .unwrap();
+        let nodes = parse_node_specs(&nodes_path).unwrap();
+        assert_eq!(
+            nodes,
+            vec![
+                NodeSpec {
+                    node_id: 1,
+                    window_start: 250,
+                    images_txt: image_a,
+                },
+                NodeSpec {
+                    node_id: 2,
+                    window_start: 250,
+                    images_txt: image_b,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_node_ids() {
+        let root = fixture_root("duplicate-id");
+        let image_a = root.join("a-images.txt");
+        let image_b = root.join("b-images.txt");
+        fs::write(&image_a, "# a\n").unwrap();
+        fs::write(&image_b, "# b\n").unwrap();
+        let nodes_path = root.join("nodes.tsv");
+        fs::write(
+            &nodes_path,
+            format!(
+                "1\t0\t{}\n1\t250\t{}\n",
+                image_a.display(),
+                image_b.display()
+            ),
+        )
+        .unwrap();
+        let error = parse_node_specs(&nodes_path).unwrap_err();
+        assert!(error.contains("duplicates node id 1"));
+    }
+
+    #[test]
+    fn rejects_duplicate_start_and_path() {
+        let root = fixture_root("duplicate-start-path");
+        let image = root.join("images.txt");
+        fs::write(&image, "# image\n").unwrap();
+        let nodes_path = root.join("nodes.tsv");
+        fs::write(
+            &nodes_path,
+            format!("1\t250\t{}\n2\t250\t{}\n", image.display(), image.display()),
+        )
+        .unwrap();
+        let error = parse_node_specs(&nodes_path).unwrap_err();
+        assert!(error.contains("duplicates window_start/images_txt"));
+    }
+
+    #[test]
+    fn rejects_missing_images_file() {
+        let root = fixture_root("missing-file");
+        let nodes_path = write_fixture(&root, "1\t0\tmissing/images.txt\n");
+        let error = parse_node_specs(&nodes_path).unwrap_err();
+        assert!(error.contains("images.txt does not exist"));
+    }
+
+    #[test]
+    fn rejects_malformed_node_rows() {
+        let root = fixture_root("malformed");
+        let nodes_path = write_fixture(&root, "1\t0\n");
+        let error = parse_node_specs(&nodes_path).unwrap_err();
+        assert!(error.contains("requires node_id<TAB>window_start<TAB>images_txt"));
+    }
+
+    fn manifest_text(rows: &str) -> String {
+        format!(
+            "# generalized-rig-manifest-v1\n\
+             # S index camera_id width height fx fy cx cy qw qx qy qz tx ty tz\n\
+             S 0 1 848 800 284.0 286.0 425.0 399.0 1 0 0 0 0 0 0\n\
+             S 1 2 848 800 284.0 286.0 425.0 399.0 1 0 0 0 -0.1 0 0\n\
+             {rows}"
+        )
+    }
+
+    fn colmap_pose(
+        image_id: u64,
+        camera_id: u64,
+        name: &str,
+        translation_x: f64,
+        points: &str,
+    ) -> String {
+        format!("{image_id} 1 0 0 0 {translation_x} 0 0 {camera_id} {name}\n{points}\n")
+    }
+
+    #[test]
+    fn parses_rig_manifest_sensors_and_assignments() {
+        let root = fixture_root("rig-manifest");
+        let path = root.join("rig.txt");
+        fs::write(&path, manifest_text("F 0 cam1.png 0\nF 0 cam2.png 1\n")).unwrap();
+        let manifest = parse_rig_manifest(&path).unwrap();
+        assert_eq!(manifest.sensors.len(), 2);
+        assert_eq!(manifest.sensors[&1].camera_id, 2);
+        assert_eq!(manifest.assignments["cam1.png"].global_image_id, 1);
+        assert_eq!(
+            manifest.assignments["cam2.png"],
+            FrameImageAssignment {
+                frame_id: 0,
+                sensor_index: 1,
+                global_image_id: 2,
+            }
+        );
+        assert!((manifest.sensors[&1].sensor_from_rig.translation.x + 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rejects_unknown_sensor_and_duplicate_frame_sensor() {
+        let root = fixture_root("rig-manifest-errors");
+        let unknown = root.join("unknown.txt");
+        fs::write(&unknown, manifest_text("F 0 cam1.png 2\n")).unwrap();
+        let error = parse_rig_manifest(&unknown).unwrap_err();
+        assert!(error.contains("unknown sensor 2"));
+
+        let duplicate = root.join("duplicate.txt");
+        fs::write(
+            &duplicate,
+            manifest_text("F 0 cam1.png 0\nF 0 cam1-other.png 0\n"),
+        )
+        .unwrap();
+        let error = parse_rig_manifest(&duplicate).unwrap_err();
+        assert!(error.contains("duplicates frame 0 sensor 0"));
+    }
+
+    #[test]
+    fn parses_empty_and_nonempty_points2d_rows() {
+        let root = fixture_root("colmap-points");
+        let path = root.join("images.txt");
+        fs::write(
+            &path,
+            format!(
+                "{}{}",
+                colmap_pose(1, 1, "cam1.png", 0.0, ""),
+                colmap_pose(2, 2, "cam2.png", -0.1, "10 20 -1 30 40 7")
+            ),
+        )
+        .unwrap();
+        let images = parse_colmap_images(&path).unwrap();
+        assert_eq!(images.len(), 2);
+        assert_eq!(images[0].name, "cam1.png");
+        assert_eq!(images[1].name, "cam2.png");
+        assert_eq!(images[1].image_id, 2);
+    }
+
+    #[test]
+    fn rejects_duplicate_and_nonfinite_colmap_poses() {
+        let root = fixture_root("colmap-errors");
+        let duplicate = root.join("duplicate.txt");
+        fs::write(
+            &duplicate,
+            format!(
+                "{}{}",
+                colmap_pose(1, 1, "cam1.png", 0.0, ""),
+                colmap_pose(1, 1, "cam1-other.png", 0.0, "")
+            ),
+        )
+        .unwrap();
+        let error = parse_colmap_images(&duplicate).unwrap_err();
+        assert!(error.contains("duplicates image id 1"));
+
+        let nonfinite = root.join("nonfinite.txt");
+        fs::write(&nonfinite, colmap_pose(1, 1, "cam1.png", f64::NAN, "")).unwrap();
+        let error = parse_colmap_images(&nonfinite).unwrap_err();
+        assert!(error.contains("non-finite"));
+    }
+
+    #[test]
+    fn extracts_one_consistent_rig_pose_per_frame() {
+        let root = fixture_root("node-data");
+        let manifest_path = root.join("rig.txt");
+        fs::write(
+            &manifest_path,
+            manifest_text("F 0 cam1.png 0\nF 0 cam2.png 1\nF 1 cam1b.png 0\nF 1 cam2b.png 1\n"),
+        )
+        .unwrap();
+        let images_path = root.join("images.txt");
+        fs::write(
+            &images_path,
+            format!(
+                "{}{}{}{}",
+                colmap_pose(1, 1, "cam1.png", 0.0, ""),
+                colmap_pose(2, 2, "cam2.png", -0.1, ""),
+                colmap_pose(3, 1, "cam1b.png", -1.0, ""),
+                colmap_pose(4, 2, "cam2b.png", -1.1, "")
+            ),
+        )
+        .unwrap();
+        let manifest = parse_rig_manifest(&manifest_path).unwrap();
+        let node = extract_node_data(
+            NodeSpec {
+                node_id: 7,
+                window_start: 0,
+                images_txt: images_path,
+            },
+            &manifest,
+        )
+        .unwrap();
+        assert_eq!(node.frames.len(), 2);
+        assert_eq!(node.frames[&0].images.len(), 2);
+        assert_eq!(node.frames[&1].images.len(), 2);
+        assert!((node.frames[&0].pose.camera_center_world().x - 0.0).abs() < 1e-12);
+        assert!((node.frames[&1].pose.camera_center_world().x - 1.0).abs() < 1e-12);
+        assert!((node.step.median_m - 1.0).abs() < 1e-12);
+        assert!((node.step.max_m - 1.0).abs() < 1e-12);
+        assert!((node.step.ratio - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rejects_inconsistent_sensor_poses_and_unknown_images() {
+        let root = fixture_root("node-errors");
+        let manifest_path = root.join("rig.txt");
+        fs::write(
+            &manifest_path,
+            manifest_text("F 0 cam1.png 0\nF 0 cam2.png 1\n"),
+        )
+        .unwrap();
+        let manifest = parse_rig_manifest(&manifest_path).unwrap();
+
+        let inconsistent_path = root.join("inconsistent.txt");
+        fs::write(
+            &inconsistent_path,
+            format!(
+                "{}{}",
+                colmap_pose(1, 1, "cam1.png", 0.0, ""),
+                colmap_pose(2, 2, "cam2.png", -0.2, "")
+            ),
+        )
+        .unwrap();
+        let error = extract_node_data(
+            NodeSpec {
+                node_id: 1,
+                window_start: 0,
+                images_txt: inconsistent_path,
+            },
+            &manifest,
+        )
+        .unwrap_err();
+        assert!(error.contains("sensor poses disagree"));
+
+        let unknown_path = root.join("unknown.txt");
+        fs::write(
+            &unknown_path,
+            colmap_pose(1, 1, "not-in-manifest.png", 0.0, ""),
+        )
+        .unwrap();
+        let error = extract_node_data(
+            NodeSpec {
+                node_id: 2,
+                window_start: 0,
+                images_txt: unknown_path,
+            },
+            &manifest,
+        )
+        .unwrap_err();
+        assert!(error.contains("absent from rig manifest"));
+    }
+
+    fn identity_camera_pose(centre: Point3<f64>) -> Pose {
+        Pose::from_world_to_camera(UnitQuaternion::identity(), -centre.coords)
+    }
+
+    fn trajectory_centres(last_frame_id: u64) -> BTreeMap<u64, Point3<f64>> {
+        (0..=last_frame_id)
+            .map(|frame_id| {
+                let index = frame_id as f64;
+                (
+                    frame_id,
+                    Point3::new(
+                        index * 0.35,
+                        ((frame_id * 13) % 17) as f64 * 0.23,
+                        ((frame_id * 7) % 11) as f64 * 0.31 + index * 0.02,
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn synthetic_node(
+        node_id: u64,
+        window_start: u64,
+        frame_ids: impl IntoIterator<Item = u64>,
+        atlas_from_node: &Sim3,
+        centres: &BTreeMap<u64, Point3<f64>>,
+        step: Option<StepStats>,
+    ) -> NodeData {
+        let local_from_atlas = atlas_from_node.inverse();
+        let mut frames = BTreeMap::new();
+        let mut images = Vec::new();
+        for frame_id in frame_ids {
+            let local_centre = local_from_atlas.transform_point(&centres[&frame_id]);
+            let pose = identity_camera_pose(local_centre);
+            let image = ColmapImage {
+                // Each node owns a local COLMAP model, so local image ids can
+                // legitimately repeat across windows.
+                image_id: frame_id,
+                global_image_id: node_id * 100_000 + frame_id + 1,
+                camera_id: 1,
+                name: format!("node{node_id}_frame{frame_id}.png"),
+                world_to_camera: pose.clone(),
+                sensor_from_rig: Some(SE3::identity()),
+            };
+            frames.insert(
+                frame_id,
+                FrameData {
+                    pose,
+                    images: vec![image.clone()],
+                },
+            );
+            images.push(image);
+        }
+        let step = step.unwrap_or_else(|| compute_step_stats(&frames));
+        NodeData {
+            spec: NodeSpec {
+                node_id,
+                window_start,
+                images_txt: PathBuf::from(format!("synthetic-{node_id}.txt")),
+            },
+            images,
+            frames,
+            step,
+        }
+    }
+
+    fn synthetic_stereo_node(
+        node_id: u64,
+        window_start: u64,
+        frame_ids: impl IntoIterator<Item = u64>,
+        centres: &BTreeMap<u64, Point3<f64>>,
+        sensor_a: &SE3,
+        sensor_b: &SE3,
+    ) -> NodeData {
+        let mut frames = BTreeMap::new();
+        let mut images = Vec::new();
+        for frame_id in frame_ids {
+            let rig_pose = identity_camera_pose(centres[&frame_id]);
+            let mut frame_images = Vec::new();
+            for (sensor_index, sensor_from_rig) in [sensor_a, sensor_b].iter().enumerate() {
+                let image = ColmapImage {
+                    image_id: frame_id * 2 + sensor_index as u64 + 1,
+                    global_image_id: node_id * 100_000 + frame_id * 2 + sensor_index as u64 + 1,
+                    camera_id: sensor_index as u64 + 1,
+                    name: format!("node{node_id}_frame{frame_id}_sensor{sensor_index}.png"),
+                    world_to_camera: compose_camera_pose_from_rig(sensor_from_rig, &rig_pose)
+                        .unwrap(),
+                    sensor_from_rig: Some((*sensor_from_rig).clone()),
+                };
+                frame_images.push(image.clone());
+                images.push(image);
+            }
+            frames.insert(
+                frame_id,
+                FrameData {
+                    pose: rig_pose,
+                    images: frame_images,
+                },
+            );
+        }
+        NodeData {
+            spec: NodeSpec {
+                node_id,
+                window_start,
+                images_txt: PathBuf::from(format!("synthetic-stereo-{node_id}.txt")),
+            },
+            images,
+            frames,
+            step: healthy_step(),
+        }
+    }
+
+    fn healthy_step() -> StepStats {
+        StepStats {
+            median_m: 1.0,
+            max_m: 1.0,
+            ratio: 1.0,
+        }
+    }
+
+    fn bad_step() -> StepStats {
+        StepStats {
+            median_m: 1.0,
+            max_m: 100.0,
+            ratio: 100.0,
+        }
+    }
+
+    fn component_for_node_count(node_count: usize) -> AtlasComponent {
+        AtlasComponent {
+            anchor_index: 0,
+            node_indices: (0..node_count).collect(),
+            atlas_from_node: (0..node_count)
+                .map(|node_index| (node_index, Sim3::identity()))
+                .collect(),
+        }
+    }
+
+    fn assert_sim3_close(actual: &Sim3, expected: &Sim3) {
+        assert!((actual.scale - expected.scale).abs() < 1.0e-12);
+        assert!((actual.translation - expected.translation).norm() < 1.0e-12);
+        assert!(actual.rotation.rotation_to(&expected.rotation).angle() < 1.0e-12);
+    }
+
+    fn assert_se3_close(actual: &SE3, expected: &SE3) {
+        assert!((actual.translation - expected.translation).norm() < 1.0e-12);
+        assert!(actual.rotation.rotation_to(&expected.rotation).angle() < 1.0e-12);
+    }
+
+    #[test]
+    fn interior_frame_owner_prefers_the_deepest_registered_overlap() {
+        let centres = trajectory_centres(20);
+        let nodes = vec![
+            synthetic_node(
+                10,
+                0,
+                0..7,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                20,
+                250,
+                0..11,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                30,
+                500,
+                4..7,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+        ];
+        let component = component_for_node_count(nodes.len());
+
+        let newest = select_frame_owners(&nodes, &component, FrameOwnerPolicy::Newest);
+        assert_eq!(newest[&5], 2);
+        let interior = select_frame_owners(&nodes, &component, FrameOwnerPolicy::Interior);
+        assert_eq!(interior[&5], 1);
+    }
+
+    #[test]
+    fn interior_frame_owner_uses_newest_start_then_node_id_for_ties() {
+        let centres = trajectory_centres(12);
+        let nodes = vec![
+            synthetic_node(
+                10,
+                0,
+                0..11,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                20,
+                250,
+                0..11,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                21,
+                250,
+                0..11,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+        ];
+        let owners = select_frame_owners(
+            &nodes,
+            &component_for_node_count(nodes.len()),
+            FrameOwnerPolicy::Interior,
+        );
+        assert_eq!(owners[&5], 2);
+    }
+
+    #[test]
+    fn interior_frame_owner_ignores_holes_and_unhealthy_nodes() {
+        let centres = trajectory_centres(20);
+        let nodes = vec![
+            synthetic_node(
+                10,
+                0,
+                0..11,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                20,
+                250,
+                (0..5).chain(6..11),
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                30,
+                500,
+                0..21,
+                &Sim3::identity(),
+                &centres,
+                Some(bad_step()),
+            ),
+        ];
+        let owners = select_frame_owners(
+            &nodes,
+            &component_for_node_count(nodes.len()),
+            FrameOwnerPolicy::Interior,
+        );
+        assert_eq!(owners[&5], 0, "the hole is not an owner candidate");
+        assert_eq!(owners[&10], 1, "unhealthy nodes are excluded");
+    }
+
+    #[test]
+    fn recomposes_calibrated_cameras_after_rig_sim3_without_scaling_baseline() {
+        let rig_local = Pose::from_world_to_camera(
+            UnitQuaternion::from_euler_angles(0.21, -0.17, 0.31),
+            Vector3::new(-0.8, 0.45, -1.2),
+        );
+        let sensor_a = SE3::new(
+            UnitQuaternion::from_euler_angles(0.04, -0.08, 0.12),
+            Vector3::new(0.11, -0.03, 0.02),
+        );
+        let sensor_b = SE3::new(
+            UnitQuaternion::from_euler_angles(-0.13, 0.06, -0.05),
+            Vector3::new(-0.27, 0.08, 0.04),
+        );
+        let input_baseline = (sensor_a.inverse().transform_point(&Point3::origin())
+            - sensor_b.inverse().transform_point(&Point3::origin()))
+        .norm();
+        assert!(sensor_a.rotation.rotation_to(&sensor_b.rotation).angle() > 1.0e-3);
+        let rig_local_centre = rig_local.camera_center_world();
+
+        for scale in [0.7, 1.3] {
+            let atlas_from_node = Sim3::new(
+                UnitQuaternion::from_euler_angles(-0.19, 0.27, -0.14),
+                Vector3::new(2.4, -1.1, 0.8),
+                scale,
+            );
+            let atlas_rig_pose = transform_pose_to_atlas(&atlas_from_node, &rig_local).unwrap();
+            let camera_a = compose_camera_pose_from_rig(&sensor_a, &atlas_rig_pose).unwrap();
+            let camera_b = compose_camera_pose_from_rig(&sensor_b, &atlas_rig_pose).unwrap();
+
+            assert_se3_close(
+                &camera_a
+                    .world_to_camera
+                    .compose(&atlas_rig_pose.world_to_camera.inverse()),
+                &sensor_a,
+            );
+            assert_se3_close(
+                &camera_b
+                    .world_to_camera
+                    .compose(&atlas_rig_pose.world_to_camera.inverse()),
+                &sensor_b,
+            );
+            let expected_rig_centre = atlas_from_node.transform_point(&rig_local_centre);
+            assert!((atlas_rig_pose.camera_center_world() - expected_rig_centre).norm() < 1.0e-12);
+            let output_baseline =
+                (camera_a.camera_center_world() - camera_b.camera_center_world()).norm();
+            assert!((output_baseline - input_baseline).abs() < 1.0e-12);
+        }
+    }
+
+    fn test_edge(
+        source_index: usize,
+        target_index: usize,
+        target_from_source: Sim3,
+        common_frames: usize,
+        retained_frames: usize,
+        inlier_ratio: Option<f64>,
+        mean_residual_ratio: Option<f64>,
+        start_gap: u64,
+    ) -> SeamEdge {
+        SeamEdge {
+            source_index,
+            target_index,
+            target_from_source,
+            common_frames,
+            retained_frames,
+            inlier_ratio,
+            mean_residual_ratio,
+            start_gap,
+            method: Some("test".to_owned()),
+        }
+    }
+
+    fn stitch_fixture_nodes() -> Vec<NodeData> {
+        let centres = trajectory_centres(35);
+        vec![
+            synthetic_node(
+                10,
+                0,
+                0..16,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                11,
+                250,
+                8..24,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                12,
+                500,
+                20..36,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+        ]
+    }
+
+    #[test]
+    fn composes_noncommuting_sim3_chain_from_oldest_anchor() {
+        let first = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.2)),
+            Vector3::new(1.0, -0.5, 0.3),
+            1.2,
+        );
+        let second = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(-0.15, 0.1, 0.0)),
+            Vector3::new(-0.7, 0.4, 1.1),
+            0.8,
+        );
+        let edges = vec![
+            SeamEdge {
+                source_index: 1,
+                target_index: 0,
+                target_from_source: first.clone(),
+                common_frames: 10,
+                retained_frames: 10,
+                inlier_ratio: Some(1.0),
+                mean_residual_ratio: Some(0.01),
+                start_gap: 1,
+                method: Some("test".to_owned()),
+            },
+            SeamEdge {
+                source_index: 2,
+                target_index: 1,
+                target_from_source: second.clone(),
+                common_frames: 10,
+                retained_frames: 10,
+                inlier_ratio: Some(1.0),
+                mean_residual_ratio: Some(0.01),
+                start_gap: 1,
+                method: Some("test".to_owned()),
+            },
+        ];
+        let components = connected_components(3, &edges);
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].anchor_index, 0);
+        assert_eq!(components[0].node_indices, vec![0, 1, 2]);
+        assert_sim3_close(&components[0].atlas_from_node[&1], &first);
+        assert_sim3_close(&components[0].atlas_from_node[&2], &first.compose(&second));
+        assert!(
+            (first.compose(&second).translation - second.compose(&first).translation).norm()
+                > 1.0e-3
+        );
+    }
+
+    #[test]
+    fn metric_se3_preserves_exact_noncommuting_unit_cycle() {
+        let centres = trajectory_centres(2);
+        let nodes = vec![
+            synthetic_node(10, 0, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(20, 250, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(30, 500, 0..2, &Sim3::identity(), &centres, None),
+        ];
+        let first = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.2)),
+            Vector3::new(1.0, -0.5, 0.3),
+            1.0,
+        );
+        let second = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(-0.15, 0.1, 0.0)),
+            Vector3::new(-0.7, 0.4, 1.1),
+            1.0,
+        );
+        let expected = first.compose(&second);
+        let edges = vec![
+            test_edge(1, 0, first.clone(), 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(2, 1, second.clone(), 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(2, 0, expected.clone(), 10, 10, Some(1.0), Some(0.01), 500),
+        ];
+        let mut components = connected_components(nodes.len(), &edges);
+        let reports = optimize_metric_se3_components(&nodes, &edges, &mut components).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].edge_count, 3);
+        assert!(reports[0].initial_cost < 1.0e-20);
+        assert!(reports[0].final_cost < 1.0e-20);
+        assert_sim3_close(&components[0].atlas_from_node[&1], &first);
+        assert_sim3_close(&components[0].atlas_from_node[&2], &expected);
+        assert!(components
+            .iter()
+            .flat_map(|component| component.atlas_from_node.values())
+            .all(|transform| (transform.scale - 1.0).abs() < UNIT_SCALE_TOLERANCE));
+    }
+
+    #[test]
+    fn metric_se3_reduces_inconsistent_cycle_cost_deterministically() {
+        let centres = trajectory_centres(2);
+        let nodes = vec![
+            synthetic_node(10, 0, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(20, 250, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(30, 500, 0..2, &Sim3::identity(), &centres, None),
+        ];
+        let first = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.2)),
+            Vector3::new(1.0, -0.5, 0.3),
+            1.0,
+        );
+        let second = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(-0.15, 0.1, 0.0)),
+            Vector3::new(-0.7, 0.4, 1.1),
+            1.0,
+        );
+        let expected = first.compose(&second);
+        let perturbation = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.04)),
+            Vector3::new(0.08, -0.03, 0.02),
+            1.0,
+        );
+        let edges = vec![
+            test_edge(1, 0, first, 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(2, 1, second, 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(
+                2,
+                0,
+                expected.compose(&perturbation),
+                10,
+                10,
+                Some(1.0),
+                Some(0.01),
+                500,
+            ),
+        ];
+        let mut first_components = connected_components(nodes.len(), &edges);
+        let first_report =
+            optimize_metric_se3_components(&nodes, &edges, &mut first_components).unwrap();
+        let mut second_components = connected_components(nodes.len(), &edges);
+        let second_report =
+            optimize_metric_se3_components(&nodes, &edges, &mut second_components).unwrap();
+        assert!(first_report[0].initial_cost > 1.0e-6);
+        assert!(first_report[0].final_cost < first_report[0].initial_cost);
+        assert_eq!(first_report, second_report);
+        assert_eq!(first_components, second_components);
+    }
+
+    #[test]
+    fn metric_se3_rejects_nonunit_and_handles_singleton_components() {
+        let centres = trajectory_centres(1);
+        let nodes = vec![
+            synthetic_node(10, 0, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(20, 250, 0..2, &Sim3::identity(), &centres, None),
+        ];
+        let nonunit = vec![test_edge(
+            1,
+            0,
+            Sim3::new(UnitQuaternion::identity(), Vector3::zeros(), 1.2),
+            10,
+            10,
+            Some(1.0),
+            Some(0.01),
+            250,
+        )];
+        let mut nonunit_components = connected_components(nodes.len(), &nonunit);
+        let error =
+            optimize_metric_se3_components(&nodes, &nonunit, &mut nonunit_components).unwrap_err();
+        assert!(error.contains("non-unit scale"));
+
+        let mut singleton_components = connected_components(nodes.len(), &[]);
+        let reports =
+            optimize_metric_se3_components(&nodes, &[], &mut singleton_components).unwrap();
+        assert_eq!(reports.len(), 2);
+        assert!(reports.iter().all(|report| {
+            report.edge_count == 0
+                && report.initial_cost == 0.0
+                && report.final_cost == 0.0
+                && report.iterations == 0
+        }));
+    }
+
+    #[test]
+    fn metric_se3_rejects_quality_transform_graph() {
+        let nodes = stitch_fixture_nodes();
+        let root = fixture_root("metric-quality-policy");
+        let error = stitch_nodes_with_policy(
+            &nodes,
+            &root,
+            &seam_alignment_config(),
+            ForestPolicy::Quality,
+            FrameOwnerPolicy::Newest,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.contains("requires --forest-policy traversal"));
+    }
+
+    #[test]
+    fn metric_se3_write_reparse_preserves_calibrated_stereo_baseline() {
+        let root = fixture_root("metric-stereo-roundtrip");
+        let centres = trajectory_centres(4);
+        let sensor_a = SE3::new(
+            UnitQuaternion::from_euler_angles(0.04, -0.08, 0.12),
+            Vector3::new(0.11, -0.03, 0.02),
+        );
+        let sensor_b = SE3::new(
+            UnitQuaternion::from_euler_angles(-0.13, 0.06, -0.05),
+            Vector3::new(-0.27, 0.08, 0.04),
+        );
+        let nodes = vec![
+            synthetic_stereo_node(10, 0, 0..5, &centres, &sensor_a, &sensor_b),
+            synthetic_stereo_node(20, 250, 0..5, &centres, &sensor_a, &sensor_b),
+            synthetic_stereo_node(30, 500, 0..5, &centres, &sensor_a, &sensor_b),
+        ];
+        let first = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.2)),
+            Vector3::new(1.0, -0.5, 0.3),
+            1.0,
+        );
+        let second = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(-0.15, 0.1, 0.0)),
+            Vector3::new(-0.7, 0.4, 1.1),
+            1.0,
+        );
+        let perturbation = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.04)),
+            Vector3::new(0.08, -0.03, 0.02),
+            1.0,
+        );
+        let edges = vec![
+            test_edge(1, 0, first.clone(), 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(2, 1, second.clone(), 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(
+                2,
+                0,
+                first.compose(&second).compose(&perturbation),
+                10,
+                10,
+                Some(1.0),
+                Some(0.01),
+                500,
+            ),
+        ];
+        let mut components = connected_components(nodes.len(), &edges);
+        let initial_node2 = components[0].atlas_from_node[&2].clone();
+        optimize_metric_se3_components(&nodes, &edges, &mut components).unwrap();
+        let optimized_node2 = components[0].atlas_from_node[&2].clone();
+        assert!(
+            (optimized_node2.translation - initial_node2.translation).norm() > 1.0e-6
+                || optimized_node2
+                    .rotation
+                    .rotation_to(&initial_node2.rotation)
+                    .angle()
+                    > 1.0e-6
+        );
+        let mut output_ids = BTreeSet::new();
+        let summary = publish_component(
+            0,
+            &nodes,
+            &components[0],
+            &root,
+            &mut output_ids,
+            FrameOwnerPolicy::Newest,
+        )
+        .unwrap();
+        assert_eq!(summary.frame_count, 5);
+        assert_eq!(summary.image_count, 10);
+        let parsed = parse_colmap_images(&root.join("component-000/images.txt")).unwrap();
+        assert_eq!(parsed.len(), 10);
+        for frame_id in 0..5 {
+            let expected_rig =
+                transform_pose_to_atlas(&optimized_node2, &nodes[2].frames[&frame_id].pose)
+                    .unwrap();
+            let expected_a = compose_camera_pose_from_rig(&sensor_a, &expected_rig).unwrap();
+            let expected_b = compose_camera_pose_from_rig(&sensor_b, &expected_rig).unwrap();
+            let output_a = parsed
+                .iter()
+                .find(|image| image.name == format!("node30_frame{frame_id}_sensor0.png"))
+                .unwrap();
+            let output_b = parsed
+                .iter()
+                .find(|image| image.name == format!("node30_frame{frame_id}_sensor1.png"))
+                .unwrap();
+            assert_se3_close(
+                &output_a.world_to_camera.world_to_camera,
+                &expected_a.world_to_camera,
+            );
+            assert_se3_close(
+                &output_b.world_to_camera.world_to_camera,
+                &expected_b.world_to_camera,
+            );
+            let input_baseline =
+                (expected_a.camera_center_world() - expected_b.camera_center_world()).norm();
+            let output_baseline = (output_a.world_to_camera.camera_center_world()
+                - output_b.world_to_camera.camera_center_world())
+            .norm();
+            assert!((output_baseline - input_baseline).abs() < 1.0e-12);
+        }
+    }
+
+    #[test]
+    fn quality_first_forest_prefers_high_support_cycle_edge_and_is_deterministic() {
+        let centres = trajectory_centres(2);
+        let nodes = vec![
+            synthetic_node(10, 0, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(20, 250, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(30, 500, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(40, 1_000, 0..2, &Sim3::identity(), &centres, None),
+        ];
+        let edges = vec![
+            // Lower support must lose even though its residual is smaller.
+            test_edge(1, 0, Sim3::identity(), 10, 8, Some(1.0), Some(0.001), 250),
+            test_edge(2, 1, Sim3::identity(), 9, 8, Some(0.8), Some(0.020), 250),
+            // The high-support cycle edge is selected first.
+            test_edge(2, 0, Sim3::identity(), 20, 8, Some(0.7), Some(0.800), 500),
+        ];
+        let all_edges = edges.clone();
+        let forest = select_quality_forest(&nodes, &edges);
+        assert_eq!(forest.len(), 2);
+        assert_eq!(
+            forest
+                .iter()
+                .map(|edge| (edge.source_index, edge.target_index))
+                .collect::<Vec<_>>(),
+            vec![(2, 0), (1, 0)]
+        );
+        let reversed = edges.into_iter().rev().collect::<Vec<_>>();
+        assert_eq!(forest, select_quality_forest(&nodes, &reversed));
+
+        let all_components = connected_components(nodes.len(), &all_edges);
+        let forest_components = connected_components(nodes.len(), &forest);
+        let component_nodes = |components: &[AtlasComponent]| {
+            components
+                .iter()
+                .map(|component| component.node_indices.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            component_nodes(&forest_components),
+            component_nodes(&all_components)
+        );
+        assert_eq!(forest_components.len(), 2);
+    }
+
+    #[test]
+    fn quality_forest_preserves_noncommuting_transform_direction() {
+        let centres = trajectory_centres(2);
+        let nodes = vec![
+            synthetic_node(10, 0, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(20, 250, 0..2, &Sim3::identity(), &centres, None),
+            synthetic_node(30, 500, 0..2, &Sim3::identity(), &centres, None),
+        ];
+        let first = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(0.0, 0.0, 0.2)),
+            Vector3::new(1.0, -0.5, 0.3),
+            1.2,
+        );
+        let second = Sim3::new(
+            UnitQuaternion::from_scaled_axis(Vector3::new(-0.15, 0.1, 0.0)),
+            Vector3::new(-0.7, 0.4, 1.1),
+            0.8,
+        );
+        let edges = vec![
+            test_edge(1, 0, first.clone(), 10, 10, Some(1.0), Some(0.01), 250),
+            test_edge(2, 1, second.clone(), 10, 10, Some(1.0), Some(0.01), 250),
+        ];
+        let forest = select_quality_forest(&nodes, &edges);
+        let components = connected_components(3, &forest);
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].anchor_index, 0);
+        assert_sim3_close(&components[0].atlas_from_node[&1], &first);
+        assert_sim3_close(&components[0].atlas_from_node[&2], &first.compose(&second));
+    }
+
+    #[test]
+    fn publishes_two_components_in_minimum_frame_order() {
+        let root = fixture_root("two-components");
+        let centres = trajectory_centres(111);
+        let nodes = vec![
+            synthetic_node(
+                10,
+                0,
+                0..16,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                11,
+                250,
+                8..24,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                12,
+                1_000,
+                100..112,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+        ];
+        assert_eq!(
+            nodes[0].frames[&8].images[0].image_id, nodes[1].frames[&8].images[0].image_id,
+            "the fixture must exercise repeated local COLMAP ids"
+        );
+        let result = stitch_nodes(&nodes, &root).unwrap();
+        assert_eq!(result.components.len(), 2);
+        assert_eq!(result.components[0].min_frame_id, Some(0));
+        assert_eq!(result.components[0].max_frame_id, Some(23));
+        assert_eq!(result.components[0].frame_count, 24);
+        assert_eq!(result.components[1].min_frame_id, Some(100));
+        assert_eq!(result.components[1].max_frame_id, Some(111));
+        assert_eq!(result.components[1].frame_count, 12);
+        assert_eq!(
+            fs::read_to_string(root.join("component-000/images.txt"))
+                .unwrap()
+                .matches("\n\n")
+                .count(),
+            24
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("component-001/images.txt"))
+                .unwrap()
+                .matches("\n\n")
+                .count(),
+            12
+        );
+        let mut output_ids = BTreeSet::new();
+        for component_index in 0..result.components.len() {
+            let output =
+                fs::read_to_string(root.join(format!("component-{component_index:03}/images.txt")))
+                    .unwrap();
+            for line in output
+                .lines()
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            {
+                let image_id = line
+                    .split_whitespace()
+                    .next()
+                    .unwrap()
+                    .parse::<u64>()
+                    .unwrap();
+                assert!(
+                    output_ids.insert(image_id),
+                    "global image id must be unique"
+                );
+            }
+        }
+        assert_eq!(
+            output_ids.len(),
+            result
+                .components
+                .iter()
+                .map(|component| component.image_count)
+                .sum()
+        );
+    }
+
+    #[test]
+    fn bad_bridge_connects_components_but_its_frames_are_not_published() {
+        let root = fixture_root("bad-bridge");
+        let centres = trajectory_centres(35);
+        let nodes = vec![
+            synthetic_node(
+                10,
+                0,
+                0..16,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                11,
+                250,
+                8..28,
+                &Sim3::identity(),
+                &centres,
+                Some(bad_step()),
+            ),
+            synthetic_node(
+                12,
+                500,
+                20..36,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+        ];
+        let result = stitch_nodes(&nodes, &root).unwrap();
+        assert_eq!(result.components.len(), 1);
+        assert_eq!(result.components[0].frame_count, 32);
+        assert!(result.seam_diagnostics.iter().any(|diagnostic| {
+            diagnostic.source_node_id == 11
+                && diagnostic.target_node_id == 10
+                && diagnostic.accepted
+                && diagnostic.selected_for_transform_graph
+        }));
+        assert!(result.seam_diagnostics.iter().any(|diagnostic| {
+            diagnostic.source_node_id == 12
+                && diagnostic.target_node_id == 11
+                && diagnostic.accepted
+                && diagnostic.selected_for_transform_graph
+        }));
+        let output = fs::read_to_string(root.join("component-000/images.txt")).unwrap();
+        for frame_id in 16..20 {
+            assert!(!output.contains(&format!("node11_frame{frame_id}.png")));
+        }
+        assert!(output.contains("node10_frame15.png"));
+        assert!(output.contains("node12_frame20.png"));
+    }
+
+    #[test]
+    fn stitching_and_output_are_deterministic() {
+        let nodes = stitch_fixture_nodes();
+        let first_root = fixture_root("determinism-first");
+        let second_root = fixture_root("determinism-second");
+        let first = stitch_nodes(&nodes, &first_root).unwrap();
+        let second = stitch_nodes(&nodes, &second_root).unwrap();
+        assert_eq!(first, second);
+        for component_index in 0..first.components.len() {
+            let relative = format!("component-{component_index:03}/images.txt");
+            assert_eq!(
+                fs::read(first_root.join(&relative)).unwrap(),
+                fs::read(second_root.join(&relative)).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn seam_diagnostics_distinguish_wrapper_and_nested_rejections() {
+        let collinear_centres = (0..=10)
+            .map(|frame_id| (frame_id, Point3::new(frame_id as f64, 0.0, 0.0)))
+            .collect::<BTreeMap<_, _>>();
+        let nested = build_seam_graph(&[
+            synthetic_node(
+                10,
+                0,
+                0..11,
+                &Sim3::identity(),
+                &collinear_centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                11,
+                250,
+                0..11,
+                &Sim3::identity(),
+                &collinear_centres,
+                Some(healthy_step()),
+            ),
+        ])
+        .1;
+        assert_eq!(nested.len(), 1);
+        assert!(!nested[0].selected_for_transform_graph);
+        assert_eq!(nested[0].reason, "Sim3Rejected");
+        assert_eq!(
+            nested[0].wrapper_rejection_reason.as_deref(),
+            Some("Sim3Rejected")
+        );
+        assert_eq!(
+            nested[0].sim3_rejection_reason.as_deref(),
+            Some("DegenerateSourceGeometry")
+        );
+        assert_eq!(nested[0].sim3_rejection_inlier_count, Some(0));
+        assert_eq!(nested[0].sim3_rejection_inlier_ratio, Some(0.0));
+        assert_eq!(nested[0].sim3_rejection_mean_residual_ratio, None);
+
+        let centres = trajectory_centres(15);
+        let wrapper = build_seam_graph(&[
+            synthetic_node(
+                20,
+                0,
+                0..8,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+            synthetic_node(
+                21,
+                250,
+                8..16,
+                &Sim3::identity(),
+                &centres,
+                Some(healthy_step()),
+            ),
+        ])
+        .1;
+        assert_eq!(wrapper.len(), 1);
+        assert_eq!(wrapper[0].reason, "InsufficientCommonFrames");
+        assert_eq!(
+            wrapper[0].wrapper_rejection_reason.as_deref(),
+            Some("InsufficientCommonFrames")
+        );
+        assert_eq!(wrapper[0].sim3_rejection_reason, None);
+        assert_eq!(wrapper[0].sim3_rejection_inlier_count, None);
+        assert!(!wrapper[0].selected_for_transform_graph);
+    }
+}

--- a/pipelines/slam/src/lib.rs
+++ b/pipelines/slam/src/lib.rs
@@ -94,6 +94,14 @@ pub use submap_alignment::{
     SubmapSim3RejectionReason, VerifiedSubmapConstraint,
 };
 
+pub mod rig_submap_alignment;
+pub use rig_submap_alignment::{
+    estimate_rig_submap_camera_centre_constraint, estimate_rig_submap_sim3_constraint,
+    RigSubmapAlignmentConfig, RigSubmapAlignmentDiagnostics, RigSubmapAlignmentError,
+    RigSubmapAlignmentRejection, RigSubmapAlignmentRejectionReason, RigSubmapAlignmentResult,
+    RigSubmapInputSide,
+};
+
 pub mod hierarchical_submap_graph;
 pub use hierarchical_submap_graph::{
     HierarchicalSubmapGraph, HierarchicalSubmapGraphError, HierarchicalSubmapId,

--- a/pipelines/slam/src/lib.rs
+++ b/pipelines/slam/src/lib.rs
@@ -98,8 +98,8 @@ pub mod rig_submap_alignment;
 pub use rig_submap_alignment::{
     estimate_rig_submap_camera_centre_constraint, estimate_rig_submap_sim3_constraint,
     RigSubmapAlignmentConfig, RigSubmapAlignmentDiagnostics, RigSubmapAlignmentError,
-    RigSubmapAlignmentRejection, RigSubmapAlignmentRejectionReason, RigSubmapAlignmentResult,
-    RigSubmapInputSide,
+    RigSubmapAlignmentMethod, RigSubmapAlignmentRejection, RigSubmapAlignmentRejectionReason,
+    RigSubmapAlignmentResult, RigSubmapBoundarySampling, RigSubmapInputSide,
 };
 
 pub mod hierarchical_submap_graph;

--- a/pipelines/slam/src/rig_submap_alignment.rs
+++ b/pipelines/slam/src/rig_submap_alignment.rs
@@ -1,0 +1,792 @@
+//! Bounded camera-centre alignment between independently gauged rig submaps.
+//!
+//! A rig frame is represented once in each local submap by its world-to-camera
+//! [`Pose`].  The adapter turns the common rig-frame camera centres into the
+//! [`SubmapPointMatch`] representation consumed by the landmark-only Sim(3)
+//! verifier.  It also derives the local-gauge rotation from the two camera
+//! attitudes and uses a bounded medoid consensus before invoking that
+//! verifier.
+//!
+//! The input may contain a large trajectory, but all quadratic work is over
+//! the retained boundary only.  Common rig-frame ids are sorted in ascending
+//! order and the earliest `max_boundary_frames` are retained.  This makes the
+//! adapter suitable for a moving seam whose newest window is still being
+//! registered without allowing the cost of a frame Cartesian product to grow
+//! with the full trajectories.
+//!
+//! Callers conventionally pass the newer submap window as `source_frames` and
+//! the previous/Atlas-adjacent window as `target_frames`.  In that orientation,
+//! the earliest common global rig-frame ids are the seam boundary by
+//! construction.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use nalgebra::{Point3, UnitQuaternion};
+use visloc_core::geometry::Pose;
+
+use crate::{
+    estimate_submap_sim3_constraint, SubmapPointMatch, SubmapSim3AlignmentConfig,
+    SubmapSim3Constraint, SubmapSim3Rejection,
+};
+
+/// Configuration for the bounded rig-frame seam adapter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RigSubmapAlignmentConfig {
+    /// Maximum number of common rig frames retained for the seam.  The
+    /// retained ids are always the earliest ids in ascending order.
+    pub max_boundary_frames: usize,
+    /// Angular radius of the independent local-gauge rotation consensus.
+    pub rotation_consensus_deg: f64,
+    /// Minimum fraction of retained rig-frame rotations in that consensus.
+    pub min_rotation_consensus_ratio: f64,
+    /// Existing robust 3D Sim(3) alignment and residual gates.
+    pub alignment: SubmapSim3AlignmentConfig,
+}
+
+impl Default for RigSubmapAlignmentConfig {
+    fn default() -> Self {
+        Self {
+            max_boundary_frames: 64,
+            rotation_consensus_deg: 5.0,
+            min_rotation_consensus_ratio: 0.6,
+            alignment: SubmapSim3AlignmentConfig::default(),
+        }
+    }
+}
+
+/// Why a rig-submap camera-centre seam was not admitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RigSubmapAlignmentRejectionReason {
+    /// The bounded seam or rotation-consensus settings are not finite or are
+    /// outside their fail-closed domains.
+    InvalidConfiguration,
+    /// A source or target trajectory contains the same global rig-frame id
+    /// more than once.
+    DuplicateFrameId,
+    /// A source or target pose (including its rotation or translation) is not
+    /// finite.
+    NonFinitePose,
+    /// A finite pose produced a non-finite camera centre.
+    NonFiniteCameraCenter,
+    /// The retained common boundary is smaller than the Sim(3) minimum.
+    InsufficientCommonFrames,
+    /// The independent camera-attitude rotations do not form a large enough
+    /// consensus cluster.
+    LowRotationConsensus,
+    /// The existing robust Sim(3) estimator rejected the camera-centre
+    /// matches.  The detailed rejection is retained in the error.
+    Sim3Rejected,
+}
+
+/// Side of a rig-frame input that supplied a malformed record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RigSubmapInputSide {
+    Source,
+    Target,
+}
+
+/// Deterministic and auditable counts from a rig-submap alignment attempt.
+///
+/// Counts are populated on both success and rejection.  In particular,
+/// `common_frame_count` is the full unique intersection while
+/// `retained_frame_count` is the bounded seam actually passed to the Sim(3)
+/// estimator.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RigSubmapAlignmentDiagnostics {
+    pub source_frame_count: usize,
+    pub target_frame_count: usize,
+    pub source_unique_frame_count: usize,
+    pub target_unique_frame_count: usize,
+    pub common_frame_count: usize,
+    pub retained_frame_count: usize,
+    pub retained_frame_ids: Vec<u64>,
+    pub rotation_candidate_count: usize,
+    pub rotation_consensus_count: usize,
+    pub rotation_consensus_ratio: f64,
+    pub rotation_consensus_max_disagreement_deg: f64,
+    pub rotation_consensus_threshold_deg: f64,
+    pub rotation_medoid_frame_id: Option<u64>,
+    pub camera_centre_match_count: usize,
+    pub sim3_inlier_count: Option<usize>,
+    pub sim3_inlier_ratio: Option<f64>,
+}
+
+impl RigSubmapAlignmentDiagnostics {
+    fn from_counts(
+        source_frame_count: usize,
+        target_frame_count: usize,
+        source_unique_frame_count: usize,
+        target_unique_frame_count: usize,
+        common_frame_count: usize,
+        retained_frame_ids: Vec<u64>,
+        rotation_consensus_threshold_deg: f64,
+    ) -> Self {
+        Self {
+            source_frame_count,
+            target_frame_count,
+            source_unique_frame_count,
+            target_unique_frame_count,
+            common_frame_count,
+            retained_frame_count: retained_frame_ids.len(),
+            retained_frame_ids,
+            rotation_candidate_count: 0,
+            rotation_consensus_count: 0,
+            rotation_consensus_ratio: 0.0,
+            rotation_consensus_max_disagreement_deg: 0.0,
+            rotation_consensus_threshold_deg,
+            rotation_medoid_frame_id: None,
+            camera_centre_match_count: 0,
+            sim3_inlier_count: None,
+            sim3_inlier_ratio: None,
+        }
+    }
+}
+
+/// Typed rejection carrying the partial seam diagnostics and, when the
+/// wrapper reached the robust estimator, its detailed rejection.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RigSubmapAlignmentRejection {
+    pub reason: RigSubmapAlignmentRejectionReason,
+    pub diagnostics: Box<RigSubmapAlignmentDiagnostics>,
+    pub offending_side: Option<RigSubmapInputSide>,
+    pub offending_frame_id: Option<u64>,
+    pub sim3_rejection: Option<Box<SubmapSim3Rejection>>,
+}
+
+/// Error alias using the conventional `Error` name for callers that prefer
+/// `Result<_, RigSubmapAlignmentError>`.
+pub type RigSubmapAlignmentError = RigSubmapAlignmentRejection;
+
+impl fmt::Display for RigSubmapAlignmentRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.reason {
+            RigSubmapAlignmentRejectionReason::InvalidConfiguration => write!(
+                f,
+                "rig-submap alignment has an invalid boundary or rotation-consensus configuration"
+            ),
+            RigSubmapAlignmentRejectionReason::DuplicateFrameId => {
+                write!(f, "rig-submap seam contains a duplicate frame id")
+            }
+            RigSubmapAlignmentRejectionReason::NonFinitePose => {
+                write!(f, "rig-submap seam contains a non-finite pose")
+            }
+            RigSubmapAlignmentRejectionReason::NonFiniteCameraCenter => {
+                write!(f, "rig-submap seam contains a non-finite camera centre")
+            }
+            RigSubmapAlignmentRejectionReason::InsufficientCommonFrames => write!(
+                f,
+                "rig-submap seam has {} retained common frames",
+                self.diagnostics.retained_frame_count
+            ),
+            RigSubmapAlignmentRejectionReason::LowRotationConsensus => write!(
+                f,
+                "rig-submap rotation consensus ratio {} is below the configured minimum",
+                self.diagnostics.rotation_consensus_ratio,
+            ),
+            RigSubmapAlignmentRejectionReason::Sim3Rejected => {
+                write!(f, "rig-submap Sim(3) alignment was rejected")
+            }
+        }
+    }
+}
+
+impl Error for RigSubmapAlignmentRejection {}
+
+/// A verified camera-centre seam constraint plus the bounded evidence used to
+/// admit it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RigSubmapAlignmentResult {
+    pub constraint: SubmapSim3Constraint,
+    pub diagnostics: RigSubmapAlignmentDiagnostics,
+}
+
+/// Estimate a `target local <- source local` Sim(3) from corresponding global
+/// rig-frame poses in two independently reconstructed submap gauges.
+///
+/// Callers should pass the newer submap window as `source_frames` and the
+/// previous/Atlas-adjacent window as `target_frames`; the earliest common ids
+/// then identify the new-window seam boundary.
+///
+/// The source and target slices are indexed by global rig-frame id.  Duplicate
+/// ids are rejected.  Their unique intersection is sorted by id and truncated
+/// to `config.max_boundary_frames` before any rotation consensus or Sim(3)
+/// work.  For each retained frame, the camera-centre pair is represented by a
+/// [`SubmapPointMatch`] whose source and target ids are that global rig-frame
+/// id.  The independent rotation candidate is exactly
+/// `q_target_cw.inverse() * q_source_cw`.
+pub fn estimate_rig_submap_sim3_constraint(
+    source_submap_id: u64,
+    target_submap_id: u64,
+    source_frames: &[(u64, Pose)],
+    target_frames: &[(u64, Pose)],
+    config: &RigSubmapAlignmentConfig,
+) -> Result<RigSubmapAlignmentResult, RigSubmapAlignmentRejection> {
+    if !valid_config(config) {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::InvalidConfiguration,
+            diagnostics: Box::new(RigSubmapAlignmentDiagnostics::from_counts(
+                source_frames.len(),
+                target_frames.len(),
+                0,
+                0,
+                0,
+                Vec::new(),
+                config.rotation_consensus_deg,
+            )),
+            offending_side: None,
+            offending_frame_id: None,
+            sim3_rejection: None,
+        });
+    }
+
+    let source_unique = unique_frame_ids(source_frames);
+    let target_unique = unique_frame_ids(target_frames);
+    let base_diagnostics = RigSubmapAlignmentDiagnostics::from_counts(
+        source_frames.len(),
+        target_frames.len(),
+        source_unique.len(),
+        target_unique.len(),
+        0,
+        Vec::new(),
+        config.rotation_consensus_deg,
+    );
+
+    if source_unique.len() != source_frames.len() {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::DuplicateFrameId,
+            diagnostics: Box::new(base_diagnostics),
+            offending_side: Some(RigSubmapInputSide::Source),
+            offending_frame_id: duplicate_frame_id(source_frames),
+            sim3_rejection: None,
+        });
+    }
+    if target_unique.len() != target_frames.len() {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::DuplicateFrameId,
+            diagnostics: Box::new(base_diagnostics),
+            offending_side: Some(RigSubmapInputSide::Target),
+            offending_frame_id: duplicate_frame_id(target_frames),
+            sim3_rejection: None,
+        });
+    }
+
+    if let Some((side, frame_id)) = first_nonfinite_pose(source_frames, target_frames) {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::NonFinitePose,
+            diagnostics: Box::new(base_diagnostics),
+            offending_side: Some(side),
+            offending_frame_id: Some(frame_id),
+            sim3_rejection: None,
+        });
+    }
+
+    if let Some((side, frame_id)) = first_nonfinite_camera_center(source_frames, target_frames) {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::NonFiniteCameraCenter,
+            diagnostics: Box::new(base_diagnostics),
+            offending_side: Some(side),
+            offending_frame_id: Some(frame_id),
+            sim3_rejection: None,
+        });
+    }
+
+    let common_frame_ids = source_unique
+        .keys()
+        .filter(|frame_id| target_unique.contains_key(frame_id))
+        .copied()
+        .collect::<Vec<_>>();
+    let retained_frame_ids = common_frame_ids
+        .iter()
+        .take(config.max_boundary_frames)
+        .copied()
+        .collect::<Vec<_>>();
+    let mut diagnostics = RigSubmapAlignmentDiagnostics::from_counts(
+        source_frames.len(),
+        target_frames.len(),
+        source_unique.len(),
+        target_unique.len(),
+        common_frame_ids.len(),
+        retained_frame_ids.clone(),
+        config.rotation_consensus_deg,
+    );
+
+    let required_common_frames = config.alignment.min_correspondences.max(3);
+    if retained_frame_ids.len() < required_common_frames {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::InsufficientCommonFrames,
+            diagnostics: Box::new(diagnostics),
+            offending_side: None,
+            offending_frame_id: None,
+            sim3_rejection: None,
+        });
+    }
+
+    let mut matches = Vec::with_capacity(retained_frame_ids.len());
+    let mut rotations = Vec::with_capacity(retained_frame_ids.len());
+    for frame_id in &retained_frame_ids {
+        let source_pose = source_unique
+            .get(frame_id)
+            .expect("retained frame id came from source map");
+        let target_pose = target_unique
+            .get(frame_id)
+            .expect("retained frame id came from target map");
+        let source_center = source_pose.camera_center_world();
+        let target_center = target_pose.camera_center_world();
+        if !point_is_finite(&source_center) {
+            diagnostics.camera_centre_match_count = matches.len();
+            return Err(RigSubmapAlignmentRejection {
+                reason: RigSubmapAlignmentRejectionReason::NonFiniteCameraCenter,
+                diagnostics: Box::new(diagnostics),
+                offending_side: Some(RigSubmapInputSide::Source),
+                offending_frame_id: Some(*frame_id),
+                sim3_rejection: None,
+            });
+        }
+        if !point_is_finite(&target_center) {
+            diagnostics.camera_centre_match_count = matches.len();
+            return Err(RigSubmapAlignmentRejection {
+                reason: RigSubmapAlignmentRejectionReason::NonFiniteCameraCenter,
+                diagnostics: Box::new(diagnostics),
+                offending_side: Some(RigSubmapInputSide::Target),
+                offending_frame_id: Some(*frame_id),
+                sim3_rejection: None,
+            });
+        }
+        matches.push(SubmapPointMatch {
+            source_landmark_id: *frame_id,
+            target_landmark_id: *frame_id,
+            source_point: source_center,
+            target_point: target_center,
+        });
+        rotations.push(IndependentRotationCandidate {
+            frame_id: *frame_id,
+            rotation: target_pose.world_to_camera.rotation.inverse()
+                * source_pose.world_to_camera.rotation,
+        });
+    }
+    diagnostics.camera_centre_match_count = matches.len();
+    diagnostics.rotation_candidate_count = rotations.len();
+
+    let consensus = rotation_consensus(&rotations, config.rotation_consensus_deg);
+    diagnostics.rotation_consensus_count = consensus.indices.len();
+    diagnostics.rotation_consensus_ratio =
+        consensus.indices.len() as f64 / rotations.len().max(1) as f64;
+    diagnostics.rotation_consensus_max_disagreement_deg = consensus.max_disagreement_deg;
+    diagnostics.rotation_medoid_frame_id = Some(consensus.medoid_frame_id);
+    if !diagnostics.rotation_consensus_ratio.is_finite()
+        || diagnostics.rotation_consensus_ratio < config.min_rotation_consensus_ratio
+    {
+        return Err(RigSubmapAlignmentRejection {
+            reason: RigSubmapAlignmentRejectionReason::LowRotationConsensus,
+            diagnostics: Box::new(diagnostics),
+            offending_side: None,
+            offending_frame_id: None,
+            sim3_rejection: None,
+        });
+    }
+
+    let constraint = match estimate_submap_sim3_constraint(
+        source_submap_id,
+        target_submap_id,
+        &matches,
+        &consensus.rotation,
+        &config.alignment,
+    ) {
+        Ok(constraint) => constraint,
+        Err(sim3_rejection) => {
+            diagnostics.sim3_inlier_count = Some(sim3_rejection.inlier_count);
+            diagnostics.sim3_inlier_ratio = Some(sim3_rejection.inlier_ratio);
+            return Err(RigSubmapAlignmentRejection {
+                reason: RigSubmapAlignmentRejectionReason::Sim3Rejected,
+                diagnostics: Box::new(diagnostics),
+                offending_side: None,
+                offending_frame_id: None,
+                sim3_rejection: Some(Box::new(sim3_rejection)),
+            });
+        }
+    };
+    diagnostics.sim3_inlier_count = Some(constraint.inlier_match_indices.len());
+    diagnostics.sim3_inlier_ratio = Some(constraint.inlier_ratio);
+    Ok(RigSubmapAlignmentResult {
+        constraint,
+        diagnostics,
+    })
+}
+
+/// Alias emphasizing that the returned Sim(3) is built from rig camera
+/// centres.  It has the same bounded implementation and result type as
+/// [`estimate_rig_submap_sim3_constraint`].
+pub fn estimate_rig_submap_camera_centre_constraint(
+    source_submap_id: u64,
+    target_submap_id: u64,
+    source_frames: &[(u64, Pose)],
+    target_frames: &[(u64, Pose)],
+    config: &RigSubmapAlignmentConfig,
+) -> Result<RigSubmapAlignmentResult, RigSubmapAlignmentRejection> {
+    estimate_rig_submap_sim3_constraint(
+        source_submap_id,
+        target_submap_id,
+        source_frames,
+        target_frames,
+        config,
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IndependentRotationCandidate {
+    frame_id: u64,
+    rotation: UnitQuaternion<f64>,
+}
+
+#[derive(Debug, Clone)]
+struct RotationConsensus {
+    rotation: UnitQuaternion<f64>,
+    medoid_frame_id: u64,
+    indices: Vec<usize>,
+    max_disagreement_deg: f64,
+}
+
+/// Select the largest angular cluster and use its deterministic medoid as the
+/// independent rotation.  The pairwise matrix is computed once, so this is
+/// O(B²) in both rotations and angular evaluations.
+fn rotation_consensus(
+    candidates: &[IndependentRotationCandidate],
+    radius_deg: f64,
+) -> RotationConsensus {
+    debug_assert!(!candidates.is_empty());
+    let count = candidates.len();
+    let radius = radius_deg.max(0.0).to_radians();
+    let mut distances = vec![vec![0.0; count]; count];
+    for i in 0..count {
+        for j in (i + 1)..count {
+            let distance = candidates[i]
+                .rotation
+                .rotation_to(&candidates[j].rotation)
+                .angle();
+            distances[i][j] = distance;
+            distances[j][i] = distance;
+        }
+    }
+
+    let mut medoid_index = 0;
+    let mut medoid_support = 0;
+    let mut medoid_distance_sum = f64::INFINITY;
+    let mut medoid_cluster = Vec::new();
+    for candidate_index in 0..count {
+        let cluster = (0..count)
+            .filter(|&other_index| distances[candidate_index][other_index] <= radius)
+            .collect::<Vec<_>>();
+        let support = cluster.len();
+        let distance_sum = cluster
+            .iter()
+            .map(|&other_index| distances[candidate_index][other_index])
+            .sum::<f64>();
+        let frame_id = candidates[candidate_index].frame_id;
+        let current_frame_id = candidates[medoid_index].frame_id;
+        let better = support > medoid_support
+            || (support == medoid_support
+                && (distance_sum < medoid_distance_sum
+                    || (distance_sum == medoid_distance_sum && frame_id < current_frame_id)));
+        if better {
+            medoid_index = candidate_index;
+            medoid_support = support;
+            medoid_distance_sum = distance_sum;
+            medoid_cluster = cluster;
+        }
+    }
+    if medoid_cluster.is_empty() {
+        medoid_cluster.push(medoid_index);
+    }
+    // The input is sorted by frame id before this function is called.  Keep
+    // the cluster in that order so the inlier evidence is reproducible.
+    medoid_cluster.sort_unstable();
+    let max_disagreement_deg = medoid_cluster
+        .iter()
+        .map(|&index| distances[medoid_index][index])
+        .fold(0.0_f64, f64::max)
+        .to_degrees();
+    RotationConsensus {
+        rotation: candidates[medoid_index].rotation,
+        medoid_frame_id: candidates[medoid_index].frame_id,
+        indices: medoid_cluster,
+        max_disagreement_deg,
+    }
+}
+
+fn unique_frame_ids(frames: &[(u64, Pose)]) -> BTreeMap<u64, &Pose> {
+    let mut unique = BTreeMap::new();
+    for (frame_id, pose) in frames {
+        unique.entry(*frame_id).or_insert(pose);
+    }
+    unique
+}
+
+fn valid_config(config: &RigSubmapAlignmentConfig) -> bool {
+    config.max_boundary_frames > 0
+        && config.rotation_consensus_deg.is_finite()
+        && config.rotation_consensus_deg > 0.0
+        && config.rotation_consensus_deg <= 180.0
+        && config.min_rotation_consensus_ratio.is_finite()
+        && config.min_rotation_consensus_ratio > 0.0
+        && config.min_rotation_consensus_ratio <= 1.0
+}
+
+fn duplicate_frame_id(frames: &[(u64, Pose)]) -> Option<u64> {
+    let mut seen = BTreeSet::new();
+    frames
+        .iter()
+        .find_map(|(frame_id, _)| (!seen.insert(*frame_id)).then_some(*frame_id))
+}
+
+fn first_nonfinite_pose(
+    source_frames: &[(u64, Pose)],
+    target_frames: &[(u64, Pose)],
+) -> Option<(RigSubmapInputSide, u64)> {
+    source_frames
+        .iter()
+        .find_map(|(frame_id, pose)| {
+            (!pose_is_finite(pose)).then_some((RigSubmapInputSide::Source, *frame_id))
+        })
+        .or_else(|| {
+            target_frames.iter().find_map(|(frame_id, pose)| {
+                (!pose_is_finite(pose)).then_some((RigSubmapInputSide::Target, *frame_id))
+            })
+        })
+}
+
+fn first_nonfinite_camera_center(
+    source_frames: &[(u64, Pose)],
+    target_frames: &[(u64, Pose)],
+) -> Option<(RigSubmapInputSide, u64)> {
+    source_frames
+        .iter()
+        .find_map(|(frame_id, pose)| {
+            (!point_is_finite(&pose.camera_center_world()))
+                .then_some((RigSubmapInputSide::Source, *frame_id))
+        })
+        .or_else(|| {
+            target_frames.iter().find_map(|(frame_id, pose)| {
+                (!point_is_finite(&pose.camera_center_world()))
+                    .then_some((RigSubmapInputSide::Target, *frame_id))
+            })
+        })
+}
+
+fn pose_is_finite(pose: &Pose) -> bool {
+    pose.world_to_camera
+        .rotation
+        .coords
+        .iter()
+        .all(|value| value.is_finite())
+        && pose
+            .world_to_camera
+            .translation
+            .iter()
+            .all(|value| value.is_finite())
+}
+
+fn point_is_finite(point: &Point3<f64>) -> bool {
+    point.coords.iter().all(|value| value.is_finite())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Point3, UnitQuaternion, Vector3};
+    use visloc_core::geometry::Sim3;
+
+    type RigFrames = Vec<(u64, Pose)>;
+
+    fn pose_from_center(rotation: UnitQuaternion<f64>, center: Point3<f64>) -> Pose {
+        Pose::from_world_to_camera(rotation, -rotation.transform_vector(&center.coords))
+    }
+
+    fn fixture(count: usize) -> (RigFrames, RigFrames, Sim3) {
+        let truth = Sim3::new(
+            UnitQuaternion::from_euler_angles(0.09, -0.13, 0.2),
+            Vector3::new(1.3, -0.7, 0.5),
+            2.4,
+        );
+        let mut source = Vec::with_capacity(count);
+        let mut target = Vec::with_capacity(count);
+        for index in 0..count {
+            let frame_id = index as u64;
+            let centre = Point3::new(
+                index as f64 * 0.17,
+                (index as f64 * 0.31).sin() * 0.7,
+                (index as f64 * 0.21).cos() * 0.5,
+            );
+            let source_rotation = UnitQuaternion::from_euler_angles(
+                index as f64 * 0.01,
+                index as f64 * -0.007,
+                index as f64 * 0.013,
+            );
+            let target_center = truth.transform_point(&centre);
+            let target_rotation = source_rotation * truth.rotation.inverse();
+            source.push((frame_id, pose_from_center(source_rotation, centre)));
+            target.push((frame_id, pose_from_center(target_rotation, target_center)));
+        }
+        // Deliberately scramble input order: the adapter's result must still
+        // use the ascending frame-id seam boundary.
+        source.reverse();
+        target.rotate_left((count / 3).min(count));
+        (source, target, truth)
+    }
+
+    fn permissive_config() -> RigSubmapAlignmentConfig {
+        RigSubmapAlignmentConfig {
+            alignment: SubmapSim3AlignmentConfig {
+                min_correspondences: 3,
+                min_inliers: 3,
+                min_inlier_ratio: 0.5,
+                max_inlier_residual_ratio: 0.1,
+                max_mean_residual_ratio: 0.1,
+                max_rotation_disagreement_deg: 10.0,
+                max_leave_one_out_log_scale_mad: 0.1,
+                min_second_to_first_singular_ratio: 0.0,
+                ransac_iterations: 512,
+                ..SubmapSim3AlignmentConfig::default()
+            },
+            ..RigSubmapAlignmentConfig::default()
+        }
+    }
+
+    #[test]
+    fn known_sim3_is_recovered_from_rig_camera_centres() {
+        let (source, target, truth) = fixture(24);
+        let result =
+            estimate_rig_submap_sim3_constraint(11, 17, &source, &target, &permissive_config())
+                .expect("known Sim3 should pass");
+        assert_eq!(result.constraint.source_submap_id, 11);
+        assert_eq!(result.constraint.target_submap_id, 17);
+        assert!((result.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-9);
+        assert!(
+            (result.constraint.target_from_source.translation - truth.translation).norm() < 1.0e-9
+        );
+        assert!(
+            result
+                .constraint
+                .target_from_source
+                .rotation
+                .rotation_to(&truth.rotation)
+                .angle()
+                < 1.0e-9
+        );
+        assert_eq!(
+            result.diagnostics.retained_frame_ids,
+            (0..24).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn centre_and_rotation_outliers_are_rejected_by_the_two_consensus_stages() {
+        let (source, mut target, truth) = fixture(30);
+        for index in [2_usize, 5, 8] {
+            target[index].1 = pose_from_center(
+                UnitQuaternion::from_euler_angles(1.2, -0.4, 0.7),
+                Point3::new(40.0 + index as f64, -30.0, 20.0),
+            );
+        }
+        let result =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &permissive_config())
+                .expect("minority outliers should be robustly rejected");
+        assert!(result.diagnostics.rotation_consensus_ratio > 0.8);
+        assert!(result.constraint.inlier_ratio > 0.8);
+        assert!((result.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-6);
+        assert!(
+            (result.constraint.target_from_source.translation - truth.translation).norm() < 1.0e-6
+        );
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected_before_intersection() {
+        let (mut source, target, _) = fixture(12);
+        source.push(
+            source
+                .iter()
+                .find(|(frame_id, _)| *frame_id == 0)
+                .unwrap()
+                .clone(),
+        );
+        let error =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &permissive_config())
+                .unwrap_err();
+        assert_eq!(
+            error.reason,
+            RigSubmapAlignmentRejectionReason::DuplicateFrameId
+        );
+        assert_eq!(error.offending_side, Some(RigSubmapInputSide::Source));
+        assert_eq!(error.offending_frame_id, Some(0));
+    }
+
+    #[test]
+    fn earliest_boundary_cap_is_sorted_and_deterministic() {
+        let (source, target, _) = fixture(20);
+        let mut config = permissive_config();
+        config.max_boundary_frames = 5;
+        let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("five-frame seam should pass");
+        let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("same input should be deterministic");
+        assert_eq!(first, second);
+        assert_eq!(first.diagnostics.retained_frame_ids, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn low_rotation_consensus_is_typed() {
+        let (source, mut target, _) = fixture(12);
+        for (index, (_, target_pose)) in target.iter_mut().enumerate() {
+            let centre = target_pose.camera_center_world();
+            let rotation = UnitQuaternion::from_euler_angles(0.0, 0.0, (index as f64 + 1.0) * 0.4);
+            *target_pose = pose_from_center(rotation, centre);
+        }
+        let mut config = permissive_config();
+        config.min_rotation_consensus_ratio = 0.9;
+        let error =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config).unwrap_err();
+        assert_eq!(
+            error.reason,
+            RigSubmapAlignmentRejectionReason::LowRotationConsensus
+        );
+    }
+
+    #[test]
+    fn invalid_boundary_and_rotation_configurations_fail_closed_at_entry() {
+        let (source, target, _) = fixture(3);
+        let mut invalid_configs = Vec::new();
+
+        let mut config = permissive_config();
+        config.max_boundary_frames = 0;
+        invalid_configs.push(config);
+        let mut config = permissive_config();
+        config.rotation_consensus_deg = 0.0;
+        invalid_configs.push(config);
+        let mut config = permissive_config();
+        config.rotation_consensus_deg = 180.1;
+        invalid_configs.push(config);
+        let mut config = permissive_config();
+        config.rotation_consensus_deg = f64::NAN;
+        invalid_configs.push(config);
+        let mut config = permissive_config();
+        config.min_rotation_consensus_ratio = 0.0;
+        invalid_configs.push(config);
+        let mut config = permissive_config();
+        config.min_rotation_consensus_ratio = 1.1;
+        invalid_configs.push(config);
+        let mut config = permissive_config();
+        config.min_rotation_consensus_ratio = f64::NAN;
+        invalid_configs.push(config);
+
+        for config in invalid_configs {
+            let error = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+                .expect_err("invalid configuration must reject before alignment");
+            assert_eq!(
+                error.reason,
+                RigSubmapAlignmentRejectionReason::InvalidConfiguration
+            );
+            assert!(error.to_string().contains("invalid"));
+        }
+    }
+}

--- a/pipelines/slam/src/rig_submap_alignment.rs
+++ b/pipelines/slam/src/rig_submap_alignment.rs
@@ -1828,8 +1828,8 @@ mod tests {
             first.diagnostics.alignment_method,
             Some(RigSubmapAlignmentMethod::FixedRotationPrimary)
         );
-        assert!(first.diagnostics.fallback_attempted == false);
-        assert!(first.diagnostics.fallback_used == false);
+        assert!(!first.diagnostics.fallback_attempted);
+        assert!(!first.diagnostics.fallback_used);
         assert!(first.constraint.inlier_ratio > 0.8);
         assert_eq!(first.constraint.target_from_source.scale, 1.0);
         assert!(

--- a/pipelines/slam/src/rig_submap_alignment.rs
+++ b/pipelines/slam/src/rig_submap_alignment.rs
@@ -9,49 +9,116 @@
 //!
 //! The input may contain a large trajectory, but all quadratic work is over
 //! the retained boundary only.  Common rig-frame ids are sorted in ascending
-//! order and the earliest `max_boundary_frames` are retained.  This makes the
-//! adapter suitable for a moving seam whose newest window is still being
-//! registered without allowing the cost of a frame Cartesian product to grow
-//! with the full trajectories.
+//! order and, by default, the earliest `max_boundary_frames` are retained.
+//! An opt-in uniform sampler can instead cover the whole common-id span while
+//! remaining bounded.  This makes the adapter suitable for a moving seam
+//! whose newest window is still being registered without allowing the cost of
+//! a frame Cartesian product to grow with the full trajectories.
 //!
 //! Callers conventionally pass the newer submap window as `source_frames` and
 //! the previous/Atlas-adjacent window as `target_frames`.  In that orientation,
 //! the earliest common global rig-frame ids are the seam boundary by
-//! construction.
+//! construction unless the uniform boundary sampler is explicitly selected.
+//!
+//! The optional fixed-rotation and generic fallback paths are deliberately
+//! wrapper-only and opt-in. They retain at most B = `max_boundary_frames`
+//! matches (64 by default). Rotation consensus and median pairwise scene
+//! scale require O(B²) temporary state, not an all-image matrix. The public
+//! configuration permits larger B; callers must retain a suitable cap.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
-use nalgebra::{Point3, UnitQuaternion};
-use visloc_core::geometry::Pose;
+use nalgebra::{Point3, UnitQuaternion, Vector3};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use visloc_core::geometry::{Pose, Sim3};
 
 use crate::{
     estimate_submap_sim3_constraint, SubmapPointMatch, SubmapSim3AlignmentConfig,
-    SubmapSim3Constraint, SubmapSim3Rejection,
+    SubmapSim3Constraint, SubmapSim3Rejection, SubmapSim3RejectionReason,
 };
 
 /// Configuration for the bounded rig-frame seam adapter.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RigSubmapAlignmentConfig {
-    /// Maximum number of common rig frames retained for the seam.  The
-    /// retained ids are always the earliest ids in ascending order.
+    /// Maximum number of common rig frames retained for the seam.
     pub max_boundary_frames: usize,
+    /// Policy used to select the bounded common-frame seam boundary.
+    pub boundary_sampling: RigSubmapBoundarySampling,
     /// Angular radius of the independent local-gauge rotation consensus.
     pub rotation_consensus_deg: f64,
     /// Minimum fraction of retained rig-frame rotations in that consensus.
     pub min_rotation_consensus_ratio: f64,
     /// Existing robust 3D Sim(3) alignment and residual gates.
     pub alignment: SubmapSim3AlignmentConfig,
+    /// Allow the rig-only fixed-rotation camera-centre fallback after the
+    /// generic Sim(3) estimator rejects. Disabled by default because this
+    /// fallback does not add independent landmark geometry.
+    pub allow_fixed_rotation_fallback: bool,
+    /// Use the orientation-constrained camera-centre estimator as the primary
+    /// alignment method. This is diagnostic-only; a generic fallback is
+    /// separately opt-in through `allow_generic_fallback_after_fixed_rotation`.
+    pub prefer_fixed_rotation_alignment: bool,
+    /// When fixed-rotation alignment is primary, allow the existing generic
+    /// landmark-style Sim(3) estimator to run only after that primary attempt
+    /// rejects. This is diagnostic-only and disabled by default so enabling
+    /// the fixed-primary path never silently changes its acceptance policy.
+    pub allow_generic_fallback_after_fixed_rotation: bool,
+    /// In fixed-rotation primary/fallback paths, force unit scale and use a
+    /// robust translation-only estimator. Generic landmark Sim(3) alignment
+    /// is never affected by this diagnostic switch.
+    pub force_fixed_rotation_unit_scale: bool,
 }
 
 impl Default for RigSubmapAlignmentConfig {
     fn default() -> Self {
         Self {
             max_boundary_frames: 64,
+            boundary_sampling: RigSubmapBoundarySampling::Earliest,
             rotation_consensus_deg: 5.0,
             min_rotation_consensus_ratio: 0.6,
             alignment: SubmapSim3AlignmentConfig::default(),
+            allow_fixed_rotation_fallback: false,
+            prefer_fixed_rotation_alignment: false,
+            allow_generic_fallback_after_fixed_rotation: false,
+            force_fixed_rotation_unit_scale: false,
+        }
+    }
+}
+
+/// Deterministic policy for selecting the bounded common-frame seam.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RigSubmapBoundarySampling {
+    /// Preserve the historical behavior: retain the lowest sorted frame ids.
+    Earliest,
+    /// Retain endpoint-inclusive, evenly spaced ids across the full overlap.
+    UniformAcrossOverlap,
+}
+
+/// Estimator path that produced (or rejected) a rig-submap alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RigSubmapAlignmentMethod {
+    /// The existing robust landmark-style Sim(3) estimator.
+    Generic,
+    /// The fixed-consensus orientation estimator was selected as primary.
+    FixedRotationPrimary,
+    /// The fixed-consensus orientation estimator was attempted after generic
+    /// Sim(3) rejection.
+    FixedRotationFallback,
+    /// The fixed-consensus orientation estimator rejected first, then the
+    /// generic landmark-style Sim(3) estimator accepted as a fallback.
+    GenericFallback,
+}
+
+impl RigSubmapAlignmentMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Generic => "generic",
+            Self::FixedRotationPrimary => "fixed-primary",
+            Self::FixedRotationFallback => "fixed-fallback",
+            Self::GenericFallback => "generic-fallback",
         }
     }
 }
@@ -109,8 +176,26 @@ pub struct RigSubmapAlignmentDiagnostics {
     pub rotation_consensus_threshold_deg: f64,
     pub rotation_medoid_frame_id: Option<u64>,
     pub camera_centre_match_count: usize,
+    /// Which estimator path was selected or produced the rejection.
+    pub alignment_method: Option<RigSubmapAlignmentMethod>,
     pub sim3_inlier_count: Option<usize>,
     pub sim3_inlier_ratio: Option<f64>,
+    /// The first generic Sim(3) rejection, retained when the fixed-rotation
+    /// fallback is attempted or used so the original gate remains auditable.
+    pub generic_sim3_rejection: Option<Box<SubmapSim3Rejection>>,
+    /// Rejection from the fixed-rotation primary estimator. This is retained
+    /// when the optional generic fallback is attempted or accepted.
+    pub fixed_rotation_rejection: Option<Box<SubmapSim3Rejection>>,
+    /// Rejection from the generic estimator after fixed-rotation primary
+    /// rejection, when that diagnostic fallback also fails.
+    pub generic_fallback_rejection: Option<Box<SubmapSim3Rejection>>,
+    /// Whether a secondary estimator was attempted after the primary path.
+    pub fallback_attempted: bool,
+    /// Whether that secondary estimator supplied the accepted constraint.
+    pub fallback_used: bool,
+    /// The fixed-rotation fallback rejection, if the generic-primary path's
+    /// attempted fixed-rotation fallback also failed.
+    pub fallback_rejection: Option<Box<SubmapSim3Rejection>>,
 }
 
 impl RigSubmapAlignmentDiagnostics {
@@ -138,8 +223,15 @@ impl RigSubmapAlignmentDiagnostics {
             rotation_consensus_threshold_deg,
             rotation_medoid_frame_id: None,
             camera_centre_match_count: 0,
+            alignment_method: None,
             sim3_inlier_count: None,
             sim3_inlier_ratio: None,
+            generic_sim3_rejection: None,
+            fixed_rotation_rejection: None,
+            generic_fallback_rejection: None,
+            fallback_attempted: false,
+            fallback_used: false,
+            fallback_rejection: None,
         }
     }
 }
@@ -152,7 +244,10 @@ pub struct RigSubmapAlignmentRejection {
     pub diagnostics: Box<RigSubmapAlignmentDiagnostics>,
     pub offending_side: Option<RigSubmapInputSide>,
     pub offending_frame_id: Option<u64>,
+    /// Rejection from the primary robust estimator (generic or fixed).
     pub sim3_rejection: Option<Box<SubmapSim3Rejection>>,
+    /// Rejection from the optional secondary estimator (fixed or generic).
+    pub fallback_rejection: Option<Box<SubmapSim3Rejection>>,
 }
 
 /// Error alias using the conventional `Error` name for callers that prefer
@@ -210,9 +305,10 @@ pub struct RigSubmapAlignmentResult {
 /// then identify the new-window seam boundary.
 ///
 /// The source and target slices are indexed by global rig-frame id.  Duplicate
-/// ids are rejected.  Their unique intersection is sorted by id and truncated
-/// to `config.max_boundary_frames` before any rotation consensus or Sim(3)
-/// work.  For each retained frame, the camera-centre pair is represented by a
+/// ids are rejected.  Their unique intersection is sorted by id and sampled
+/// according to `config.boundary_sampling`, bounded by
+/// `config.max_boundary_frames`, before any rotation consensus or Sim(3) work.
+/// For each retained frame, the camera-centre pair is represented by a
 /// [`SubmapPointMatch`] whose source and target ids are that global rig-frame
 /// id.  The independent rotation candidate is exactly
 /// `q_target_cw.inverse() * q_source_cw`.
@@ -238,6 +334,7 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: None,
             offending_frame_id: None,
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
 
@@ -260,6 +357,7 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: Some(RigSubmapInputSide::Source),
             offending_frame_id: duplicate_frame_id(source_frames),
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
     if target_unique.len() != target_frames.len() {
@@ -269,6 +367,7 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: Some(RigSubmapInputSide::Target),
             offending_frame_id: duplicate_frame_id(target_frames),
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
 
@@ -279,6 +378,7 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: Some(side),
             offending_frame_id: Some(frame_id),
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
 
@@ -289,6 +389,7 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: Some(side),
             offending_frame_id: Some(frame_id),
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
 
@@ -297,11 +398,11 @@ pub fn estimate_rig_submap_sim3_constraint(
         .filter(|frame_id| target_unique.contains_key(frame_id))
         .copied()
         .collect::<Vec<_>>();
-    let retained_frame_ids = common_frame_ids
-        .iter()
-        .take(config.max_boundary_frames)
-        .copied()
-        .collect::<Vec<_>>();
+    let retained_frame_ids = sample_boundary_frame_ids(
+        &common_frame_ids,
+        config.max_boundary_frames,
+        config.boundary_sampling,
+    );
     let mut diagnostics = RigSubmapAlignmentDiagnostics::from_counts(
         source_frames.len(),
         target_frames.len(),
@@ -320,6 +421,7 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: None,
             offending_frame_id: None,
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
 
@@ -342,6 +444,7 @@ pub fn estimate_rig_submap_sim3_constraint(
                 offending_side: Some(RigSubmapInputSide::Source),
                 offending_frame_id: Some(*frame_id),
                 sim3_rejection: None,
+                fallback_rejection: None,
             });
         }
         if !point_is_finite(&target_center) {
@@ -352,6 +455,7 @@ pub fn estimate_rig_submap_sim3_constraint(
                 offending_side: Some(RigSubmapInputSide::Target),
                 offending_frame_id: Some(*frame_id),
                 sim3_rejection: None,
+                fallback_rejection: None,
             });
         }
         matches.push(SubmapPointMatch {
@@ -384,9 +488,81 @@ pub fn estimate_rig_submap_sim3_constraint(
             offending_side: None,
             offending_frame_id: None,
             sim3_rejection: None,
+            fallback_rejection: None,
         });
     }
 
+    if config.prefer_fixed_rotation_alignment {
+        diagnostics.alignment_method = Some(RigSubmapAlignmentMethod::FixedRotationPrimary);
+        match estimate_fixed_rotation_fallback(
+            source_submap_id,
+            target_submap_id,
+            &matches,
+            &consensus.rotation,
+            &config.alignment,
+            config.force_fixed_rotation_unit_scale,
+        ) {
+            Ok(constraint) => {
+                diagnostics.sim3_inlier_count = Some(constraint.inlier_match_indices.len());
+                diagnostics.sim3_inlier_ratio = Some(constraint.inlier_ratio);
+                return Ok(RigSubmapAlignmentResult {
+                    constraint,
+                    diagnostics,
+                });
+            }
+            Err(rejection) => {
+                diagnostics.sim3_inlier_count = Some(rejection.inlier_count);
+                diagnostics.sim3_inlier_ratio = Some(rejection.inlier_ratio);
+                diagnostics.fixed_rotation_rejection = Some(Box::new(rejection.clone()));
+                if config.allow_generic_fallback_after_fixed_rotation {
+                    diagnostics.fallback_attempted = true;
+                    diagnostics.alignment_method = Some(RigSubmapAlignmentMethod::GenericFallback);
+                    match estimate_submap_sim3_constraint(
+                        source_submap_id,
+                        target_submap_id,
+                        &matches,
+                        &consensus.rotation,
+                        &config.alignment,
+                    ) {
+                        Ok(constraint) => {
+                            diagnostics.fallback_used = true;
+                            diagnostics.sim3_inlier_count =
+                                Some(constraint.inlier_match_indices.len());
+                            diagnostics.sim3_inlier_ratio = Some(constraint.inlier_ratio);
+                            return Ok(RigSubmapAlignmentResult {
+                                constraint,
+                                diagnostics,
+                            });
+                        }
+                        Err(generic_rejection) => {
+                            diagnostics.sim3_inlier_count = Some(generic_rejection.inlier_count);
+                            diagnostics.sim3_inlier_ratio = Some(generic_rejection.inlier_ratio);
+                            diagnostics.generic_fallback_rejection =
+                                Some(Box::new(generic_rejection.clone()));
+                            return Err(RigSubmapAlignmentRejection {
+                                reason: RigSubmapAlignmentRejectionReason::Sim3Rejected,
+                                diagnostics: Box::new(diagnostics),
+                                offending_side: None,
+                                offending_frame_id: None,
+                                sim3_rejection: Some(Box::new(rejection)),
+                                fallback_rejection: Some(Box::new(generic_rejection)),
+                            });
+                        }
+                    }
+                }
+                return Err(RigSubmapAlignmentRejection {
+                    reason: RigSubmapAlignmentRejectionReason::Sim3Rejected,
+                    diagnostics: Box::new(diagnostics),
+                    offending_side: None,
+                    offending_frame_id: None,
+                    sim3_rejection: Some(Box::new(rejection)),
+                    fallback_rejection: None,
+                });
+            }
+        }
+    }
+
+    diagnostics.alignment_method = Some(RigSubmapAlignmentMethod::Generic);
     let constraint = match estimate_submap_sim3_constraint(
         source_submap_id,
         target_submap_id,
@@ -398,13 +574,46 @@ pub fn estimate_rig_submap_sim3_constraint(
         Err(sim3_rejection) => {
             diagnostics.sim3_inlier_count = Some(sim3_rejection.inlier_count);
             diagnostics.sim3_inlier_ratio = Some(sim3_rejection.inlier_ratio);
-            return Err(RigSubmapAlignmentRejection {
-                reason: RigSubmapAlignmentRejectionReason::Sim3Rejected,
-                diagnostics: Box::new(diagnostics),
-                offending_side: None,
-                offending_frame_id: None,
-                sim3_rejection: Some(Box::new(sim3_rejection)),
-            });
+            diagnostics.generic_sim3_rejection = Some(Box::new(sim3_rejection.clone()));
+            if !config.allow_fixed_rotation_fallback {
+                return Err(RigSubmapAlignmentRejection {
+                    reason: RigSubmapAlignmentRejectionReason::Sim3Rejected,
+                    diagnostics: Box::new(diagnostics),
+                    offending_side: None,
+                    offending_frame_id: None,
+                    sim3_rejection: Some(Box::new(sim3_rejection)),
+                    fallback_rejection: None,
+                });
+            }
+
+            diagnostics.fallback_attempted = true;
+            diagnostics.alignment_method = Some(RigSubmapAlignmentMethod::FixedRotationFallback);
+            match estimate_fixed_rotation_fallback(
+                source_submap_id,
+                target_submap_id,
+                &matches,
+                &consensus.rotation,
+                &config.alignment,
+                config.force_fixed_rotation_unit_scale,
+            ) {
+                Ok(constraint) => {
+                    diagnostics.fallback_used = true;
+                    diagnostics.sim3_inlier_count = Some(constraint.inlier_match_indices.len());
+                    diagnostics.sim3_inlier_ratio = Some(constraint.inlier_ratio);
+                    constraint
+                }
+                Err(fallback_rejection) => {
+                    diagnostics.fallback_rejection = Some(Box::new(fallback_rejection.clone()));
+                    return Err(RigSubmapAlignmentRejection {
+                        reason: RigSubmapAlignmentRejectionReason::Sim3Rejected,
+                        diagnostics: Box::new(diagnostics),
+                        offending_side: None,
+                        offending_frame_id: None,
+                        sim3_rejection: Some(Box::new(sim3_rejection)),
+                        fallback_rejection: Some(Box::new(fallback_rejection)),
+                    });
+                }
+            }
         }
     };
     diagnostics.sim3_inlier_count = Some(constraint.inlier_match_indices.len());
@@ -412,6 +621,577 @@ pub fn estimate_rig_submap_sim3_constraint(
     Ok(RigSubmapAlignmentResult {
         constraint,
         diagnostics,
+    })
+}
+
+/// Estimate a camera-centre Sim(3) while keeping the already verified rig
+/// rotation fixed.
+///
+/// This is intentionally private to the rig wrapper.  It is not a replacement
+/// for landmark-based Sim(3): it is only useful when camera-centre geometry is
+/// sufficient to recover scale and translation after the generic estimator
+/// rejects a degenerate point cloud.  The retained seam is bounded by the
+/// caller (64 by default). Each two-point hypothesis evaluates O(B) residuals,
+/// and the leave-one-out stability check is O(B²). Median pairwise scene
+/// scale uses O(B²) temporary state; hypothesis/refit state is O(B).
+fn estimate_fixed_rotation_fallback(
+    source_submap_id: u64,
+    target_submap_id: u64,
+    matches: &[SubmapPointMatch],
+    rotation: &UnitQuaternion<f64>,
+    config: &SubmapSim3AlignmentConfig,
+    force_unit_scale: bool,
+) -> Result<SubmapSim3Constraint, SubmapSim3Rejection> {
+    if force_unit_scale {
+        return estimate_fixed_rotation_unit_scale(
+            source_submap_id,
+            target_submap_id,
+            matches,
+            rotation,
+            config,
+        );
+    }
+    let count = matches.len();
+    let required = config.min_correspondences.max(3);
+    if count < required {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::TooFewCorrespondences,
+            count,
+        ));
+    }
+    if matches.iter().any(|point_match| {
+        !point_is_finite(&point_match.source_point) || !point_is_finite(&point_match.target_point)
+    }) {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::NonFinitePoint,
+            count,
+        ));
+    }
+    let unique_source = matches
+        .iter()
+        .map(|point_match| point_match.source_landmark_id)
+        .collect::<BTreeSet<_>>();
+    let unique_target = matches
+        .iter()
+        .map(|point_match| point_match.target_landmark_id)
+        .collect::<BTreeSet<_>>();
+    if unique_source.len() != count || unique_target.len() != count {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::NonUniqueCorrespondences,
+            count,
+        ));
+    }
+
+    let target_points = matches
+        .iter()
+        .map(|point_match| point_match.target_point)
+        .collect::<Vec<_>>();
+    let target_scene_scale = fallback_median_pairwise_distance(&target_points);
+    if !target_scene_scale.is_finite() || target_scene_scale <= 1.0e-12 {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::InvalidTargetSceneScale,
+            count,
+        ));
+    }
+    let threshold = (target_scene_scale * config.max_inlier_residual_ratio).max(1.0e-9);
+    let mut rng = StdRng::seed_from_u64(config.random_seed);
+    let mut best_inliers = Vec::new();
+    let mut best_mean = f64::INFINITY;
+
+    for _ in 0..config.ransac_iterations.max(1) {
+        let Some([first, second]) = sample_two(count, &mut rng) else {
+            break;
+        };
+        let pair = [matches[first], matches[second]];
+        let Some((scale, translation)) = fit_scale_translation_fixed_rotation(&pair, rotation)
+        else {
+            continue;
+        };
+        if !valid_fallback_scale(scale, config) {
+            continue;
+        }
+        let transform = Sim3::new(*rotation, translation, scale);
+        let residuals = matches
+            .iter()
+            .map(|point_match| {
+                (transform.transform_point(&point_match.source_point) - point_match.target_point)
+                    .norm()
+            })
+            .collect::<Vec<_>>();
+        let inliers = residuals
+            .iter()
+            .enumerate()
+            .filter_map(|(index, residual)| (*residual <= threshold).then_some(index))
+            .collect::<Vec<_>>();
+        let mean = if inliers.is_empty() {
+            f64::INFINITY
+        } else {
+            inliers.iter().map(|index| residuals[*index]).sum::<f64>() / inliers.len() as f64
+        };
+        if inliers.len() > best_inliers.len()
+            || (inliers.len() == best_inliers.len() && mean < best_mean)
+        {
+            best_inliers = inliers;
+            best_mean = mean;
+        }
+    }
+
+    if best_inliers.is_empty() {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::NoRobustFit,
+            count,
+        ));
+    }
+    let mut rejection = fallback_rejection(SubmapSim3RejectionReason::TooFewInliers, count);
+    rejection.inlier_count = best_inliers.len();
+    rejection.inlier_ratio = best_inliers.len() as f64 / count as f64;
+    if best_inliers.len() < config.min_inliers.max(3) {
+        return Err(rejection);
+    }
+    if rejection.inlier_ratio < config.min_inlier_ratio {
+        rejection.reason = SubmapSim3RejectionReason::LowInlierRatio;
+        return Err(rejection);
+    }
+
+    let first_inliers = best_inliers
+        .iter()
+        .map(|&index| matches[index])
+        .collect::<Vec<_>>();
+    let Some((first_scale, first_translation)) =
+        fit_scale_translation_fixed_rotation(&first_inliers, rotation)
+    else {
+        rejection.reason = SubmapSim3RejectionReason::NoRobustFit;
+        return Err(rejection);
+    };
+    if !valid_fallback_scale(first_scale, config) {
+        rejection.reason = SubmapSim3RejectionReason::ScaleOutOfBounds;
+        return Err(rejection);
+    }
+    let first_transform = Sim3::new(*rotation, first_translation, first_scale);
+    best_inliers = matches
+        .iter()
+        .enumerate()
+        .filter_map(|(index, point_match)| {
+            ((first_transform.transform_point(&point_match.source_point)
+                - point_match.target_point)
+                .norm()
+                <= threshold)
+                .then_some(index)
+        })
+        .collect();
+    rejection.inlier_count = best_inliers.len();
+    rejection.inlier_ratio = best_inliers.len() as f64 / count as f64;
+    if best_inliers.len() < config.min_inliers.max(3) {
+        rejection.reason = SubmapSim3RejectionReason::TooFewInliers;
+        return Err(rejection);
+    }
+    if rejection.inlier_ratio < config.min_inlier_ratio {
+        rejection.reason = SubmapSim3RejectionReason::LowInlierRatio;
+        return Err(rejection);
+    }
+
+    let inliers = best_inliers
+        .iter()
+        .map(|&index| matches[index])
+        .collect::<Vec<_>>();
+    let Some((scale, translation)) = fit_scale_translation_fixed_rotation(&inliers, rotation)
+    else {
+        rejection.reason = SubmapSim3RejectionReason::NoRobustFit;
+        return Err(rejection);
+    };
+    if !valid_fallback_scale(scale, config) {
+        rejection.reason = SubmapSim3RejectionReason::ScaleOutOfBounds;
+        return Err(rejection);
+    }
+    let transform = Sim3::new(*rotation, translation, scale);
+    let mean_residual_ratio = inliers
+        .iter()
+        .map(|point_match| {
+            (transform.transform_point(&point_match.source_point) - point_match.target_point).norm()
+        })
+        .sum::<f64>()
+        / inliers.len() as f64
+        / target_scene_scale;
+    rejection.mean_residual_ratio = Some(mean_residual_ratio);
+    if !mean_residual_ratio.is_finite() || mean_residual_ratio > config.max_mean_residual_ratio {
+        rejection.reason = SubmapSim3RejectionReason::HighMeanResidual;
+        return Err(rejection);
+    }
+
+    // The rotation is the independently verified consensus by construction.
+    // Keep the diagnostic explicit so callers can distinguish this from a
+    // generic estimator that happened to fit a similar orientation.
+    let rotation_disagreement_deg = 0.0;
+    rejection.rotation_disagreement_deg = Some(rotation_disagreement_deg);
+    if rotation_disagreement_deg > config.max_rotation_disagreement_deg {
+        rejection.reason = SubmapSim3RejectionReason::RotationInconsistent;
+        return Err(rejection);
+    }
+    let leave_one_out_log_scale_mad =
+        fixed_rotation_leave_one_out_log_scale_mad(&inliers, rotation, scale)
+            .unwrap_or(f64::INFINITY);
+    rejection.leave_one_out_log_scale_mad = Some(leave_one_out_log_scale_mad);
+    if !leave_one_out_log_scale_mad.is_finite()
+        || leave_one_out_log_scale_mad > config.max_leave_one_out_log_scale_mad
+    {
+        rejection.reason = SubmapSim3RejectionReason::UnstableLeaveOneOutScale;
+        return Err(rejection);
+    }
+
+    let inlier_ratio = best_inliers.len() as f64 / count as f64;
+    Ok(SubmapSim3Constraint {
+        source_submap_id,
+        target_submap_id,
+        target_from_source: transform,
+        correspondence_count: count,
+        inlier_match_indices: best_inliers,
+        inlier_ratio,
+        mean_residual_ratio,
+        rotation_disagreement_deg,
+        leave_one_out_log_scale_mad,
+        target_scene_scale,
+    })
+}
+
+/// Estimate a fixed-rotation, unit-scale camera-centre constraint.
+///
+/// Every retained correspondence supplies one translation hypothesis.  Each
+/// hypothesis is scored against the same bounded residual threshold, then the
+/// best inlier set is refit by its translation mean and reclassified once.
+/// The final scale and leave-one-out scale MAD are exactly one and zero, so
+/// the existing inlier, residual, rotation, and scale gates remain the policy
+/// that decides admission.  The retained seam is bounded by the caller, hence
+/// hypothesis scoring uses O(B²) residual work in the worst case. Median
+/// pairwise scene scale uses O(B²) temporary state; hypothesis state is O(B).
+fn estimate_fixed_rotation_unit_scale(
+    source_submap_id: u64,
+    target_submap_id: u64,
+    matches: &[SubmapPointMatch],
+    rotation: &UnitQuaternion<f64>,
+    config: &SubmapSim3AlignmentConfig,
+) -> Result<SubmapSim3Constraint, SubmapSim3Rejection> {
+    let count = matches.len();
+    let required = config.min_correspondences.max(3);
+    if count < required {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::TooFewCorrespondences,
+            count,
+        ));
+    }
+    if !rotation.coords.iter().all(|value| value.is_finite())
+        || matches.iter().any(|point_match| {
+            !point_is_finite(&point_match.source_point)
+                || !point_is_finite(&point_match.target_point)
+        })
+    {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::NonFinitePoint,
+            count,
+        ));
+    }
+    let unique_source = matches
+        .iter()
+        .map(|point_match| point_match.source_landmark_id)
+        .collect::<BTreeSet<_>>();
+    let unique_target = matches
+        .iter()
+        .map(|point_match| point_match.target_landmark_id)
+        .collect::<BTreeSet<_>>();
+    if unique_source.len() != count || unique_target.len() != count {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::NonUniqueCorrespondences,
+            count,
+        ));
+    }
+    if !valid_fallback_scale(1.0, config) {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::ScaleOutOfBounds,
+            count,
+        ));
+    }
+    let target_scene_scale = fallback_median_pairwise_distance(
+        &matches
+            .iter()
+            .map(|point_match| point_match.target_point)
+            .collect::<Vec<_>>(),
+    );
+    if !target_scene_scale.is_finite() || target_scene_scale <= 1.0e-12 {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::InvalidTargetSceneScale,
+            count,
+        ));
+    }
+    let threshold = (target_scene_scale * config.max_inlier_residual_ratio).max(1.0e-9);
+    let mut hypothesis_indices = (0..count).collect::<Vec<_>>();
+    hypothesis_indices.sort_by_key(|&index| {
+        (
+            matches[index].source_landmark_id,
+            matches[index].target_landmark_id,
+            index,
+        )
+    });
+    let mut best_inliers = Vec::new();
+    let mut best_mean = f64::INFINITY;
+    let mut best_hypothesis = (u64::MAX, u64::MAX, usize::MAX);
+    for index in hypothesis_indices {
+        let translation = matches[index].target_point.coords
+            - rotation.transform_vector(&matches[index].source_point.coords);
+        if !translation.iter().all(|value| value.is_finite()) {
+            continue;
+        }
+        let transform = Sim3::new(*rotation, translation, 1.0);
+        let residuals = matches
+            .iter()
+            .map(|point_match| {
+                (transform.transform_point(&point_match.source_point) - point_match.target_point)
+                    .norm()
+            })
+            .collect::<Vec<_>>();
+        let inliers = residuals
+            .iter()
+            .enumerate()
+            .filter_map(|(match_index, residual)| (*residual <= threshold).then_some(match_index))
+            .collect::<Vec<_>>();
+        let mean = if inliers.is_empty() {
+            f64::INFINITY
+        } else {
+            inliers
+                .iter()
+                .map(|&match_index| residuals[match_index])
+                .sum::<f64>()
+                / inliers.len() as f64
+        };
+        let hypothesis_key = (
+            matches[index].source_landmark_id,
+            matches[index].target_landmark_id,
+            index,
+        );
+        if inliers.len() > best_inliers.len()
+            || (inliers.len() == best_inliers.len()
+                && (mean.total_cmp(&best_mean).is_lt()
+                    || (mean.total_cmp(&best_mean).is_eq() && hypothesis_key < best_hypothesis)))
+        {
+            best_inliers = inliers;
+            best_mean = mean;
+            best_hypothesis = hypothesis_key;
+        }
+    }
+
+    if best_inliers.is_empty() {
+        return Err(fallback_rejection(
+            SubmapSim3RejectionReason::NoRobustFit,
+            count,
+        ));
+    }
+    let mut rejection = fallback_rejection(SubmapSim3RejectionReason::TooFewInliers, count);
+    rejection.inlier_count = best_inliers.len();
+    rejection.inlier_ratio = best_inliers.len() as f64 / count as f64;
+    if best_inliers.len() < config.min_inliers.max(3) {
+        return Err(rejection);
+    }
+    if rejection.inlier_ratio < config.min_inlier_ratio {
+        rejection.reason = SubmapSim3RejectionReason::LowInlierRatio;
+        return Err(rejection);
+    }
+
+    let first_translation = mean_translation_fixed_rotation(&best_inliers, matches, rotation);
+    if !first_translation.iter().all(|value| value.is_finite()) {
+        rejection.reason = SubmapSim3RejectionReason::NoRobustFit;
+        return Err(rejection);
+    }
+    let first_transform = Sim3::new(*rotation, first_translation, 1.0);
+    best_inliers = matches
+        .iter()
+        .enumerate()
+        .filter_map(|(index, point_match)| {
+            ((first_transform.transform_point(&point_match.source_point)
+                - point_match.target_point)
+                .norm()
+                <= threshold)
+                .then_some(index)
+        })
+        .collect();
+    rejection.inlier_count = best_inliers.len();
+    rejection.inlier_ratio = best_inliers.len() as f64 / count as f64;
+    if best_inliers.len() < config.min_inliers.max(3) {
+        rejection.reason = SubmapSim3RejectionReason::TooFewInliers;
+        return Err(rejection);
+    }
+    if rejection.inlier_ratio < config.min_inlier_ratio {
+        rejection.reason = SubmapSim3RejectionReason::LowInlierRatio;
+        return Err(rejection);
+    }
+
+    let translation = mean_translation_fixed_rotation(&best_inliers, matches, rotation);
+    if !translation.iter().all(|value| value.is_finite()) {
+        rejection.reason = SubmapSim3RejectionReason::NoRobustFit;
+        return Err(rejection);
+    }
+    let transform = Sim3::new(*rotation, translation, 1.0);
+    let mean_residual_ratio = best_inliers
+        .iter()
+        .map(|&index| {
+            (transform.transform_point(&matches[index].source_point) - matches[index].target_point)
+                .norm()
+        })
+        .sum::<f64>()
+        / best_inliers.len() as f64
+        / target_scene_scale;
+    rejection.mean_residual_ratio = Some(mean_residual_ratio);
+    if !mean_residual_ratio.is_finite() || mean_residual_ratio > config.max_mean_residual_ratio {
+        rejection.reason = SubmapSim3RejectionReason::HighMeanResidual;
+        return Err(rejection);
+    }
+
+    let rotation_disagreement_deg = 0.0;
+    rejection.rotation_disagreement_deg = Some(rotation_disagreement_deg);
+    if rotation_disagreement_deg > config.max_rotation_disagreement_deg {
+        rejection.reason = SubmapSim3RejectionReason::RotationInconsistent;
+        return Err(rejection);
+    }
+    let leave_one_out_log_scale_mad = 0.0;
+    rejection.leave_one_out_log_scale_mad = Some(leave_one_out_log_scale_mad);
+    if leave_one_out_log_scale_mad > config.max_leave_one_out_log_scale_mad {
+        rejection.reason = SubmapSim3RejectionReason::UnstableLeaveOneOutScale;
+        return Err(rejection);
+    }
+
+    let inlier_ratio = best_inliers.len() as f64 / count as f64;
+    Ok(SubmapSim3Constraint {
+        source_submap_id,
+        target_submap_id,
+        target_from_source: transform,
+        correspondence_count: count,
+        inlier_match_indices: best_inliers,
+        inlier_ratio,
+        mean_residual_ratio,
+        rotation_disagreement_deg,
+        leave_one_out_log_scale_mad,
+        target_scene_scale,
+    })
+}
+
+fn mean_translation_fixed_rotation(
+    indices: &[usize],
+    matches: &[SubmapPointMatch],
+    rotation: &UnitQuaternion<f64>,
+) -> Vector3<f64> {
+    indices.iter().fold(Vector3::zeros(), |sum, &index| {
+        sum + matches[index].target_point.coords
+            - rotation.transform_vector(&matches[index].source_point.coords)
+    }) / indices.len().max(1) as f64
+}
+
+fn fallback_rejection(
+    reason: SubmapSim3RejectionReason,
+    correspondence_count: usize,
+) -> SubmapSim3Rejection {
+    SubmapSim3Rejection {
+        reason,
+        correspondence_count,
+        inlier_count: 0,
+        inlier_ratio: 0.0,
+        mean_residual_ratio: None,
+        rotation_disagreement_deg: None,
+        leave_one_out_log_scale_mad: None,
+    }
+}
+
+fn fit_scale_translation_fixed_rotation(
+    matches: &[SubmapPointMatch],
+    rotation: &UnitQuaternion<f64>,
+) -> Option<(f64, Vector3<f64>)> {
+    if matches.len() < 2 {
+        return None;
+    }
+    let source_mean = matches.iter().fold(Vector3::zeros(), |sum, point_match| {
+        sum + point_match.source_point.coords
+    }) / matches.len() as f64;
+    let target_mean = matches.iter().fold(Vector3::zeros(), |sum, point_match| {
+        sum + point_match.target_point.coords
+    }) / matches.len() as f64;
+    let mut numerator = 0.0;
+    let mut denominator = 0.0;
+    for point_match in matches {
+        let source = rotation * (point_match.source_point.coords - source_mean);
+        let target = point_match.target_point.coords - target_mean;
+        numerator += source.dot(&target);
+        denominator += source.norm_squared();
+    }
+    if !numerator.is_finite() || !denominator.is_finite() || denominator <= 1.0e-12 {
+        return None;
+    }
+    let scale = numerator / denominator;
+    let translation = target_mean - scale * (rotation * source_mean);
+    (scale.is_finite() && translation.iter().all(|value| value.is_finite()))
+        .then_some((scale, translation))
+}
+
+fn valid_fallback_scale(scale: f64, config: &SubmapSim3AlignmentConfig) -> bool {
+    scale.is_finite() && scale >= config.min_scale && scale <= config.max_scale
+}
+
+fn sample_two(count: usize, rng: &mut StdRng) -> Option<[usize; 2]> {
+    if count < 2 {
+        return None;
+    }
+    for _ in 0..64 {
+        let first = rng.gen_range(0..count);
+        let second = rng.gen_range(0..count);
+        if first != second {
+            return Some([first, second]);
+        }
+    }
+    None
+}
+
+fn fallback_median_pairwise_distance(points: &[Point3<f64>]) -> f64 {
+    let mut distances = Vec::new();
+    for first in 0..points.len() {
+        for second in (first + 1)..points.len() {
+            let distance = (points[first] - points[second]).norm();
+            if distance.is_finite() && distance > 0.0 {
+                distances.push(distance);
+            }
+        }
+    }
+    fallback_median(distances).unwrap_or(0.0)
+}
+
+fn fixed_rotation_leave_one_out_log_scale_mad(
+    matches: &[SubmapPointMatch],
+    rotation: &UnitQuaternion<f64>,
+    reference_scale: f64,
+) -> Option<f64> {
+    if matches.len() < 4 || !reference_scale.is_finite() || reference_scale <= 0.0 {
+        return None;
+    }
+    let mut deviations = Vec::with_capacity(matches.len());
+    for omitted in 0..matches.len() {
+        let kept = matches
+            .iter()
+            .enumerate()
+            .filter_map(|(index, point_match)| (index != omitted).then_some(*point_match))
+            .collect::<Vec<_>>();
+        let (scale, _) = fit_scale_translation_fixed_rotation(&kept, rotation)?;
+        if !scale.is_finite() || scale <= 0.0 {
+            return None;
+        }
+        deviations.push((scale / reference_scale).ln().abs());
+    }
+    fallback_median(deviations)
+}
+
+fn fallback_median(mut values: Vec<f64>) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(f64::total_cmp);
+    let middle = values.len() / 2;
+    Some(if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) * 0.5
+    } else {
+        values[middle]
     })
 }
 
@@ -512,6 +1292,41 @@ fn rotation_consensus(
         medoid_frame_id: candidates[medoid_index].frame_id,
         indices: medoid_cluster,
         max_disagreement_deg,
+    }
+}
+
+/// Select at most `max_boundary_frames` from a sorted, unique overlap.
+///
+/// The intersection itself is built by the caller in O(common) map scans;
+/// this pass is O(common + B) time and O(B) output state.  Integer positions
+/// are used for the uniform policy so the endpoints are exact and no sampled
+/// id can be duplicated when the cap is smaller than the overlap.
+fn sample_boundary_frame_ids(
+    common_frame_ids: &[u64],
+    max_boundary_frames: usize,
+    sampling: RigSubmapBoundarySampling,
+) -> Vec<u64> {
+    if common_frame_ids.is_empty() || max_boundary_frames == 0 {
+        return Vec::new();
+    }
+    if common_frame_ids.len() <= max_boundary_frames {
+        return common_frame_ids.to_vec();
+    }
+    match sampling {
+        RigSubmapBoundarySampling::Earliest => common_frame_ids[..max_boundary_frames].to_vec(),
+        RigSubmapBoundarySampling::UniformAcrossOverlap => {
+            if max_boundary_frames == 1 {
+                return vec![common_frame_ids[0]];
+            }
+            let span = (common_frame_ids.len() - 1) as u128;
+            let intervals = (max_boundary_frames - 1) as u128;
+            (0..max_boundary_frames)
+                .map(|sample_index| {
+                    let position = (sample_index as u128 * span / intervals) as usize;
+                    common_frame_ids[position]
+                })
+                .collect()
+        }
     }
 }
 
@@ -635,6 +1450,36 @@ mod tests {
         (source, target, truth)
     }
 
+    fn unit_scale_fixture(count: usize) -> (RigFrames, RigFrames, Sim3) {
+        let truth = Sim3::new(
+            UnitQuaternion::from_euler_angles(0.09, -0.13, 0.2),
+            Vector3::new(1.3, -0.7, 0.5),
+            1.0,
+        );
+        let mut source = Vec::with_capacity(count);
+        let mut target = Vec::with_capacity(count);
+        for index in 0..count {
+            let frame_id = index as u64;
+            let centre = Point3::new(
+                index as f64 * 0.17,
+                (index as f64 * 0.31).sin() * 0.7,
+                (index as f64 * 0.21).cos() * 0.5,
+            );
+            let source_rotation = UnitQuaternion::from_euler_angles(
+                index as f64 * 0.01,
+                index as f64 * -0.007,
+                index as f64 * 0.013,
+            );
+            let target_center = truth.transform_point(&centre);
+            let target_rotation = source_rotation * truth.rotation.inverse();
+            source.push((frame_id, pose_from_center(source_rotation, centre)));
+            target.push((frame_id, pose_from_center(target_rotation, target_center)));
+        }
+        source.reverse();
+        target.rotate_left((count / 3).min(count));
+        (source, target, truth)
+    }
+
     fn permissive_config() -> RigSubmapAlignmentConfig {
         RigSubmapAlignmentConfig {
             alignment: SubmapSim3AlignmentConfig {
@@ -653,6 +1498,62 @@ mod tests {
         }
     }
 
+    fn collinear_fixture(count: usize) -> (RigFrames, RigFrames, Sim3) {
+        let truth = Sim3::new(
+            UnitQuaternion::from_euler_angles(0.11, -0.17, 0.23),
+            Vector3::new(1.1, -0.6, 0.4),
+            2.4,
+        );
+        let mut source = Vec::with_capacity(count);
+        let mut target = Vec::with_capacity(count);
+        for index in 0..count {
+            let frame_id = index as u64;
+            let centre = Point3::new(index as f64 * 0.4, 0.0, 0.0);
+            let source_rotation = UnitQuaternion::from_euler_angles(
+                index as f64 * 0.013,
+                index as f64 * -0.009,
+                index as f64 * 0.007,
+            );
+            let target_center = truth.transform_point(&centre);
+            let target_rotation = source_rotation * truth.rotation.inverse();
+            source.push((frame_id, pose_from_center(source_rotation, centre)));
+            target.push((frame_id, pose_from_center(target_rotation, target_center)));
+        }
+        (source, target, truth)
+    }
+
+    fn fixed_rotation_mismatch_fixture(
+        count: usize,
+        rotation_offset_deg: f64,
+    ) -> (RigFrames, RigFrames, Sim3) {
+        let (source, mut target, truth) = fixture(count);
+        let offset =
+            UnitQuaternion::from_axis_angle(&Vector3::z_axis(), rotation_offset_deg.to_radians());
+        let consensus_rotation = truth.rotation * offset;
+        for (frame_id, target_pose) in &mut target {
+            let target_center = target_pose.camera_center_world();
+            let source_rotation = source
+                .iter()
+                .find(|(source_frame_id, _)| source_frame_id == frame_id)
+                .expect("fixture source frame id")
+                .1
+                .world_to_camera
+                .rotation;
+            let target_rotation = source_rotation * consensus_rotation.inverse();
+            *target_pose = pose_from_center(target_rotation, target_center);
+        }
+        (source, target, truth)
+    }
+
+    fn fallback_test_config() -> RigSubmapAlignmentConfig {
+        let mut config = permissive_config();
+        config.alignment.min_correspondences = 8;
+        config.alignment.min_inliers = 8;
+        config.alignment.min_second_to_first_singular_ratio = 0.01;
+        config.allow_fixed_rotation_fallback = false;
+        config
+    }
+
     #[test]
     fn known_sim3_is_recovered_from_rig_camera_centres() {
         let (source, target, truth) = fixture(24);
@@ -661,6 +1562,10 @@ mod tests {
                 .expect("known Sim3 should pass");
         assert_eq!(result.constraint.source_submap_id, 11);
         assert_eq!(result.constraint.target_submap_id, 17);
+        assert_eq!(
+            result.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::Generic)
+        );
         assert!((result.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-9);
         assert!(
             (result.constraint.target_from_source.translation - truth.translation).norm() < 1.0e-9
@@ -726,12 +1631,47 @@ mod tests {
         let (source, target, _) = fixture(20);
         let mut config = permissive_config();
         config.max_boundary_frames = 5;
+        assert_eq!(
+            config.boundary_sampling,
+            RigSubmapBoundarySampling::Earliest
+        );
         let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
             .expect("five-frame seam should pass");
         let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
             .expect("same input should be deterministic");
         assert_eq!(first, second);
         assert_eq!(first.diagnostics.retained_frame_ids, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn uniform_boundary_cap_is_endpoint_inclusive_and_deterministic() {
+        let (source, target, _) = fixture(20);
+        let mut config = permissive_config();
+        config.max_boundary_frames = 5;
+        config.boundary_sampling = RigSubmapBoundarySampling::UniformAcrossOverlap;
+        let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("uniform five-frame seam should pass");
+        let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("same uniform input should be deterministic");
+        assert_eq!(first, second);
+        assert_eq!(first.diagnostics.retained_frame_ids, vec![0, 4, 9, 14, 19]);
+    }
+
+    #[test]
+    fn uniform_boundary_sampling_has_no_duplicates_on_sparse_ids() {
+        let common = vec![10, 20, 30, 100, 200, 500, 900];
+        assert_eq!(
+            sample_boundary_frame_ids(&common, 4, RigSubmapBoundarySampling::UniformAcrossOverlap,),
+            vec![10, 30, 200, 900]
+        );
+        assert_eq!(
+            sample_boundary_frame_ids(&common, 1, RigSubmapBoundarySampling::UniformAcrossOverlap,),
+            vec![10]
+        );
+        assert_eq!(
+            sample_boundary_frame_ids(&common, 32, RigSubmapBoundarySampling::UniformAcrossOverlap,),
+            common
+        );
     }
 
     #[test]
@@ -788,5 +1728,416 @@ mod tests {
             );
             assert!(error.to_string().contains("invalid"));
         }
+    }
+
+    #[test]
+    fn fixed_rotation_fallback_is_opt_in_for_collinear_centres() {
+        let (source, target, truth) = collinear_fixture(24);
+        let config = fallback_test_config();
+        let error =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config).unwrap_err();
+        assert_eq!(
+            error.reason,
+            RigSubmapAlignmentRejectionReason::Sim3Rejected
+        );
+        assert!(!error.diagnostics.fallback_attempted);
+        assert_eq!(
+            error.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::Generic)
+        );
+        assert!(!RigSubmapAlignmentConfig::default().allow_fixed_rotation_fallback);
+        assert!(!RigSubmapAlignmentConfig::default().prefer_fixed_rotation_alignment);
+        assert!(!RigSubmapAlignmentConfig::default().allow_generic_fallback_after_fixed_rotation);
+        assert!(!RigSubmapAlignmentConfig::default().force_fixed_rotation_unit_scale);
+        assert_eq!(
+            error
+                .sim3_rejection
+                .as_ref()
+                .expect("generic rejection is retained")
+                .reason,
+            SubmapSim3RejectionReason::DegenerateSourceGeometry
+        );
+
+        let mut opted_in = config;
+        opted_in.allow_fixed_rotation_fallback = true;
+        let result = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &opted_in)
+            .expect("fixed orientation recovers the collinear gauge");
+        assert!(result.diagnostics.fallback_attempted);
+        assert!(result.diagnostics.fallback_used);
+        assert_eq!(
+            result.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::FixedRotationFallback)
+        );
+        assert!(result.diagnostics.generic_sim3_rejection.is_some());
+        assert!((result.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-9);
+        assert!(
+            (result.constraint.target_from_source.translation - truth.translation).norm() < 1.0e-9
+        );
+        assert!(
+            result
+                .constraint
+                .target_from_source
+                .rotation
+                .rotation_to(&truth.rotation)
+                .angle()
+                < 1.0e-9
+        );
+    }
+
+    #[test]
+    fn fixed_rotation_fallback_rejects_centre_outliers_robustly() {
+        let (source, mut target, truth) = collinear_fixture(32);
+        for index in [3_usize, 11, 27] {
+            let rotation = target[index].1.world_to_camera.rotation;
+            target[index].1 =
+                pose_from_center(rotation, Point3::new(90.0 + index as f64, -70.0, 40.0));
+        }
+        let mut config = fallback_test_config();
+        config.allow_fixed_rotation_fallback = true;
+        let result = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("a minority of centre outliers should be rejected");
+        assert!(result.diagnostics.fallback_used);
+        assert!(result.constraint.inlier_ratio > 0.8);
+        assert!((result.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-6);
+        assert!(
+            (result.constraint.target_from_source.translation - truth.translation).norm() < 1.0e-6
+        );
+        assert!(!result.constraint.inlier_match_indices.contains(&3));
+        assert!(!result.constraint.inlier_match_indices.contains(&11));
+        assert!(!result.constraint.inlier_match_indices.contains(&27));
+    }
+
+    #[test]
+    fn fixed_rotation_unit_scale_recovers_known_gauge_with_outliers() {
+        let (source, mut target, truth) = unit_scale_fixture(32);
+        let outlier_frame_ids = [target[3].0, target[11].0, target[27].0];
+        for index in [3_usize, 11, 27] {
+            let rotation = target[index].1.world_to_camera.rotation;
+            target[index].1 =
+                pose_from_center(rotation, Point3::new(90.0 + index as f64, -70.0, 40.0));
+        }
+        let mut config = permissive_config();
+        config.prefer_fixed_rotation_alignment = true;
+        config.force_fixed_rotation_unit_scale = true;
+        let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("unit-scale fixed rotation should reject a minority of outliers");
+        let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("unit-scale fixed rotation should be deterministic");
+        assert_eq!(first, second);
+        assert_eq!(
+            first.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::FixedRotationPrimary)
+        );
+        assert!(first.diagnostics.fallback_attempted == false);
+        assert!(first.diagnostics.fallback_used == false);
+        assert!(first.constraint.inlier_ratio > 0.8);
+        assert_eq!(first.constraint.target_from_source.scale, 1.0);
+        assert!(
+            (first.constraint.target_from_source.translation - truth.translation).norm() < 1.0e-9
+        );
+        assert_eq!(first.constraint.leave_one_out_log_scale_mad, 0.0);
+        for frame_id in outlier_frame_ids {
+            let retained_index = first
+                .diagnostics
+                .retained_frame_ids
+                .iter()
+                .position(|retained_id| *retained_id == frame_id)
+                .expect("outlier frame is retained");
+            assert!(!first
+                .constraint
+                .inlier_match_indices
+                .contains(&retained_index));
+        }
+    }
+
+    #[test]
+    fn fixed_rotation_unit_scale_rejects_malformed_degenerate_and_invalid_scale() {
+        let rotation = UnitQuaternion::identity();
+        let mut config = permissive_config().alignment;
+        let malformed = vec![
+            SubmapPointMatch {
+                source_landmark_id: 0,
+                target_landmark_id: 0,
+                source_point: Point3::new(f64::NAN, 0.0, 0.0),
+                target_point: Point3::origin(),
+            },
+            SubmapPointMatch {
+                source_landmark_id: 1,
+                target_landmark_id: 1,
+                source_point: Point3::new(1.0, 0.0, 0.0),
+                target_point: Point3::new(1.0, 0.0, 0.0),
+            },
+            SubmapPointMatch {
+                source_landmark_id: 2,
+                target_landmark_id: 2,
+                source_point: Point3::new(2.0, 0.0, 0.0),
+                target_point: Point3::new(2.0, 0.0, 0.0),
+            },
+        ];
+        let error = estimate_fixed_rotation_unit_scale(0, 1, &malformed, &rotation, &config)
+            .expect_err("non-finite points must fail closed");
+        assert_eq!(error.reason, SubmapSim3RejectionReason::NonFinitePoint);
+
+        let degenerate = malformed
+            .into_iter()
+            .enumerate()
+            .map(|(index, mut point_match)| {
+                point_match.source_point = Point3::new(index as f64, 0.0, 0.0);
+                point_match.target_point = Point3::origin();
+                point_match
+            })
+            .collect::<Vec<_>>();
+        let error = estimate_fixed_rotation_unit_scale(0, 1, &degenerate, &rotation, &config)
+            .expect_err("zero target scene scale must fail closed");
+        assert_eq!(
+            error.reason,
+            SubmapSim3RejectionReason::InvalidTargetSceneScale
+        );
+
+        config.min_scale = 1.01;
+        let (source, target, _) = unit_scale_fixture(12);
+        let matches = source
+            .iter()
+            .zip(target.iter())
+            .map(
+                |((frame_id, source_pose), (_, target_pose))| SubmapPointMatch {
+                    source_landmark_id: *frame_id,
+                    target_landmark_id: *frame_id,
+                    source_point: source_pose.camera_center_world(),
+                    target_point: target_pose.camera_center_world(),
+                },
+            )
+            .collect::<Vec<_>>();
+        let error = estimate_fixed_rotation_unit_scale(0, 1, &matches, &rotation, &config)
+            .expect_err("unit scale outside configured bounds must reject");
+        assert_eq!(error.reason, SubmapSim3RejectionReason::ScaleOutOfBounds);
+    }
+
+    #[test]
+    fn fixed_rotation_unit_scale_switch_is_default_off_and_preserves_default_path() {
+        let (source, target, _) = collinear_fixture(24);
+        let mut config = fallback_test_config();
+        config.allow_fixed_rotation_fallback = true;
+        let baseline = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("legacy fixed fallback should pass");
+        let mut explicit_default = config.clone();
+        explicit_default.force_fixed_rotation_unit_scale = false;
+        let explicit =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &explicit_default)
+                .expect("explicit false must retain legacy path");
+        assert_eq!(baseline, explicit);
+        assert!(!RigSubmapAlignmentConfig::default().force_fixed_rotation_unit_scale);
+    }
+
+    #[test]
+    fn fixed_rotation_fallback_rejects_invalid_scale_and_unstable_loo() {
+        let (source, target, _) = collinear_fixture(24);
+        let mut invalid_scale = fallback_test_config();
+        invalid_scale.allow_fixed_rotation_fallback = true;
+        invalid_scale.alignment.min_scale = 10.0;
+        let error = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &invalid_scale)
+            .unwrap_err();
+        assert!(error.diagnostics.fallback_attempted);
+        assert_eq!(
+            error
+                .diagnostics
+                .fallback_rejection
+                .as_ref()
+                .expect("fallback rejection is retained")
+                .reason,
+            SubmapSim3RejectionReason::NoRobustFit
+        );
+
+        let mut unstable_loo = fallback_test_config();
+        unstable_loo.allow_fixed_rotation_fallback = true;
+        unstable_loo.alignment.max_leave_one_out_log_scale_mad = -1.0;
+        let error =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &unstable_loo).unwrap_err();
+        assert_eq!(
+            error
+                .diagnostics
+                .fallback_rejection
+                .as_ref()
+                .expect("fallback rejection is retained")
+                .reason,
+            SubmapSim3RejectionReason::UnstableLeaveOneOutScale
+        );
+        assert!(error
+            .diagnostics
+            .fallback_rejection
+            .as_ref()
+            .and_then(|rejection| rejection.leave_one_out_log_scale_mad)
+            .is_some());
+    }
+
+    #[test]
+    fn fixed_rotation_fallback_is_deterministic() {
+        let (source, target, _) = collinear_fixture(24);
+        let mut config = fallback_test_config();
+        config.allow_fixed_rotation_fallback = true;
+        config.alignment.random_seed = 73;
+        let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("first deterministic run");
+        let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("second deterministic run");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn malformed_input_never_attempts_fixed_rotation_fallback() {
+        let (mut source, target, _) = collinear_fixture(24);
+        source[4].1 = pose_from_center(UnitQuaternion::identity(), Point3::new(f64::NAN, 0.0, 0.0));
+        let mut config = fallback_test_config();
+        config.allow_fixed_rotation_fallback = true;
+        let error =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config).unwrap_err();
+        assert_eq!(
+            error.reason,
+            RigSubmapAlignmentRejectionReason::NonFinitePose
+        );
+        assert!(!error.diagnostics.fallback_attempted);
+        assert!(error.sim3_rejection.is_none());
+        assert!(error.fallback_rejection.is_none());
+    }
+
+    #[test]
+    fn fixed_rotation_primary_is_deterministic_and_skips_generic_estimator() {
+        let (source, target, truth) = collinear_fixture(24);
+        let mut config = fallback_test_config();
+        config.prefer_fixed_rotation_alignment = true;
+        let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("fixed-primary should recover the collinear gauge");
+        let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("fixed-primary should be deterministic");
+        assert_eq!(first, second);
+        assert_eq!(
+            first.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::FixedRotationPrimary)
+        );
+        assert!(!first.diagnostics.fallback_attempted);
+        assert!(!first.diagnostics.fallback_used);
+        assert!(first.diagnostics.generic_sim3_rejection.is_none());
+        assert!((first.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-9);
+
+        let mut rejecting = config;
+        rejecting.alignment.min_scale = 10.0;
+        let error =
+            estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &rejecting).unwrap_err();
+        assert_eq!(
+            error.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::FixedRotationPrimary)
+        );
+        assert!(!error.diagnostics.fallback_attempted);
+        assert!(error.sim3_rejection.is_some());
+        assert!(error.diagnostics.fixed_rotation_rejection.is_some());
+        assert_eq!(
+            error.sim3_rejection.as_ref().unwrap().reason,
+            SubmapSim3RejectionReason::NoRobustFit
+        );
+    }
+
+    #[test]
+    fn alignment_method_names_are_stable() {
+        assert_eq!(RigSubmapAlignmentMethod::Generic.as_str(), "generic");
+        assert_eq!(
+            RigSubmapAlignmentMethod::FixedRotationPrimary.as_str(),
+            "fixed-primary"
+        );
+        assert_eq!(
+            RigSubmapAlignmentMethod::FixedRotationFallback.as_str(),
+            "fixed-fallback"
+        );
+        assert_eq!(
+            RigSubmapAlignmentMethod::GenericFallback.as_str(),
+            "generic-fallback"
+        );
+    }
+
+    #[test]
+    fn generic_fallback_after_fixed_primary_is_opt_in_and_deterministic() {
+        let (source, target, truth) = fixed_rotation_mismatch_fixture(24, 20.0);
+        let mut config = fallback_test_config();
+        config.prefer_fixed_rotation_alignment = true;
+        config.alignment.max_rotation_disagreement_deg = 60.0;
+
+        let fixed_only = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect_err("fixed-primary should reject the mismatched rig rotation");
+        assert_eq!(
+            fixed_only.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::FixedRotationPrimary)
+        );
+        assert!(!fixed_only.diagnostics.fallback_attempted);
+        assert!(fixed_only.diagnostics.fixed_rotation_rejection.is_some());
+        assert!(fixed_only.diagnostics.generic_fallback_rejection.is_none());
+
+        config.allow_generic_fallback_after_fixed_rotation = true;
+        let first = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("generic fallback should recover the centre geometry");
+        let second = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect("generic fallback should be deterministic");
+        assert_eq!(first, second);
+        assert_eq!(
+            first.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::GenericFallback)
+        );
+        assert!(first.diagnostics.fallback_attempted);
+        assert!(first.diagnostics.fallback_used);
+        assert!(first.diagnostics.fixed_rotation_rejection.is_some());
+        assert!(first.diagnostics.generic_fallback_rejection.is_none());
+        assert!(
+            (first
+                .constraint
+                .target_from_source
+                .rotation
+                .rotation_to(&truth.rotation))
+            .angle()
+                < 1.0e-9
+        );
+        assert!((first.constraint.target_from_source.scale - truth.scale).abs() < 1.0e-9);
+    }
+
+    #[test]
+    fn generic_fallback_after_fixed_primary_retains_both_rejections() {
+        let (source, target, _) = fixed_rotation_mismatch_fixture(24, 20.0);
+        let mut config = fallback_test_config();
+        config.prefer_fixed_rotation_alignment = true;
+        config.allow_generic_fallback_after_fixed_rotation = true;
+        config.alignment.max_rotation_disagreement_deg = 5.0;
+        let error = estimate_rig_submap_sim3_constraint(0, 1, &source, &target, &config)
+            .expect_err("the strict generic fallback rotation gate should reject");
+        assert_eq!(
+            error.diagnostics.alignment_method,
+            Some(RigSubmapAlignmentMethod::GenericFallback)
+        );
+        assert!(error.diagnostics.fallback_attempted);
+        assert!(!error.diagnostics.fallback_used);
+        assert!(error.diagnostics.fixed_rotation_rejection.is_some());
+        assert!(error.diagnostics.generic_fallback_rejection.is_some());
+        assert_eq!(
+            error
+                .sim3_rejection
+                .as_ref()
+                .expect("primary fixed rejection")
+                .reason,
+            error
+                .diagnostics
+                .fixed_rotation_rejection
+                .as_ref()
+                .expect("diagnostic fixed rejection")
+                .reason
+        );
+        assert_eq!(
+            error
+                .fallback_rejection
+                .as_ref()
+                .expect("fallback generic rejection")
+                .reason,
+            error
+                .diagnostics
+                .generic_fallback_rejection
+                .as_ref()
+                .expect("diagnostic generic rejection")
+                .reason
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add bounded local-window replay and opt-in rig seam diagnostics; preserve calibrated sensor extrinsics during trajectory publication.
- Add deterministic overlap controls and sparse unit-scale SE3 cycle optimization with finite/cost/anchor checks. Default behavior is unchanged.
- Preserve frozen OpenLORIS 10k evidence: 9,998 images, but L trajectory RMSE/p95 still miss COLMAP; interior ownership and equal-weight optimization regress and are not promoted.
- Correct README comparison context and update current handover. This PR does not claim a merged landmark model, equivalent-quality mapper speed, or completion of M8–M10.

## Validation

- 34 trajectory-example tests, including noncommuting transforms and actual write/reparse stereo calibration preservation.
- 638 SLAM library tests passed, 7 ignored; 10 pose-graph integration tests passed.
- cargo check --workspace --all-targets; example clippy with warnings denied; cargo fmt --check; git diff --check.
- Frozen 10k default output byte-identical; metric variant repeated byte-identically. Independent 500-frame projection audit matches reported reprojection and validates bidirectional tracks.

## Remaining goal

Real landmark integration, observation-based bounded refinement, COLMAP quality gates, full mapper/E2E performance, tier/restart/stress validation remain open.