### PR TITLE
test(slam): validate private implicit Schur PCG primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ p95 target, but **RMSE parity is still open**.
 | Observation-weighted mean reprojection ↓ | 0.9030 px | **0.5817 px** | Met |
 
 Both models contain connected 4,494-frame and 505-frame components. Lower
-reprojection error is not proof of better trajectory accuracy. This is a
+reprojection error is not proof of better trajectory accuracy. ATE uses one
+Sim(3) alignment per component; RMSE and p95 are computed from the pooled
+GT-scored image errors, not averages of component scores. This is a
 repeated development-sequence evaluation, not held-out validation, and no
 10k speed win at equivalent quality is claimed. See the
 [frozen COLMAP control](benchmarks/electro/m8-openloris-colmap-10k-control.json)

--- a/benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json
+++ b/benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json
@@ -102,10 +102,11 @@
       "checks_passed": 8,
       "rust_duration": "3m42s"
     },
-    "final_ci_status": "pending_final_evidence_head",
+    "final_ci": {"run_id": 34104286558, "head_commit": "7623012213bb3e00114a79258dacc91689938490", "checks_passed": 8, "rust_duration": "4m21s"},
+    "merge": {"pr": 76, "commit": "56bea962c71a728f0898390792f0168cade62dd0", "merged_at": "2026-09-07T09:12:44Z", "local_and_remote_branch_removed": true},
     "benchmark_registry_and_documentation_links": "pass"
   },
-  "decision": "Promote the output-preserving selection reuse after final CI: serial main-stage median time is 10.6 percent lower with unchanged outputs/logs and no material RSS change. All frozen mode regressions and both pass-one checkpoints match. The COLMAP RMSE gate and full mapper/native E2E, tier, restart and 100k I/O gates remain open.",
+  "decision": "Promoted after all eight final CI checks and merged as PR76: serial main-stage median time is 10.6 percent lower with unchanged outputs/logs and no material RSS change. All frozen mode regressions and both pass-one checkpoints match. The COLMAP RMSE gate and full mapper/native E2E, tier, restart and 100k I/O gates remain open.",
   "mode_regressions": {
     "candidate-filtered-tail": {
       "reference": "connected-filtered-ba-v1/component-001",

--- a/benchmarks/electro/m8-openloris-implicit-schur-prototype-v1.json
+++ b/benchmarks/electro/m8-openloris-implicit-schur-prototype-v1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "date": "2026-09-07",
+  "status": "private_numerical_gate_passed_production_unmodified",
+  "pull_request": "https://github.com/rsasaki0109/visloc-rs/pull/77",
+  "initial_implementation_commit": "469ee9a",
+  "numerical_supplement_commit": "8a1485a",
+  "source_sha256": "f468f484606345958a47488ee90a20faa4abc22f6ecbbb9a4c4a4976282c32e9",
+  "scope": {
+    "source": "pipelines/slam/src/bundle.rs",
+    "module": "implicit_schur_prototype_tests",
+    "test_only": true,
+    "production_solver_public_api_and_cli_changed": false,
+    "operator": "Damped pose diagonal minus E times damped landmark inverse times E transpose; original cross-block order retained",
+    "preconditioner": "Block Jacobi of the reduced Schur matrix; repeated sensor cross blocks summed by rig pose before forming each diagonal contribution",
+    "storage": "Borrowed landmark/cross blocks, per-landmark 3x3 inverses and per-pose 6x6 diagonal/preconditioner blocks; no reduced pose-pair matrix or factor fill in the operator",
+    "explicit_dense_oracles": "Small test fixtures only; not a production fallback",
+    "successful_exit": "Recompute norm(rhs - operator(solution)) and require it to meet max(absolute_tolerance, relative_tolerance * norm(rhs))",
+    "empty_pose_input": "Rejected; production landmark-only/all-fixed BA integration is not covered",
+    "singular_landmark": "Match existing mixed-pose solve_step skip and zero back-substitution; not a physical validity claim"
+  },
+  "independent_hand_fixture": {
+    "method": "Read-only NumPy full 15x15 and reduced 12x12 solves, independent of Rust implementation",
+    "pose_diagonal": "10 I6 for each of two poses",
+    "landmark_hessian": "4 I3",
+    "cross_blocks": "A=[I3;0], [(pose0,A),(pose0,2A),(pose1,-A)]",
+    "gradients": "pose=[1,...,12], landmark=[1,2,3]",
+    "cases": [
+      {
+        "lambda": 0.0,
+        "schur_translation_diagonal_pose0": 7.75,
+        "schur_translation_diagonal_pose1": 9.75,
+        "schur_translation_cross": 0.75,
+        "reduced_rhs_first3": [-0.25, -0.5, -0.75],
+        "full_min_eigenvalue": 2.6411010564593247,
+        "full_vs_recovered_step_l2": 2.0134752377258409e-16
+      },
+      {
+        "lambda": 0.5,
+        "schur_translation_diagonal_pose0": 8.5,
+        "schur_translation_diagonal_pose1": 10.277777777777779,
+        "schur_translation_cross": 0.6666666666666666,
+        "reduced_rhs_first3": [-0.3333333333333333, -0.6666666666666666, -1.0],
+        "full_min_eigenvalue": 3.1411010564593247,
+        "full_vs_recovered_step_l2": 3.033782894060535e-16
+      }
+    ]
+  },
+  "root_validation": {
+    "cargo test -p visloc-slam --lib bundle::": "21 passed, including 10 private prototype tests",
+    "cargo clippy -p visloc-slam --lib --tests -- -D warnings": "passed",
+    "cargo fmt --check": "passed",
+    "python3 -m unittest discover -s tests -p 'test_*openloris*.py'": "23 passed",
+    "python3 -m unittest discover -s tests -p 'test_audit_colmap*.py'": "23 passed",
+    "bash scripts/check_docs_links.sh": "passed",
+    "benchmark_registry_validate": "189 files passed",
+    "benchmark_registry_check_generated": "passed"
+  },
+  "final_head_ci": "pending; see pull request exact-head checks before merge",
+  "readme_scoring_clarification": "One Sim(3) alignment per component, then pooled GT-scored image errors for RMSE and p95, not averages of component metrics. Scorer source and frozen comparison values unchanged; aggregation regression test added.",
+  "limits": {
+    "global_or_10k_experiment_run": false,
+    "pipeline_peak_rss_or_speed_gain_measured": false,
+    "trajectory_quality_gain_measured": false,
+    "gauge_validity_inferred_from_linear_convergence": false,
+    "outstanding": "Pre-assembly production eligibility checks, model gauges, deterministic nonlinear acceptance, landmark-only integration, small-model/1k comparison, connected 10k quality/resource tests, mapper/native E2E accounting, all-tier nonregression, restart and 100k I/O"
+  },
+  "primary_references": [
+    "https://ceres-solver.readthedocs.io/latest/nnls_solving.html#iterative-schur",
+    "https://homes.cs.washington.edu/~sagarwal/bal.pdf"
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -52,8 +52,11 @@
 > PR #76は最終CI8項目通過（run 34104286558）後、`56bea96`へmergeし旧branchも整理済み。
 > [scan共有の測定記録](../benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json)。
 > 現在は `feat/m8-implicit-schur-prototype`。private/test-onlyのimplicit Schur作用素と
-> PCGの数値検証へ進みます。既定solver・公開API・mapper CLIは変更せず、global runは
-> まだ行いません。具体的な検証契約は有界BA文書の末尾にあります。
+> PCGの数値試作を実装済み。既定solver・公開API・mapper CLIは変更せず、global runは
+> まだ行いません。真の線形残差、複数センサーのcross項、明示行列との作用素・step一致を
+> 検証しています。空pose入力の拒否は、本番の全pose固定/点のみBAの検証とは別です。
+> 次の本番組み込みでは非対応factorを行列組立前に拒否し、固定gaugeの小規模/1k比較を
+> 先行します。具体的な検証契約は有界BA文書の末尾にあります。
 > この局所処理の時間をmapper全体やnative E2Eの高速化実績とは扱いません。
 > 10k精度、高速化、省メモリ、各規模の非回帰とM9/M10の最終条件は維持します。
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -49,8 +49,11 @@
 > 全6実行でモデル・ログ全文一致、RSS中央値525,232/525,036 KiB（実質同じ）。
 > strict主成分、点保持両成分、2回適用両成分、filtered末尾成分の非回帰が完了。
 > 各6ファイルと、2回適用の両成分1巡目checkpointも凍結モデルに完全一致。
-> 実装commitのCIは8項目通過（run 34102096800）、最終headのCI/mergeは未完了。
+> PR #76は最終CI8項目通過（run 34104286558）後、`56bea96`へmergeし旧branchも整理済み。
 > [scan共有の測定記録](../benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json)。
+> 現在は `feat/m8-implicit-schur-prototype`。private/test-onlyのimplicit Schur作用素と
+> PCGの数値検証へ進みます。既定solver・公開API・mapper CLIは変更せず、global runは
+> まだ行いません。具体的な検証契約は有界BA文書の末尾にあります。
 > この局所処理の時間をmapper全体やnative E2Eの高速化実績とは扱いません。
 > 10k精度、高速化、省メモリ、各規模の非回帰とM9/M10の最終条件は維持します。
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -57,6 +57,10 @@
 > 検証しています。空pose入力の拒否は、本番の全pose固定/点のみBAの検証とは別です。
 > 次の本番組み込みでは非対応factorを行列組立前に拒否し、固定gaugeの小規模/1k比較を
 > 先行します。具体的な検証契約は有界BA文書の末尾にあります。
+> `469ee9a`＋`8a1485a`の試作10テストを含むBA 21テスト、clippy/fmt、関連Python
+> 46テストが通過。手計算fixtureとfull 15×15連立系も独立照合済みです。
+> [数値検証記録](../benchmarks/electro/m8-openloris-implicit-schur-prototype-v1.json)。
+> PR #77の最終head CI確認とmergeが次のcheckpointです。
 > この局所処理の時間をmapper全体やnative E2Eの高速化実績とは扱いません。
 > 10k精度、高速化、省メモリ、各規模の非回帰とM9/M10の最終条件は維持します。
 

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -535,14 +535,15 @@ integration/recovery/repair/filtering/publication only,
 not the source-window mapper, atlas construction, frontend or native E2E.
 See [selection reuse evidence](../benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json).
 
-### Read-only solver-memory audit (not a selected next implementation)
+### Solver-memory audit (production path unchanged)
 
 The current pure-visual sparse path in `pipelines/slam/src/bundle.rs`,
 `solve_step_pose_blocks`, avoids a dense camera Hessian but still materializes
 the reduced Schur matrix as block-column maps. Its nested pose-pair loop for
 each landmark adds shared-track couplings, and it calls the direct cached
 block-Cholesky solver. `LandmarkBlock.cross` retains pose/landmark cross blocks.
-No matrix-free iterative Schur/PCG path currently exists in these solvers.
+No production matrix-free iterative Schur/PCG path currently exists in these
+solvers; the private test-only prototype below does not change that path.
 
 A matrix-free Schur operator could avoid storing the reduced matrix and its
 factor fill, but would still retain observation/cross-block state unless that
@@ -569,7 +570,7 @@ global refinement will improve this dataset's trajectory. A future experiment
 must retain identical observations, calibration, damping and GT-free acceptance
 before attributing any change to the solver.
 
-#### Proposed private operator gate
+#### Private operator gate
 
 PR #76 merged as `56bea96` after all eight final CI checks passed
 (run 34104286558); its old branch is removed. The selected next bounded task
@@ -578,6 +579,10 @@ prototype, not a new mapper flag or global solve. Reuse `NormalEquationsBa`,
 `LandmarkBlock` and the already constrained `CameraHessian::PoseDiagonal`;
 explicitly reject `Dense` input. Do not add a variant to the shared public
 `LinearSolver` enum or a required field to public `BaConfig` struct literals.
+A later production entry point must reject unsupported priors/factors before
+normal-equation assembly: rejecting an already allocated `Dense` system cannot
+undo its quadratic allocation. The private prototype alone does not prove this
+pipeline-level memory gate.
 
 For each landmark, compute the sum of all cross-block transposed products
 before applying its damped 3-by-3 inverse, then scatter through every original
@@ -591,7 +596,9 @@ Match the current pose/landmark identity damping and singular-landmark inverse
 skip/back-substitution behavior in the operator oracle. Check operator action,
 reduced RHS, preconditioner diagonal and complete pose/landmark step against
 small explicit systems, including repeated sensor slots, zero/nonzero damping,
-fixed rotations and all-fixed-pose cases. Test dimension/nonfinite errors,
+fixed rotations and empty pose systems. The prototype rejects an empty pose
+system; this is not a test of the production landmark-only/all-fixed solve.
+That separate branch must be validated during integration. Test dimension/nonfinite errors,
 residual criteria, iteration limits and repeated-run determinism. Numerical
 agreement with a direct solver is tolerance-based; default-path compatibility
 and same-prototype repeat determinism are separate checks.
@@ -601,3 +608,28 @@ positive damping, is not evidence of a physically valid gauge. Component
 anchoring and fixed-rig calibration remain model-level prerequisites before
 any later integration. This gate proves a solver primitive only; global memory,
 runtime, trajectory quality and all original M8–M10 outcomes remain unproven.
+
+#### Next integration gate (not implemented by this prototype)
+
+After the private numerical gate and CI, expose an additive, opt-in pure-visual
+entry point with separate iterative options. Keep existing public enum variants,
+configuration struct literals and default solver behavior unchanged. Before
+assembling normal equations, reject velocity/bias states and unsupported
+priors or nonvisual factors; never fall back to a dense camera matrix. Check
+component anchors and fixed physical rig calibration at the model boundary.
+
+First compare the same anchored small model against the direct solver, then a
+frozen 1k input with identical observations, calibration, damping and robust
+loss. Record true linear residuals, iteration counts, nonlinear cost acceptance,
+whole-process peak RSS, time and output geometry. Explicitly test landmark-only
+systems and rejected steps without partial pose/point mutation. A failed PCG
+solve must be visible and handled through a bounded rejection/damping policy,
+not an unbounded direct-solver fallback. Preserve deterministic repeated runs.
+
+Only after these gates pass, select a separately recorded connected-atlas 10k
+experiment with a 2 GiB stop limit and fixed observation/support/geometry
+checks. Keep GT out of optimization and acceptance; score the unchanged two
+components afterward. Lower linear residual or nonlinear reprojection cost
+alone does not meet the trajectory gate. Mapper-only and native-E2E accounting
+must include their respective upstream stages; this prototype supplies neither
+a pipeline memory bound nor an end-to-end speed comparison.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -571,7 +571,9 @@ before attributing any change to the solver.
 
 #### Proposed private operator gate
 
-If selected after PR #76 closes, start with a private, test-only operator/PCG
+PR #76 merged as `56bea96` after all eight final CI checks passed
+(run 34104286558); its old branch is removed. The selected next bounded task
+on `feat/m8-implicit-schur-prototype` starts with a private, test-only operator/PCG
 prototype, not a new mapper flag or global solve. Reuse `NormalEquationsBa`,
 `LandmarkBlock` and the already constrained `CameraHessian::PoseDiagonal`;
 explicitly reject `Dense` input. Do not add a variant to the shared public

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -609,6 +609,16 @@ anchoring and fixed-rig calibration remain model-level prerequisites before
 any later integration. This gate proves a solver primitive only; global memory,
 runtime, trajectory quality and all original M8–M10 outcomes remain unproven.
 
+The implementation (`469ee9a`, numerical supplement `8a1485a`) passes all ten
+private prototype tests and all 21 tests in the BA namespace, independently
+rerun by the reviewer. A hand-computable two-pose fixture checks zero/nonzero
+damping against the full 15-by-15 normal system, including same-pose sensor
+cross terms. The rig matvec tolerance uses the magnitudes of the unreduced and
+eliminated terms so cancellation does not hide the floating-point scale.
+Clippy, formatting and 46 relevant Python tests pass. PR #77 final-head CI is
+pending; [numerical evidence](../benchmarks/electro/m8-openloris-implicit-schur-prototype-v1.json)
+records scope and limitations. No production or 10k performance claim follows.
+
 #### Next integration gate (not implemented by this prototype)
 
 After the private numerical gate and CI, expose an additive, opt-in pure-visual

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -31,11 +31,16 @@ Final tier nonregression, restart and 100k I/O gates also remain open.
 See [filtering quality evidence](../benchmarks/electro/m8-openloris-atlas-connected-filtered-ba-v1.json)
 and [scan-reuse measurements](../benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json).
 
-The next selected primitive-level memory experiment is an implicit Schur operator,
-initially only a private correctness prototype compared against the existing
-explicit solver. It must not silently allocate a dense system, alter public
+The selected primitive-level memory experiment is an implicit Schur operator.
+The private, test-only prototype now compares operator action, reduced RHS,
+block-Jacobi preconditioning and recovered steps against explicit systems.
+Successful PCG exits recompute the true residual; damping or zero RHS is not
+treated as evidence of a valid physical gauge. Production behavior is unchanged.
+The next integration must not silently allocate a dense system, alter public
 `LinearSolver`/`BaConfig` contracts, or infer valid rig gauges from a damped
-linear solve. No global run or quality improvement is assumed from this option;
+linear solve. Unsupported factors must be rejected before assembly, and an
+anchored small-system/1k comparison precedes any connected-atlas global run.
+No global run or quality improvement is assumed from this option;
 see the [solver-memory audit and primary references](openloris_atlas_bounded_ba.md).
 
 ## Historical M7 baseline

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -23,14 +23,15 @@ PR #76 reduces duplicate landmark-selection scans without changing any model
 or log bytes. Three serial runs per arm measure a local-stage median reduction
 from 172.69 to 154.39 s (10.6%), with essentially unchanged RSS. Remaining
 mode-regression checks now pass, including both pass-one checkpoints; final
-CI/merge checks remain in progress. These times exclude
+CI also passed all eight checks, and PR #76 merged as `56bea96` with its old
+branch removed. These times exclude
 source-window reconstruction, atlas construction and the frontend: **mapper-
 only and native-E2E performance are still unproven for this atlas pipeline**.
 Final tier nonregression, restart and 100k I/O gates also remain open.
 See [filtering quality evidence](../benchmarks/electro/m8-openloris-atlas-connected-filtered-ba-v1.json)
 and [scan-reuse measurements](../benchmarks/electro/m8-openloris-atlas-selected-scan-reuse-v1.json).
 
-The next memory option under consideration is an implicit Schur operator,
+The next selected primitive-level memory experiment is an implicit Schur operator,
 initially only a private correctness prototype compared against the existing
 explicit solver. It must not silently allocate a dense system, alter public
 `LinearSolver`/`BaConfig` contracts, or infer valid rig gauges from a damped

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -5830,6 +5830,64 @@ mod implicit_schur_prototype_tests {
         }
     }
 
+    fn hand_check_system() -> NormalEquationsBa {
+        let mut a = Matrix6x3::zeros();
+        for component in 0..3 {
+            a[(component, component)] = 1.0;
+        }
+        NormalEquationsBa {
+            h_pp: CameraHessian::PoseDiagonal(vec![
+                Matrix6::from_diagonal(&Vector6::from_element(10.0)),
+                Matrix6::from_diagonal(&Vector6::from_element(10.0)),
+            ]),
+            b_p: DVector::from_iterator(12, (1..=12).map(|value| value as f64)),
+            landmarks: vec![LandmarkBlock {
+                h_ll: Matrix3::from_diagonal(&Vector3::from_element(4.0)),
+                b_l: Vector3::new(1.0, 2.0, 3.0),
+                // B = 10 I, H_ll = 4 I, A = [I; 0], with two sensor
+                // observations sharing pose 0 and one observation at pose 1.
+                cross: vec![(0, a), (0, 2.0 * a), (1, -a)],
+            }],
+        }
+    }
+
+    fn full_normal_system(system: &NormalEquationsBa, lambda: f64) -> (DMatrix<f64>, DVector<f64>) {
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            panic!("test oracle requires pose blocks");
+        };
+        let mut normal = DMatrix::zeros(15, 15);
+        for (pose, block) in diagonal.iter().enumerate() {
+            let mut damped = *block;
+            for component in 0..6 {
+                damped[(component, component)] += lambda;
+            }
+            normal
+                .fixed_view_mut::<6, 6>(pose * 6, pose * 6)
+                .copy_from(&damped);
+        }
+        let mut h_ll = system.landmarks[0].h_ll;
+        for component in 0..3 {
+            h_ll[(component, component)] += lambda;
+        }
+        normal.fixed_view_mut::<3, 3>(12, 12).copy_from(&h_ll);
+        for (pose, cross) in &system.landmarks[0].cross {
+            for row in 0..6 {
+                for column in 0..3 {
+                    normal[(pose * 6 + row, 12 + column)] += cross[(row, column)];
+                    normal[(12 + column, pose * 6 + row)] += cross[(row, column)];
+                }
+            }
+        }
+        let mut rhs = DVector::zeros(15);
+        for (index, value) in system.b_p.iter().enumerate() {
+            rhs[index] = -*value;
+        }
+        for (index, value) in system.landmarks[0].b_l.iter().enumerate() {
+            rhs[12 + index] = -*value;
+        }
+        (normal, rhs)
+    }
+
     #[test]
     fn implicit_operator_matches_explicit_schur_rhs_preconditioner_and_step() {
         let lambda = 0.25;
@@ -5887,6 +5945,79 @@ mod implicit_schur_prototype_tests {
         let expected_pose0 =
             expected_inverse * Vector6::from_iterator((0..6).map(|i| (i + 1) as f64));
         assert!((applied.fixed_rows::<6>(0).into_owned() - expected_pose0).norm() < 1.0e-12);
+    }
+
+    #[test]
+    fn hand_check_fixture_matches_schur_and_full_normal_for_both_damping_values() {
+        for lambda in [0.0, 0.5] {
+            let system = hand_check_system();
+            let operator = ImplicitSchurOperator::new(&system, lambda).unwrap();
+            let schur = explicit_schur(&system, lambda);
+            let expected_pose0 = if lambda == 0.0 { 7.75 } else { 8.5 };
+            let expected_pose1 = if lambda == 0.0 {
+                9.75
+            } else {
+                10.277777777777779
+            };
+            let expected_cross = if lambda == 0.0 {
+                0.75
+            } else {
+                0.6666666666666666
+            };
+            for component in 0..3 {
+                assert!((schur[(component, component)] - expected_pose0).abs() < 1.0e-12);
+                assert!((schur[(6 + component, 6 + component)] - expected_pose1).abs() < 1.0e-12);
+                assert!((schur[(component, 6 + component)] - expected_cross).abs() < 1.0e-12);
+                assert!((schur[(6 + component, component)] - expected_cross).abs() < 1.0e-12);
+            }
+            for component in 3..6 {
+                assert!((schur[(component, component)] - (10.0 + lambda)).abs() < 1.0e-12);
+                assert!((schur[(6 + component, 6 + component)] - (10.0 + lambda)).abs() < 1.0e-12);
+                assert_eq!(schur[(component, 6 + component)], 0.0);
+            }
+
+            let expected_rhs0 = if lambda == 0.0 {
+                [-0.25, -0.5, -0.75]
+            } else {
+                [-1.0 / 3.0, -2.0 / 3.0, -1.0]
+            };
+            let expected_rhs1 = if lambda == 0.0 {
+                [-7.25, -8.5, -9.75]
+            } else {
+                [-65.0 / 9.0, -76.0 / 9.0, -29.0 / 3.0]
+            };
+            for component in 0..3 {
+                assert!((operator.rhs[component] - expected_rhs0[component]).abs() < 1.0e-12);
+                assert!((operator.rhs[6 + component] - expected_rhs1[component]).abs() < 1.0e-12);
+            }
+
+            let (normal, full_rhs) = full_normal_system(&system, lambda);
+            let full_delta = solve_normal_equations(&normal, &full_rhs).unwrap();
+            let mut direct_system = hand_check_system();
+            let direct = solve_step(
+                &mut direct_system,
+                2,
+                1,
+                0,
+                0,
+                lambda,
+                LinearSolver::Sparse,
+                false,
+                &mut None,
+            )
+            .unwrap();
+            assert!((direct.0.clone() - full_delta.rows(0, 12)).norm() < 1.0e-10);
+            assert!((direct.1.clone() - full_delta.rows(12, 3)).norm() < 1.0e-10);
+            let result = operator
+                .solve_pcg(operator.rhs(), PcgOptions::default())
+                .unwrap();
+            assert!((result.solution.clone() - full_delta.rows(0, 12)).norm() < 1.0e-9);
+            assert!(
+                (operator.complete_delta(&result.solution).unwrap() - full_delta.rows(12, 3))
+                    .norm()
+                    < 1.0e-9
+            );
+        }
     }
 
     #[test]
@@ -5964,7 +6095,50 @@ mod implicit_schur_prototype_tests {
         let x = DVector::from_element(6, 0.2);
         let expected = explicit_schur(&system, 0.1) * &x;
         let actual = operator.apply(&x).unwrap();
-        assert!((&actual - expected).norm() < 1.0e-9);
+        // Explicit and implicit forms reassociate cross-sensor products.  The
+        // rounding scale is the sum of the unreduced Bx term and the
+        // eliminated E C⁻¹ Eᵀx term, since their subtraction can cancel to a
+        // much smaller Schur result.  This is scale-aware rather than a
+        // pixel-constant absolute threshold and follows camera/rig scaling.
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            panic!("rig matvec test requires pose blocks");
+        };
+        let mut base = DVector::zeros(x.len());
+        for (pose, block) in diagonal.iter().enumerate() {
+            let mut damped = *block;
+            for component in 0..6 {
+                damped[(component, component)] += 0.1;
+            }
+            let value = damped * x.fixed_rows::<6>(pose * 6).into_owned();
+            for component in 0..6 {
+                base[pose * 6 + component] = value[component];
+            }
+        }
+        // Sum the magnitudes of the individual E C⁻¹ Eᵀx pair products, not
+        // only their potentially-cancelled aggregate.  This captures the
+        // arithmetic scale of the two evaluation orders.
+        let inverse = (system.landmarks[0].h_ll + 0.1 * Matrix3::<f64>::identity())
+            .try_inverse()
+            .unwrap();
+        let mut eliminated_term_scale = 0.0;
+        for (_pose, a) in &system.landmarks[0].cross {
+            for (other_pose, b) in &system.landmarks[0].cross {
+                let x_other: Vector6<f64> = x.fixed_rows::<6>(other_pose * 6).into_owned();
+                let term: Vector6<f64> = a * inverse * b.transpose() * x_other;
+                eliminated_term_scale += term.norm();
+            }
+        }
+        let scale =
+            (base.norm() + eliminated_term_scale + actual.norm() + expected.norm()).max(1.0);
+        let tolerance = 64.0 * f64::EPSILON * scale;
+        let difference = (&actual - &expected).norm();
+        assert!(
+            difference <= tolerance,
+            "rig matvec diff={} scale={} tolerance={}",
+            difference,
+            scale,
+            tolerance
+        );
     }
 
     #[test]
@@ -6070,7 +6244,7 @@ mod implicit_schur_prototype_tests {
     }
 
     #[test]
-    fn empty_pose_operator_is_not_a_landmark_only_fallback() {
+    fn empty_pose_operator_rejects_pose_reduced_system() {
         let empty = NormalEquationsBa {
             h_pp: CameraHessian::PoseDiagonal(Vec::new()),
             b_p: DVector::zeros(0),
@@ -6080,9 +6254,9 @@ mod implicit_schur_prototype_tests {
             ImplicitSchurOperator::new(&empty, 0.0),
             Err(ImplicitSchurError::EmptySystem)
         ));
-        // The production solve_step has a separate p_count == 0 branch for
-        // landmark-only BA; this pose-reduced prototype intentionally does
-        // not silently take ownership of that path.
+        // This only checks the prototype's empty pose-reduced input.  It is
+        // not a production all-fixed-pose solver test: solve_step has a
+        // separate p_count == 0 landmark-only branch.
     }
 
     #[test]

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -5298,6 +5298,897 @@ impl LocalRefiner for BundleAdjustmentRefiner {
     }
 }
 
+/// Test-only implicit Schur prototype.
+///
+/// This deliberately does not participate in the public BA API.  It is a
+/// small numerical oracle for a future matrix-free backend: the production
+/// solver still uses `LinearSolver::{Dense,Sparse}` unchanged.  The operator
+/// consumes the already assembled pure-visual `PoseDiagonal` system and
+/// never constructs pose-pair blocks, triplets, or a Cholesky factor.
+#[cfg(test)]
+mod implicit_schur_prototype_tests {
+    use super::*;
+    use nalgebra::UnitQuaternion;
+
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    enum ImplicitSchurError {
+        DenseCameraHessian,
+        EmptySystem,
+        DimensionMismatch {
+            expected: usize,
+            actual: usize,
+        },
+        NonFinite(&'static str),
+        InvalidLambda,
+        InvalidTolerance,
+        NonSpdPreconditioner(usize),
+        NonPositiveCurvature,
+        ResidualCheckFailed {
+            recursive_norm: f64,
+            true_norm: f64,
+            target: f64,
+        },
+        MaxIterations {
+            iterations: usize,
+            residual_norm: f64,
+            target: f64,
+        },
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    struct PcgOptions {
+        max_iterations: usize,
+        relative_tolerance: f64,
+        absolute_tolerance: f64,
+    }
+
+    impl Default for PcgOptions {
+        fn default() -> Self {
+            Self {
+                max_iterations: 128,
+                relative_tolerance: 1.0e-12,
+                absolute_tolerance: 1.0e-12,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct PcgResult {
+        solution: DVector<f64>,
+        iterations: usize,
+        residual_norm: f64,
+        target: f64,
+    }
+
+    /// A pure-visual Schur operator over the six-dimensional pose blocks.
+    ///
+    /// `landmarks` and their cross blocks are borrowed from
+    /// `NormalEquationsBa`; only the per-landmark 3×3 inverse cache and the
+    /// pose-block-Jacobi inverse are retained.  A repeated pose slot in one
+    /// landmark is intentional: the constructor groups those blocks only for
+    /// the preconditioner, while `apply` evaluates every original cross block
+    /// so same-frame multi-sensor terms are not lost.
+    struct ImplicitSchurOperator<'a> {
+        diagonal: Vec<Matrix6<f64>>,
+        landmarks: &'a [LandmarkBlock],
+        h_ll_inverse: Vec<Option<Matrix3<f64>>>,
+        preconditioner_inverse: Vec<Matrix6<f64>>,
+        rhs: DVector<f64>,
+    }
+
+    impl<'a> ImplicitSchurOperator<'a> {
+        fn new(system: &'a NormalEquationsBa, lambda: f64) -> Result<Self, ImplicitSchurError> {
+            if !lambda.is_finite() || lambda < 0.0 {
+                return Err(ImplicitSchurError::InvalidLambda);
+            }
+            let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+                return Err(ImplicitSchurError::DenseCameraHessian);
+            };
+            if diagonal.is_empty() {
+                return Err(ImplicitSchurError::EmptySystem);
+            }
+            let dimension = diagonal.len() * 6;
+            if system.b_p.len() != dimension {
+                return Err(ImplicitSchurError::DimensionMismatch {
+                    expected: dimension,
+                    actual: system.b_p.len(),
+                });
+            }
+            if !system.b_p.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("pose gradient"));
+            }
+            if !diagonal
+                .iter()
+                .flat_map(|block| block.iter())
+                .all(|value| value.is_finite())
+            {
+                return Err(ImplicitSchurError::NonFinite("pose Hessian"));
+            }
+
+            let mut damped_diagonal = diagonal.clone();
+            if lambda > 0.0 {
+                for block in &mut damped_diagonal {
+                    for component in 0..6 {
+                        block[(component, component)] += lambda;
+                    }
+                }
+            }
+            if !damped_diagonal
+                .iter()
+                .flat_map(|block| block.iter())
+                .all(|value| value.is_finite())
+            {
+                return Err(ImplicitSchurError::NonFinite("damped pose Hessian"));
+            }
+
+            let mut h_ll_inverse = Vec::with_capacity(system.landmarks.len());
+            let mut rhs = -&system.b_p;
+            for landmark in &system.landmarks {
+                if !landmark
+                    .h_ll
+                    .iter()
+                    .chain(landmark.b_l.iter())
+                    .all(|value| value.is_finite())
+                {
+                    return Err(ImplicitSchurError::NonFinite("landmark block"));
+                }
+                for (pose, cross) in &landmark.cross {
+                    if *pose >= diagonal.len() {
+                        return Err(ImplicitSchurError::DimensionMismatch {
+                            expected: diagonal.len(),
+                            actual: (*pose).saturating_add(1),
+                        });
+                    }
+                    if !cross.iter().all(|value| value.is_finite()) {
+                        return Err(ImplicitSchurError::NonFinite("landmark cross block"));
+                    }
+                }
+
+                let mut h_ll = landmark.h_ll;
+                if lambda > 0.0 {
+                    for component in 0..3 {
+                        h_ll[(component, component)] += lambda;
+                    }
+                }
+                if !h_ll.iter().all(|value| value.is_finite()) {
+                    return Err(ImplicitSchurError::NonFinite("damped landmark Hessian"));
+                }
+                let inverse = h_ll.try_inverse();
+                if let Some(inverse) = inverse {
+                    if !inverse.iter().all(|value| value.is_finite()) {
+                        return Err(ImplicitSchurError::NonFinite("landmark inverse"));
+                    }
+                }
+                h_ll_inverse.push(inverse);
+                let Some(inverse) = inverse else {
+                    // Match solve_step: an un-invertible landmark contributes
+                    // neither to the Schur system nor to back-substitution.
+                    continue;
+                };
+                for (pose, cross) in &landmark.cross {
+                    let update: Vector6<f64> = cross * inverse * landmark.b_l;
+                    for component in 0..6 {
+                        rhs[pose * 6 + component] += update[component];
+                    }
+                }
+            }
+            if !rhs.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("reduced right hand side"));
+            }
+
+            // Block-Jacobi preconditioner: aggregate all cross blocks that
+            // touch the same pose before forming the diagonal Schur term.
+            // This is essential when two sensors observe the same landmark
+            // from one rig frame: the cross-sensor terms belong in the same
+            // pose block, not in two independent diagonal blocks.
+            let mut preconditioner = damped_diagonal.clone();
+            for (landmark, inverse) in system.landmarks.iter().zip(&h_ll_inverse) {
+                let Some(inverse) = inverse else {
+                    continue;
+                };
+                let mut grouped: BTreeMap<usize, Matrix6x3<f64>> = BTreeMap::new();
+                for (pose, cross) in &landmark.cross {
+                    *grouped.entry(*pose).or_insert_with(Matrix6x3::zeros) += cross;
+                }
+                for (pose, cross) in grouped {
+                    preconditioner[pose] -= cross * inverse * cross.transpose();
+                }
+            }
+            if !preconditioner
+                .iter()
+                .flat_map(|block| block.iter())
+                .all(|value| value.is_finite())
+            {
+                return Err(ImplicitSchurError::NonFinite("Schur preconditioner"));
+            }
+
+            let mut preconditioner_inverse = Vec::with_capacity(preconditioner.len());
+            for (pose, block) in preconditioner.iter().enumerate() {
+                let Some(cholesky) = block.cholesky() else {
+                    return Err(ImplicitSchurError::NonSpdPreconditioner(pose));
+                };
+                let inverse = cholesky.inverse();
+                if !inverse.iter().all(|value| value.is_finite()) {
+                    return Err(ImplicitSchurError::NonFinite("preconditioner inverse"));
+                }
+                preconditioner_inverse.push(inverse);
+            }
+
+            Ok(Self {
+                diagonal: damped_diagonal,
+                landmarks: &system.landmarks,
+                h_ll_inverse,
+                preconditioner_inverse,
+                rhs,
+            })
+        }
+
+        fn dimension(&self) -> usize {
+            self.diagonal.len() * 6
+        }
+
+        fn rhs(&self) -> &DVector<f64> {
+            &self.rhs
+        }
+
+        fn h_ll_inverse(&self, index: usize) -> Option<Matrix3<f64>> {
+            self.h_ll_inverse[index]
+        }
+
+        fn apply(&self, x: &DVector<f64>) -> Result<DVector<f64>, ImplicitSchurError> {
+            if x.len() != self.dimension() {
+                return Err(ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: x.len(),
+                });
+            }
+            if !x.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("operator input"));
+            }
+            let mut out = DVector::zeros(self.dimension());
+            for (pose, block) in self.diagonal.iter().enumerate() {
+                let x_pose: Vector6<f64> = x.fixed_rows::<6>(pose * 6).into_owned();
+                let value = block * x_pose;
+                for component in 0..6 {
+                    out[pose * 6 + component] = value[component];
+                }
+            }
+            for (landmark, inverse) in self.landmarks.iter().zip(&self.h_ll_inverse) {
+                let Some(inverse) = inverse else {
+                    continue;
+                };
+                let mut projected = Vector3::zeros();
+                // Keep the original cross vector order.  Do not deduplicate
+                // here: duplicate pose slots encode separate sensor rows.
+                for (pose, cross) in &landmark.cross {
+                    let x_pose: Vector6<f64> = x.fixed_rows::<6>(pose * 6).into_owned();
+                    projected += cross.transpose() * x_pose;
+                }
+                let reduced = *inverse * projected;
+                for (pose, cross) in &landmark.cross {
+                    let value: Vector6<f64> = cross * reduced;
+                    for component in 0..6 {
+                        out[pose * 6 + component] -= value[component];
+                    }
+                }
+            }
+            if !out.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("operator output"));
+            }
+            Ok(out)
+        }
+
+        fn apply_preconditioner(
+            &self,
+            residual: &DVector<f64>,
+        ) -> Result<DVector<f64>, ImplicitSchurError> {
+            if residual.len() != self.dimension() {
+                return Err(ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: residual.len(),
+                });
+            }
+            if !residual.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("preconditioner input"));
+            }
+            let mut out = DVector::zeros(self.dimension());
+            for (pose, inverse) in self.preconditioner_inverse.iter().enumerate() {
+                let residual_pose: Vector6<f64> = residual.fixed_rows::<6>(pose * 6).into_owned();
+                let value = inverse * residual_pose;
+                for component in 0..6 {
+                    out[pose * 6 + component] = value[component];
+                }
+            }
+            if !out.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("preconditioner output"));
+            }
+            Ok(out)
+        }
+
+        fn solve_pcg(
+            &self,
+            rhs: &DVector<f64>,
+            options: PcgOptions,
+        ) -> Result<PcgResult, ImplicitSchurError> {
+            if rhs.len() != self.dimension() {
+                return Err(ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: rhs.len(),
+                });
+            }
+            if !rhs.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("PCG right hand side"));
+            }
+            if !options.relative_tolerance.is_finite()
+                || options.relative_tolerance < 0.0
+                || !options.absolute_tolerance.is_finite()
+                || options.absolute_tolerance < 0.0
+            {
+                return Err(ImplicitSchurError::InvalidTolerance);
+            }
+            // A converged zero-RHS or positively damped system only proves a
+            // numerical linear solve.  It does not prove that the model's
+            // monocular/rig gauge has been anchored; that remains a caller-
+            // level invariant outside this prototype.
+            let rhs_norm = rhs.norm();
+            let target = options
+                .absolute_tolerance
+                .max(options.relative_tolerance * rhs_norm);
+            if !target.is_finite() {
+                return Err(ImplicitSchurError::NonFinite("PCG target"));
+            }
+            let mut solution = DVector::zeros(self.dimension());
+            let mut residual = rhs.clone();
+            let mut residual_norm = residual.norm();
+            if !residual_norm.is_finite() {
+                return Err(ImplicitSchurError::NonFinite("initial residual"));
+            }
+            if residual_norm <= target {
+                return self.checked_result(rhs, solution, 0, residual_norm, target);
+            }
+            if options.max_iterations == 0 {
+                return Err(ImplicitSchurError::MaxIterations {
+                    iterations: 0,
+                    residual_norm,
+                    target,
+                });
+            }
+
+            let mut preconditioned = self.apply_preconditioner(&residual)?;
+            let mut direction = preconditioned.clone();
+            let mut rho = residual.dot(&preconditioned);
+            if !rho.is_finite() || rho <= 0.0 {
+                return Err(ImplicitSchurError::NonPositiveCurvature);
+            }
+
+            for iteration in 1..=options.max_iterations {
+                let applied = self.apply(&direction)?;
+                let curvature = direction.dot(&applied);
+                if !curvature.is_finite() || curvature <= 0.0 {
+                    return Err(ImplicitSchurError::NonPositiveCurvature);
+                }
+                let alpha = rho / curvature;
+                if !alpha.is_finite() {
+                    return Err(ImplicitSchurError::NonFinite("PCG step"));
+                }
+                solution += alpha * &direction;
+                residual -= alpha * applied;
+                residual_norm = residual.norm();
+                if !solution.iter().all(|value| value.is_finite()) || !residual_norm.is_finite() {
+                    return Err(ImplicitSchurError::NonFinite("PCG iterate"));
+                }
+                if residual_norm <= target {
+                    return self.checked_result(rhs, solution, iteration, residual_norm, target);
+                }
+                if iteration == options.max_iterations {
+                    return Err(ImplicitSchurError::MaxIterations {
+                        iterations: iteration,
+                        residual_norm,
+                        target,
+                    });
+                }
+                preconditioned = self.apply_preconditioner(&residual)?;
+                let next_rho = residual.dot(&preconditioned);
+                if !next_rho.is_finite() || next_rho <= 0.0 {
+                    return Err(ImplicitSchurError::NonPositiveCurvature);
+                }
+                let beta = next_rho / rho;
+                if !beta.is_finite() {
+                    return Err(ImplicitSchurError::NonFinite("PCG direction"));
+                }
+                direction = &preconditioned + beta * direction;
+                rho = next_rho;
+            }
+            unreachable!("the max-iteration branch returns above");
+        }
+
+        fn checked_result(
+            &self,
+            rhs: &DVector<f64>,
+            solution: DVector<f64>,
+            iterations: usize,
+            recursive_norm: f64,
+            target: f64,
+        ) -> Result<PcgResult, ImplicitSchurError> {
+            let applied = self.apply(&solution)?;
+            let true_residual = rhs - &applied;
+            let true_norm = true_residual.norm();
+            if !true_norm.is_finite() {
+                return Err(ImplicitSchurError::NonFinite("true PCG residual"));
+            }
+            if true_norm > target {
+                return Err(ImplicitSchurError::ResidualCheckFailed {
+                    recursive_norm,
+                    true_norm,
+                    target,
+                });
+            }
+            Ok(PcgResult {
+                solution,
+                iterations,
+                residual_norm: true_norm,
+                target,
+            })
+        }
+
+        fn complete_delta(
+            &self,
+            delta_pose: &DVector<f64>,
+        ) -> Result<DVector<f64>, ImplicitSchurError> {
+            if delta_pose.len() != self.dimension() {
+                return Err(ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: delta_pose.len(),
+                });
+            }
+            if !delta_pose.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("pose delta"));
+            }
+            let mut delta_landmarks = DVector::zeros(self.landmarks.len() * 3);
+            for (index, (landmark, inverse)) in
+                self.landmarks.iter().zip(&self.h_ll_inverse).enumerate()
+            {
+                let Some(inverse) = inverse else {
+                    continue;
+                };
+                let mut accumulated = -landmark.b_l;
+                for (pose, cross) in &landmark.cross {
+                    let delta: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+                    accumulated -= cross.transpose() * delta;
+                }
+                let value = *inverse * accumulated;
+                for component in 0..3 {
+                    delta_landmarks[index * 3 + component] = value[component];
+                }
+            }
+            if !delta_landmarks.iter().all(|value| value.is_finite()) {
+                return Err(ImplicitSchurError::NonFinite("landmark delta"));
+            }
+            Ok(delta_landmarks)
+        }
+    }
+
+    fn explicit_schur(system: &NormalEquationsBa, lambda: f64) -> DMatrix<f64> {
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            panic!("test oracle requires pose blocks");
+        };
+        let dimension = diagonal.len() * 6;
+        let mut schur = DMatrix::zeros(dimension, dimension);
+        for (pose, block) in diagonal.iter().enumerate() {
+            let mut damped = *block;
+            for component in 0..6 {
+                damped[(component, component)] += lambda;
+            }
+            schur
+                .fixed_view_mut::<6, 6>(pose * 6, pose * 6)
+                .copy_from(&damped);
+        }
+        for landmark in &system.landmarks {
+            let mut h_ll = landmark.h_ll;
+            for component in 0..3 {
+                h_ll[(component, component)] += lambda;
+            }
+            let Some(inverse) = h_ll.try_inverse() else {
+                continue;
+            };
+            for (pose, a) in &landmark.cross {
+                for (other_pose, b) in &landmark.cross {
+                    let block = a * inverse * b.transpose();
+                    for row in 0..6 {
+                        for column in 0..6 {
+                            schur[(pose * 6 + row, other_pose * 6 + column)] -=
+                                block[(row, column)];
+                        }
+                    }
+                }
+            }
+        }
+        schur
+    }
+
+    fn synthetic_system() -> NormalEquationsBa {
+        let diagonal = vec![
+            Matrix6::from_diagonal(&Vector6::from_element(20.0)),
+            Matrix6::from_diagonal(&Vector6::from_element(22.0)),
+        ];
+        let cross0 =
+            Matrix6x3::from_fn(|row, column| 0.02 * (row as f64 + 1.0) * (column as f64 + 1.0));
+        let cross1 =
+            Matrix6x3::from_fn(|row, column| 0.015 * (row as f64 + 2.0) * (column as f64 + 1.0));
+        let cross2 =
+            Matrix6x3::from_fn(|row, column| 0.01 * (row as f64 + 3.0) * (column as f64 + 2.0));
+        NormalEquationsBa {
+            h_pp: CameraHessian::PoseDiagonal(diagonal),
+            b_p: DVector::from_iterator(12, (0..12).map(|index| 0.03 * (index + 1) as f64)),
+            landmarks: vec![LandmarkBlock {
+                h_ll: Matrix3::from_diagonal(&Vector3::new(7.0, 8.0, 9.0)),
+                b_l: Vector3::new(0.2, -0.1, 0.3),
+                // The first two entries deliberately share pose 0, as two
+                // sensors on one rig frame would.
+                cross: vec![(0, cross0), (0, cross1), (1, cross2)],
+            }],
+        }
+    }
+
+    #[test]
+    fn implicit_operator_matches_explicit_schur_rhs_preconditioner_and_step() {
+        let lambda = 0.25;
+        let system = synthetic_system();
+        let operator = ImplicitSchurOperator::new(&system, lambda).unwrap();
+        let explicit = explicit_schur(&system, lambda);
+        let x = DVector::from_iterator(12, (0..12).map(|index| 0.04 * (index + 1) as f64));
+        let explicit_product = &explicit * &x;
+        let implicit_product = operator.apply(&x).unwrap();
+        assert!((&explicit_product - implicit_product).norm() < 1.0e-12);
+
+        let mut explicit_rhs = -&system.b_p;
+        let h_ll_inverse = operator.h_ll_inverse(0).unwrap();
+        for (pose, cross) in &system.landmarks[0].cross {
+            let update: Vector6<f64> = cross * h_ll_inverse * system.landmarks[0].b_l;
+            for component in 0..6 {
+                explicit_rhs[pose * 6 + component] += update[component];
+            }
+        }
+        assert_eq!(operator.rhs.as_slice(), explicit_rhs.as_slice());
+
+        let mut direct_system = synthetic_system();
+        let direct = solve_step(
+            &mut direct_system,
+            2,
+            1,
+            0,
+            0,
+            lambda,
+            LinearSolver::Sparse,
+            false,
+            &mut None,
+        )
+        .unwrap();
+        let result = operator
+            .solve_pcg(operator.rhs(), PcgOptions::default())
+            .unwrap();
+        assert!(result.residual_norm <= result.target);
+        assert!((&result.solution - &direct.0).norm() < 1.0e-9);
+        let implicit_landmark_delta = operator.complete_delta(&result.solution).unwrap();
+        assert!((&implicit_landmark_delta - direct.1).norm() < 1.0e-9);
+
+        // The pose-0 preconditioner block must include the cross term between
+        // the two repeated pose-0 sensor blocks, not two independent terms.
+        let mut pose0_cross = system.landmarks[0].cross[0].1;
+        pose0_cross += system.landmarks[0].cross[1].1;
+        let mut expected = Matrix6::from_diagonal(&Vector6::from_element(20.0));
+        for component in 0..6 {
+            expected[(component, component)] += lambda;
+        }
+        expected -= pose0_cross * h_ll_inverse * pose0_cross.transpose();
+        let probe = DVector::from_iterator(12, (0..12).map(|index| (index + 1) as f64));
+        let applied = operator.apply_preconditioner(&probe).unwrap();
+        let expected_inverse = expected.cholesky().unwrap().inverse();
+        let expected_pose0 =
+            expected_inverse * Vector6::from_iterator((0..6).map(|i| (i + 1) as f64));
+        assert!((applied.fixed_rows::<6>(0).into_owned() - expected_pose0).norm() < 1.0e-12);
+    }
+
+    #[test]
+    fn implicit_operator_matches_explicit_schur_and_direct_step_without_damping() {
+        let system = synthetic_system();
+        let operator = ImplicitSchurOperator::new(&system, 0.0).unwrap();
+        let explicit = explicit_schur(&system, 0.0);
+        let x = DVector::from_iterator(12, (0..12).map(|index| 0.02 * (index + 2) as f64));
+        assert!((operator.apply(&x).unwrap() - explicit * &x).norm() < 1.0e-10);
+
+        let mut direct_system = synthetic_system();
+        let direct = solve_step(
+            &mut direct_system,
+            2,
+            1,
+            0,
+            0,
+            0.0,
+            LinearSolver::Sparse,
+            false,
+            &mut None,
+        )
+        .unwrap();
+        let result = operator
+            .solve_pcg(operator.rhs(), PcgOptions::default())
+            .unwrap();
+        assert!((&result.solution - &direct.0).norm() < 1.0e-9);
+        assert!((operator.complete_delta(&result.solution).unwrap() - direct.1).norm() < 1.0e-9);
+    }
+
+    #[test]
+    fn rig_sensor_observations_share_one_pose_slot_and_keep_cross_terms() {
+        let camera = Camera::pinhole(0, 640, 480, 500.0, 500.0, 320.0, 240.0);
+        let mut ba = BundleAdjustment::new(camera.clone());
+        ba.add_pose(0, Pose::identity());
+        ba.add_landmark(0, Point3::new(0.3, -0.2, 4.0));
+        ba.add_rig_observation(BaRigObservation {
+            keyframe_id: 0,
+            landmark_id: 0,
+            xy: Point2::new(357.5, 215.0),
+            camera: camera.clone(),
+            sensor_from_rig: SE3::identity(),
+        });
+        ba.add_rig_observation(BaRigObservation {
+            keyframe_id: 0,
+            landmark_id: 0,
+            xy: Point2::new(382.0, 215.0),
+            camera,
+            sensor_from_rig: SE3::new(UnitQuaternion::identity(), Vector3::new(0.2, 0.0, 0.0)),
+        });
+        let pose_index = BTreeMap::from([(0_u64, 0_usize)]);
+        let landmark_index = BTreeMap::from([(0_u64, 0_usize)]);
+        let system = build_normal_equations(
+            &ba,
+            &ba.camera.intrinsics().unwrap(),
+            &pose_index,
+            &landmark_index,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &RobustKernel::None,
+            None,
+            false,
+            true,
+        );
+        assert_eq!(system.landmarks[0].cross.len(), 2);
+        assert_eq!(
+            system.landmarks[0]
+                .cross
+                .iter()
+                .map(|(pose, _)| *pose)
+                .collect::<Vec<_>>(),
+            vec![0, 0]
+        );
+        let operator = ImplicitSchurOperator::new(&system, 0.1).unwrap();
+        let x = DVector::from_element(6, 0.2);
+        let expected = explicit_schur(&system, 0.1) * &x;
+        let actual = operator.apply(&x).unwrap();
+        assert!((&actual - expected).norm() < 1.0e-9);
+    }
+
+    #[test]
+    fn fixed_rotation_is_preserved_by_operator_and_back_substitution() {
+        let mut system = synthetic_system();
+        let pose_index = BTreeMap::from([(10_u64, 0_usize), (20_u64, 1_usize)]);
+        let fixed = BTreeSet::from([10_u64]);
+        constrain_fixed_pose_rotations(&fixed, &pose_index, &mut system);
+        let operator = ImplicitSchurOperator::new(&system, 0.5).unwrap();
+        assert_eq!(operator.rhs[3], 0.0);
+        assert_eq!(operator.rhs[4], 0.0);
+        assert_eq!(operator.rhs[5], 0.0);
+        let mut x = DVector::zeros(12);
+        x[3] = 1.0;
+        x[4] = -2.0;
+        x[5] = 3.0;
+        let applied = operator.apply(&x).unwrap();
+        assert_eq!(applied[3], 1.5);
+        assert_eq!(applied[4], -3.0);
+        assert_eq!(applied[5], 4.5);
+        let result = operator
+            .solve_pcg(operator.rhs(), PcgOptions::default())
+            .unwrap();
+        assert_eq!(result.solution[3], 0.0);
+        assert_eq!(result.solution[4], 0.0);
+        assert_eq!(result.solution[5], 0.0);
+    }
+
+    #[test]
+    fn operator_rejects_dense_dimension_and_nonfinite_inputs() {
+        let mut system = synthetic_system();
+        let dimension = system.b_p.len();
+        system.h_pp = CameraHessian::Dense(DMatrix::identity(dimension, dimension));
+        assert!(matches!(
+            ImplicitSchurOperator::new(&system, 0.0),
+            Err(ImplicitSchurError::DenseCameraHessian)
+        ));
+
+        let mut system = synthetic_system();
+        system.b_p = DVector::zeros(1);
+        assert!(matches!(
+            ImplicitSchurOperator::new(&system, 0.0),
+            Err(ImplicitSchurError::DimensionMismatch {
+                expected: 12,
+                actual: 1,
+            })
+        ));
+
+        let mut system = synthetic_system();
+        system.landmarks[0].cross[0].1[(0, 0)] = f64::NAN;
+        assert!(matches!(
+            ImplicitSchurOperator::new(&system, 0.0),
+            Err(ImplicitSchurError::NonFinite("landmark cross block"))
+        ));
+
+        let mut system = synthetic_system();
+        system.landmarks[0].cross[0].0 = usize::MAX;
+        assert!(matches!(
+            ImplicitSchurOperator::new(&system, 0.0),
+            Err(ImplicitSchurError::DimensionMismatch {
+                expected: 2,
+                actual: usize::MAX,
+            })
+        ));
+
+        let system = synthetic_system();
+        let operator = ImplicitSchurOperator::new(&system, 0.0).unwrap();
+        let mut nonfinite = DVector::zeros(operator.dimension());
+        nonfinite[0] = f64::NAN;
+        assert_eq!(
+            operator.apply(&nonfinite),
+            Err(ImplicitSchurError::NonFinite("operator input"))
+        );
+
+        let system = synthetic_system();
+        assert!(matches!(
+            ImplicitSchurOperator::new(&system, f64::NAN),
+            Err(ImplicitSchurError::InvalidLambda)
+        ));
+        let operator = ImplicitSchurOperator::new(&system, 0.0).unwrap();
+        assert!(matches!(
+            operator.solve_pcg(
+                operator.rhs(),
+                PcgOptions {
+                    relative_tolerance: -1.0,
+                    ..PcgOptions::default()
+                }
+            ),
+            Err(ImplicitSchurError::InvalidTolerance)
+        ));
+        let mut huge_rhs = operator.rhs().clone();
+        huge_rhs[0] = f64::MAX;
+        assert!(matches!(
+            operator.solve_pcg(
+                &huge_rhs,
+                PcgOptions {
+                    relative_tolerance: 2.0,
+                    ..PcgOptions::default()
+                }
+            ),
+            Err(ImplicitSchurError::NonFinite("PCG target"))
+        ));
+    }
+
+    #[test]
+    fn empty_pose_operator_is_not_a_landmark_only_fallback() {
+        let empty = NormalEquationsBa {
+            h_pp: CameraHessian::PoseDiagonal(Vec::new()),
+            b_p: DVector::zeros(0),
+            landmarks: Vec::new(),
+        };
+        assert!(matches!(
+            ImplicitSchurOperator::new(&empty, 0.0),
+            Err(ImplicitSchurError::EmptySystem)
+        ));
+        // The production solve_step has a separate p_count == 0 branch for
+        // landmark-only BA; this pose-reduced prototype intentionally does
+        // not silently take ownership of that path.
+    }
+
+    #[test]
+    fn singular_landmark_inverse_is_skipped_like_direct_solver() {
+        let mut system = synthetic_system();
+        system.landmarks[0].h_ll = Matrix3::zeros();
+        let operator = ImplicitSchurOperator::new(&system, 0.0).unwrap();
+        assert!(operator.h_ll_inverse(0).is_none());
+        let expected = DVector::from_iterator(12, system.b_p.iter().map(|value| -value));
+        assert_eq!(operator.rhs.as_slice(), expected.as_slice());
+        let delta_landmarks = operator.complete_delta(&DVector::zeros(12)).unwrap();
+        assert!(delta_landmarks.iter().all(|value| *value == 0.0));
+    }
+
+    #[test]
+    fn pcg_reports_limits_curvature_and_zero_rhs_without_gauge_claim() {
+        let system = synthetic_system();
+        let operator = ImplicitSchurOperator::new(&system, 0.25).unwrap();
+        let zero = DVector::zeros(operator.dimension());
+        let zero_result = operator
+            .solve_pcg(
+                &zero,
+                PcgOptions {
+                    max_iterations: 0,
+                    ..PcgOptions::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(zero_result.iterations, 0);
+        assert_eq!(zero_result.residual_norm, 0.0);
+
+        let limited = operator.solve_pcg(
+            operator.rhs(),
+            PcgOptions {
+                max_iterations: 0,
+                ..PcgOptions::default()
+            },
+        );
+        assert!(matches!(
+            limited,
+            Err(ImplicitSchurError::MaxIterations { .. })
+        ));
+
+        let bad_solution = DVector::zeros(operator.dimension());
+        assert!(matches!(
+            operator.checked_result(operator.rhs(), bad_solution, 0, 0.0, 0.0),
+            Err(ImplicitSchurError::ResidualCheckFailed { .. })
+        ));
+
+        let mut indefinite = synthetic_system();
+        if let CameraHessian::PoseDiagonal(diagonal) = &mut indefinite.h_pp {
+            for block in diagonal {
+                *block = Matrix6::from_diagonal(&Vector6::from_element(5.0));
+            }
+        }
+        indefinite.landmarks[0].h_ll = Matrix3::identity();
+        indefinite.landmarks[0].cross = vec![
+            (
+                0,
+                Matrix6x3::from_fn(
+                    |row, column| {
+                        if row == 0 && column == 0 {
+                            2.0
+                        } else {
+                            0.0
+                        }
+                    },
+                ),
+            ),
+            (
+                1,
+                Matrix6x3::from_fn(
+                    |row, column| {
+                        if row == 0 && column == 0 {
+                            2.0
+                        } else {
+                            0.0
+                        }
+                    },
+                ),
+            ),
+        ];
+        let indefinite_operator = ImplicitSchurOperator::new(&indefinite, 0.0).unwrap();
+        let mut negative_eigenvector = DVector::zeros(indefinite_operator.dimension());
+        negative_eigenvector[0] = 1.0;
+        negative_eigenvector[6] = 1.0;
+        assert!(matches!(
+            indefinite_operator.solve_pcg(&negative_eigenvector, PcgOptions::default()),
+            Err(ImplicitSchurError::NonPositiveCurvature)
+        ));
+    }
+
+    #[test]
+    fn repeated_pcg_runs_are_deterministic() {
+        let system = synthetic_system();
+        let operator = ImplicitSchurOperator::new(&system, 0.25).unwrap();
+        let first = operator
+            .solve_pcg(operator.rhs(), PcgOptions::default())
+            .unwrap();
+        let second = operator
+            .solve_pcg(operator.rhs(), PcgOptions::default())
+            .unwrap();
+        assert_eq!(first, second);
+    }
+}
+
 #[cfg(test)]
 mod visual_jacobian_audit_tests {
     use super::*;

--- a/tests/test_score_openloris_model.py
+++ b/tests/test_score_openloris_model.py
@@ -8,6 +8,7 @@ import math
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 
@@ -119,6 +120,34 @@ class ScoreOpenLorisModelTests(unittest.TestCase):
             transforms = score.load_camera_extrinsics(path)
             self.assertTrue(np.allclose(transforms[1][:3, 3], [1.0, 2.0, 3.0]))
             self.assertTrue(np.allclose(transforms[2][:3, 3], [5.0, 2.0, 3.0]))
+
+    def test_aggregate_pools_image_errors_not_component_metrics(self) -> None:
+        names = [f"image-{index}" for index in range(5)]
+        manifest = {name: (1, float(index)) for index, name in enumerate(names)}
+        reference = {name: np.zeros(3) for name in names}
+        components = [
+            ({"rmse_m": 0.0, "p95_m": 0.0}, np.zeros(3), names[:3]),
+            ({"rmse_m": 4.0, "p95_m": 4.0}, np.full(2, 4.0), names[3:]),
+        ]
+        # Isolate aggregation from per-component alignment (tested separately).
+        with (
+            mock.patch.object(score, "load_manifest", return_value=manifest),
+            mock.patch.object(score, "load_ground_truth", return_value=None),
+            mock.patch.object(score, "load_camera_extrinsics", return_value=None),
+            mock.patch.object(score, "interpolate_camera_centres", return_value=reference),
+            mock.patch.object(score, "load_model_centres", side_effect=[names[:3], names[3:]]),
+            mock.patch.object(score, "score_component", side_effect=components),
+            mock.patch.object(score, "sha256_file", return_value="fixture-only"),
+        ):
+            result = score.score(
+                [Path("component-a"), Path("component-b")],
+                Path("manifest"), Path("ground-truth"), Path("transforms"),
+            )
+        self.assertEqual(result["models"], 2)
+        self.assertEqual(result["gt_scored_images"], 5)
+        self.assertAlmostEqual(result["component_weighted_rmse_m"], math.sqrt(32.0 / 5.0))
+        self.assertEqual(result["component_weighted_p95_m"], 4.0)
+        self.assertEqual(result["component_weighted_median_m"], 0.0)
 
     def test_alias_map_is_reversed_for_colmap_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_score_openloris_model.py
+++ b/tests/test_score_openloris_model.py
@@ -135,7 +135,13 @@ class ScoreOpenLorisModelTests(unittest.TestCase):
             mock.patch.object(score, "load_ground_truth", return_value=None),
             mock.patch.object(score, "load_camera_extrinsics", return_value=None),
             mock.patch.object(score, "interpolate_camera_centres", return_value=reference),
-            mock.patch.object(score, "load_model_centres", side_effect=[names[:3], names[3:]]),
+            mock.patch.object(
+                score, "load_model_centres",
+                side_effect=[
+                    {name: reference[name] for name in component_names}
+                    for component_names in (names[:3], names[3:])
+                ],
+            ),
             mock.patch.object(score, "score_component", side_effect=components),
             mock.patch.object(score, "sha256_file", return_value="fixture-only"),
         ):


### PR DESCRIPTION
## Result
Merged as 0460c9ca07af63e5ce0d592d05a763b1b9b21d9a at 2026-09-07T10:02:05Z. All eight checks passed for exact final head 36fe70043adfb3a215a1e007657b5ef7782c1346 (CI run 34108930129, Rust job 3m34s). Local and remote feature branches removed; main clean.

## Scope
- Private test-only implicit Schur operator and block-Jacobi PCG; production solver, public API and mapper CLI unchanged.
- Explicit/full normal-system and direct-solver numerical oracles, repeated rig sensor cross terms, true residuals, rejection paths and determinism.
- README clarifies per-component Sim3 alignment followed by pooled image-error RMSE/p95. Existing comparison values and visuals remain unchanged.
- Integration contract requires unsupported-factor rejection before assembly, gauge checks, small-model/1k parity and bounded failures before any global 10k run.

## Validation
- BA namespace: 21 passed, including 10 private prototype tests, independently rerun.
- Clippy with warnings denied and formatting passed.
- OpenLORIS Python tests: 23 passed; independent COLMAP auditors: 23 passed.
- Documentation links and 189 registry files validated; generated docs current.
- Independent NumPy full 15x15 vs reduced solve agrees within 3.1e-16 for hand-computable lambda 0/.5 fixtures.
- Numerical evidence: benchmarks/electro/m8-openloris-implicit-schur-prototype-v1.json (written before final CI; final CI and merge confirmed here).

## Limits and next gate
No production memory/speed improvement or global/10k experiment is claimed. M8 trajectory RMSE parity and all full M8-M10 resource, scale and E2E gates remain open. Empty-pose rejection is not production landmark-only BA integration coverage. Next is an additive opt-in runtime entry point with separate options/errors, shared bounded LM acceptance, pre-assembly eligibility and finite positive damping, followed by anchored same-input small-model/1k validation. No dense fallback.