### PR TITLE
test(sfm): diagnose frozen rig BA normal systems without solver changes

### DIFF
--- a/benchmarks/electro/m8-openloris-matrix-free-1k-input-v1.json
+++ b/benchmarks/electro/m8-openloris-matrix-free-1k-input-v1.json
@@ -67,6 +67,27 @@
     "max_world_point_norm_m": 8287.678420723867,
     "interpretation": "Conditioning/cancellation clue only; not a Hessian/operator audit, not proof of the sole PCG failure cause, and not a filtering criterion"
   },
+  "independent_source_point_302_scale_diagnostic": {
+    "point_id": 302,
+    "source_camera_depths_m": [
+      0.00011093307669790553,
+      0.00019652808018441603
+    ],
+    "landmark_jacobian_singular_values": [
+      5061051.199270975,
+      2961540.225766277,
+      41063.853180371814
+    ],
+    "landmark_jacobian_condition": 123.24832686889977,
+    "landmark_hessian_max_abs": 16834347216659.188,
+    "hessian_spectral_scale_eps": 0.005687503632865668,
+    "hessian_lambda_1e_minus4_addition_changes_diagonal": [
+      false,
+      false,
+      false
+    ],
+    "scope": "Source-camera local point diagnostic only; not exact reconstructed-body BA normal system, not proof of the full PCG failure cause."
+  },
   "independent_input_trajectory_rescore": {
     "scorer": "scripts/score_openloris_model.py",
     "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",

--- a/benchmarks/electro/m8-openloris-matrix-free-1k-input-v1.json
+++ b/benchmarks/electro/m8-openloris-matrix-free-1k-input-v1.json
@@ -47,6 +47,26 @@
     "used_as_a_filter": false,
     "proves_full_numerical_rank_or_conditioning": false
   },
+  "independent_input_depth_diagnostic": {
+    "method": "Project every original point-track observation through its source world-to-camera pose; no optimization, filtering or model writes",
+    "observations": 130900,
+    "min_depth_observation": {
+      "point_id": 302,
+      "image_id": 190,
+      "keypoint_index": 47,
+      "z_m": 0.00011093307669790553
+    },
+    "depth_percentiles_m": {
+      "0": 0.00011093307669790553,
+      "0.1": 0.16809455699237194,
+      "1": 0.4111597123823517,
+      "50": 1.6102844221317474,
+      "99": 6.384586358226048,
+      "100": 5207.122999967967
+    },
+    "max_world_point_norm_m": 8287.678420723867,
+    "interpretation": "Conditioning/cancellation clue only; not a Hessian/operator audit, not proof of the sole PCG failure cause, and not a filtering criterion"
+  },
   "independent_input_trajectory_rescore": {
     "scorer": "scripts/score_openloris_model.py",
     "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",

--- a/benchmarks/electro/m8-openloris-matrix-free-rig-ba-comparison-v1.json
+++ b/benchmarks/electro/m8-openloris-matrix-free-rig-ba-comparison-v1.json
@@ -5,6 +5,9 @@
   "purpose": "Same-input post-mapping direct versus implicit BA diagnostic; no mapper/native E2E or 10k performance claim",
   "branch": "feat/m8-matrix-free-rig-ba-comparison",
   "pull_request": "https://github.com/rsasaki0109/visloc-rs/pull/79",
+  "merge_commit": "42bf86f955fa5ff681f0272faeb887cfbb87df65",
+  "merged_at": "2026-09-07T11:32:55Z",
+  "old_local_and_remote_branch_removed": true,
   "implementation_commit": "c810be96dfd08846fcf5da0062fcd28e0c1ce84f",
   "source": "examples/compare_rig_bundle_adjustment.rs",
   "source_sha256": "196dcd293e42bf036f30894efa75969418061320d7da5d3eddf3d0b57dade23c",
@@ -756,7 +759,11 @@
     "implementation_ci_run": 34116147600,
     "implementation_ci_all_eight_checks_passed": true,
     "implementation_ci_rust_seconds": 207,
-    "ci_status": "implementation CI passed; pending final evidence-head CI"
+    "final_ci_run": 34116769919,
+    "final_ci_head": "5f9899099dcd26513aa7b184fb664c6f0a888481",
+    "final_ci_all_eight_checks_passed": true,
+    "final_ci_rust_seconds": 243,
+    "ci_status": "final-head CI passed; merged and old branch removed"
   },
   "build": {
     "command": "cargo build --release --example compare_rig_bundle_adjustment",

--- a/benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json
+++ b/benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json
@@ -1,0 +1,470 @@
+{
+  "schema_version": 1,
+  "experiment": "m8-openloris-real-normal-system-oracle-v1",
+  "date": "2026-09-07",
+  "status": "diagnostic_complete_not_quality_or_speed_promotion",
+  "implementation_commit": "3e50dc5ae6a2ac68a66d7b74f7dea3c27df3ca93",
+  "source_sha256": {
+    "examples/compare_rig_bundle_adjustment.rs": "8135b678993880b2e946bfccdc6d98656c7ee2a8dfe531b17fbbd22cde205f2a",
+    "pipelines/slam/src/bundle.rs": "474a5238a43932876ccba24e247d7d849d39df815f8f9df218cf48dcf4e6823c"
+  },
+  "binaries": {
+    "release_example_sha256": "3479143f08c452c3973961d13dc9139cf3a04a77f24d7e6e998e728af8f20354",
+    "release_lib_test_path": "target/release/deps/visloc_slam-033870405c01cac5",
+    "release_lib_test_sha256": "178cc1b64dca7b0099d3bf89ded1e5bb66dbbe0181d30b758b754f1eaf5c566e"
+  },
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-real-normal-system-oracle-v1",
+  "input": {
+    "baseline_evidence": "m8-openloris-matrix-free-rig-ba-comparison-v1.json",
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+    "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+    "combined_sha256": "ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829",
+    "combined_hash_encoding": "SHA256 over ordered label UTF8, NUL, lowercase hex file SHA256 ASCII, 0xff; labels cameras.txt, images.txt, points3D.txt, rig-manifest",
+    "fixture": "input.fixture",
+    "fixture_sha256": "a71ef3401ea6d75a06f18ded0d475ad48fd929202a64fecaeaa790ee964da1ea",
+    "fixture_bytes": 30587925,
+    "initial_cost": 126510.39875730938,
+    "initial_cost_bits": "4683430141614839853",
+    "poses": 500,
+    "variable_poses": 499,
+    "landmarks": 4716,
+    "observations": 130900,
+    "fixed_pose": 0,
+    "schur_dimension": 2994,
+    "cross_blocks": 130677,
+    "cross_pair_work": 28556575
+  },
+  "audit": {
+    "source_file_and_combined_hashes_independently_verified": true,
+    "fixture_cost_roundtrip_bits_verified": true,
+    "source_cost_matches_previous_printed_precision": true,
+    "all_130900_observation_ids_xy_camera_and_source_track_order_verified": true,
+    "frame_mapping": "image name -> rig manifest (never image ID inference)",
+    "all_4716_landmarks_equal_source": true,
+    "all_sensor_extrinsics_equal_manifest": true,
+    "filtering": false,
+    "ground_truth_in_optimizer": false
+  },
+  "execution": {
+    "rayon_num_threads": 1,
+    "release": true,
+    "ignored_test": "bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle",
+    "test_arguments": [
+      "--exact",
+      "--ignored",
+      "--nocapture"
+    ],
+    "env": [
+      "VISLOC_MATRIX_FREE_ORACLE_FIXTURE=<artifact_root>/input.fixture",
+      "VISLOC_MATRIX_FREE_ORACLE_EXPECTED_SOURCE_SHA256=<input.combined_sha256>"
+    ],
+    "both_runs_exactly_one_test_passed": true,
+    "one_initial_normal_system_per_run": true,
+    "pcg_relative_tolerance": 1e-12,
+    "pcg_absolute_tolerance": 1e-12,
+    "normal_system_reused_for_all_cases": true,
+    "no_production_solver_or_public_api_change": true
+  },
+  "caps": {
+    "variable_pose_blocks": 512,
+    "total_poses": 513,
+    "landmarks": 8192,
+    "observations": 262144,
+    "schur_dimension": 3072,
+    "cross_pair_work": 64000000,
+    "scope": "Explicit dense matrices exist only in bounded cfg(test) oracle; not a production or 10k execution path."
+  },
+  "reports": [
+    {
+      "lambda": 0.0001,
+      "pcg_max_iterations": 128,
+      "pose_blocks": 499,
+      "landmark_count": 4716,
+      "observation_count": 130900,
+      "schur_dimension": 2994,
+      "singular_landmarks": 0,
+      "raw_schur_asymmetry": 2.5,
+      "schur_base_action_norm": 497074506588.21185,
+      "schur_eliminated_action_norm": 496920297300.87494,
+      "schur_arithmetic_scale": 993994803889.0868,
+      "operator_raw_action_error": 0.18766986108875738,
+      "operator_raw_action_relative_error": 1.8880366411824645e-13,
+      "operator_lower_action_error": 0.13604259781144346,
+      "operator_lower_action_relative_error": 1.3686449595024596e-13,
+      "operator_rhs_error": 0,
+      "direct_explicit_pose_error": 1.0238849112498438e-10,
+      "direct_explicit_landmark_error": 1.7809226090588427e-8,
+      "direct_feasibility": {
+        "finite": true,
+        "pose_true_residual": 0.0000027539870190289396,
+        "implicit_pose_true_residual": 0.01848082089914065,
+        "max_landmark_backsub_residual": 0.019034750569830294,
+        "geometry_observation_count": 130020,
+        "geometry_invalid_observations": 880,
+        "geometry_nonpositive_depth": 880,
+        "geometry_cost": 118048.75621912605,
+        "geometry_rms_error": 0.9528523885424591,
+        "geometry_max_error": 21.940591649548654,
+        "geometry_feasible": false,
+        "feasible": false
+      },
+      "explicit_feasibility": {
+        "finite": true,
+        "pose_true_residual": 0.000004919094885193126,
+        "implicit_pose_true_residual": 0.016225321613743043,
+        "max_landmark_backsub_residual": 0.008911541938941529,
+        "geometry_observation_count": 130020,
+        "geometry_invalid_observations": 880,
+        "geometry_nonpositive_depth": 880,
+        "geometry_cost": 118048.75623107003,
+        "geometry_rms_error": 0.9528523885906631,
+        "geometry_max_error": 21.940591652336,
+        "geometry_feasible": false,
+        "feasible": false
+      },
+      "direct_prediction": {
+        "half_damped": 6427.184101361952,
+        "squared_damped": 12854.368202723905,
+        "squared_undamped": 12971.211031021008
+      },
+      "explicit_prediction": {
+        "half_damped": 6427.184101137311,
+        "squared_damped": 12854.368202274622,
+        "squared_undamped": 12971.21103057123
+      },
+      "pcg_status": "failure:MaxIterations { iterations: 128, recursive_norm: 41263.72612053205, residual_norm: 41263.7264460946, target: 7.354716589947665e-7 }",
+      "pcg_iterations": 128,
+      "pcg_true_residual": 41263.7264460946,
+      "pcg_target": 7.354716589947665e-7,
+      "matrix_free_pose_error": null,
+      "matrix_free_landmark_error": null,
+      "matrix_free_feasibility": null,
+      "matrix_free_prediction": null
+    },
+    {
+      "lambda": 0.0001,
+      "pcg_max_iterations": 512,
+      "pose_blocks": 499,
+      "landmark_count": 4716,
+      "observation_count": 130900,
+      "schur_dimension": 2994,
+      "singular_landmarks": 0,
+      "raw_schur_asymmetry": 2.5,
+      "schur_base_action_norm": 497074506588.21185,
+      "schur_eliminated_action_norm": 496920297300.87494,
+      "schur_arithmetic_scale": 993994803889.0868,
+      "operator_raw_action_error": 0.18766986108875738,
+      "operator_raw_action_relative_error": 1.8880366411824645e-13,
+      "operator_lower_action_error": 0.13604259781144346,
+      "operator_lower_action_relative_error": 1.3686449595024596e-13,
+      "operator_rhs_error": 0,
+      "direct_explicit_pose_error": 1.0238849112498438e-10,
+      "direct_explicit_landmark_error": 1.7809226090588427e-8,
+      "direct_feasibility": {
+        "finite": true,
+        "pose_true_residual": 0.0000027539870190289396,
+        "implicit_pose_true_residual": 0.01848082089914065,
+        "max_landmark_backsub_residual": 0.019034750569830294,
+        "geometry_observation_count": 130020,
+        "geometry_invalid_observations": 880,
+        "geometry_nonpositive_depth": 880,
+        "geometry_cost": 118048.75621912605,
+        "geometry_rms_error": 0.9528523885424591,
+        "geometry_max_error": 21.940591649548654,
+        "geometry_feasible": false,
+        "feasible": false
+      },
+      "explicit_feasibility": {
+        "finite": true,
+        "pose_true_residual": 0.000004919094885193126,
+        "implicit_pose_true_residual": 0.016225321613743043,
+        "max_landmark_backsub_residual": 0.008911541938941529,
+        "geometry_observation_count": 130020,
+        "geometry_invalid_observations": 880,
+        "geometry_nonpositive_depth": 880,
+        "geometry_cost": 118048.75623107003,
+        "geometry_rms_error": 0.9528523885906631,
+        "geometry_max_error": 21.940591652336,
+        "geometry_feasible": false,
+        "feasible": false
+      },
+      "direct_prediction": {
+        "half_damped": 6427.184101361952,
+        "squared_damped": 12854.368202723905,
+        "squared_undamped": 12971.211031021008
+      },
+      "explicit_prediction": {
+        "half_damped": 6427.184101137311,
+        "squared_damped": 12854.368202274622,
+        "squared_undamped": 12971.21103057123
+      },
+      "pcg_status": "failure:MaxIterations { iterations: 512, recursive_norm: 318.34634181495545, residual_norm: 318.3459481943091, target: 7.354716589947665e-7 }",
+      "pcg_iterations": 512,
+      "pcg_true_residual": 318.3459481943091,
+      "pcg_target": 7.354716589947665e-7,
+      "matrix_free_pose_error": null,
+      "matrix_free_landmark_error": null,
+      "matrix_free_feasibility": null,
+      "matrix_free_prediction": null
+    },
+    {
+      "lambda": 10000000000,
+      "pcg_max_iterations": 128,
+      "pose_blocks": 499,
+      "landmark_count": 4716,
+      "observation_count": 130900,
+      "schur_dimension": 2994,
+      "singular_landmarks": 0,
+      "raw_schur_asymmetry": 0.46875,
+      "schur_base_action_norm": 497479792884.8528,
+      "schur_eliminated_action_norm": 475496352280.0941,
+      "schur_arithmetic_scale": 972976145164.9469,
+      "operator_raw_action_error": 0.019453946118937877,
+      "operator_raw_action_relative_error": 1.9994268323649274e-14,
+      "operator_lower_action_error": 0.013092988309381425,
+      "operator_lower_action_relative_error": 1.3456638556294507e-14,
+      "operator_rhs_error": 0,
+      "direct_explicit_pose_error": 4.549768906850898e-19,
+      "direct_explicit_landmark_error": 1.5044895800209034e-19,
+      "direct_feasibility": {
+        "finite": true,
+        "pose_true_residual": 3.0228983518717446e-9,
+        "implicit_pose_true_residual": 4.49208180588725e-7,
+        "max_landmark_backsub_residual": 6.548595739904808e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "explicit_feasibility": {
+        "finite": true,
+        "pose_true_residual": 6.4945806084734065e-9,
+        "implicit_pose_true_residual": 1.28800155078187e-7,
+        "max_landmark_backsub_residual": 4.3788258908908216e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "direct_prediction": {
+        "half_damped": 8.7832798335682,
+        "squared_damped": 17.5665596671364,
+        "squared_undamped": 32.97081597530542
+      },
+      "explicit_prediction": {
+        "half_damped": 8.783279833568203,
+        "squared_damped": 17.566559667136406,
+        "squared_undamped": 32.97081597530531
+      },
+      "pcg_status": "success",
+      "pcg_iterations": 22,
+      "pcg_true_residual": 5.639331821966476e-7,
+      "pcg_target": 7.377914999757461e-7,
+      "matrix_free_pose_error": 2.0919877485600968e-17,
+      "matrix_free_landmark_error": 9.871189290876146e-18,
+      "matrix_free_feasibility": {
+        "finite": true,
+        "pose_true_residual": 5.248398232638574e-7,
+        "implicit_pose_true_residual": 5.639331821966476e-7,
+        "max_landmark_backsub_residual": 2.469834459723764e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "matrix_free_prediction": {
+        "half_damped": 8.783279833568196,
+        "squared_damped": 17.566559667136392,
+        "squared_undamped": 32.97081597530536
+      }
+    },
+    {
+      "lambda": 10000000000,
+      "pcg_max_iterations": 512,
+      "pose_blocks": 499,
+      "landmark_count": 4716,
+      "observation_count": 130900,
+      "schur_dimension": 2994,
+      "singular_landmarks": 0,
+      "raw_schur_asymmetry": 0.46875,
+      "schur_base_action_norm": 497479792884.8528,
+      "schur_eliminated_action_norm": 475496352280.0941,
+      "schur_arithmetic_scale": 972976145164.9469,
+      "operator_raw_action_error": 0.019453946118937877,
+      "operator_raw_action_relative_error": 1.9994268323649274e-14,
+      "operator_lower_action_error": 0.013092988309381425,
+      "operator_lower_action_relative_error": 1.3456638556294507e-14,
+      "operator_rhs_error": 0,
+      "direct_explicit_pose_error": 4.549768906850898e-19,
+      "direct_explicit_landmark_error": 1.5044895800209034e-19,
+      "direct_feasibility": {
+        "finite": true,
+        "pose_true_residual": 3.0228983518717446e-9,
+        "implicit_pose_true_residual": 4.49208180588725e-7,
+        "max_landmark_backsub_residual": 6.548595739904808e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "explicit_feasibility": {
+        "finite": true,
+        "pose_true_residual": 6.4945806084734065e-9,
+        "implicit_pose_true_residual": 1.28800155078187e-7,
+        "max_landmark_backsub_residual": 4.3788258908908216e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "direct_prediction": {
+        "half_damped": 8.7832798335682,
+        "squared_damped": 17.5665596671364,
+        "squared_undamped": 32.97081597530542
+      },
+      "explicit_prediction": {
+        "half_damped": 8.783279833568203,
+        "squared_damped": 17.566559667136406,
+        "squared_undamped": 32.97081597530531
+      },
+      "pcg_status": "success",
+      "pcg_iterations": 22,
+      "pcg_true_residual": 5.639331821966476e-7,
+      "pcg_target": 7.377914999757461e-7,
+      "matrix_free_pose_error": 2.0919877485600968e-17,
+      "matrix_free_landmark_error": 9.871189290876146e-18,
+      "matrix_free_feasibility": {
+        "finite": true,
+        "pose_true_residual": 5.248398232638574e-7,
+        "implicit_pose_true_residual": 5.639331821966476e-7,
+        "max_landmark_backsub_residual": 2.469834459723764e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "matrix_free_prediction": {
+        "half_damped": 8.783279833568196,
+        "squared_damped": 17.566559667136392,
+        "squared_undamped": 32.97081597530536
+      }
+    }
+  ],
+  "repeats": {
+    "numerical_report_lines_identical": true,
+    "wall_seconds": [
+      16.84,
+      16.62
+    ],
+    "peak_rss_kib": [
+      346084,
+      346020
+    ],
+    "scope": "Whole diagnostic test process, including explicit matrix/factorization. Shared warm host; not a solver speed or production memory comparison.",
+    "files": {
+      "oracle-1.log": {
+        "sha256": "1d6677eb5774d35bbb1d3bc3ad3ec13db985fe5ca396e69ebdd90aaa0f52a0c8",
+        "bytes": 10907,
+        "text": null
+      },
+      "oracle-1.time": {
+        "sha256": "f8b9350ed1af8db34ef376bca592383facda524737d1ef719ad01ee3ba8a920c",
+        "bytes": 888,
+        "text": "\tCommand being timed: \"target/release/deps/visloc_slam-033870405c01cac5 bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle --exact --ignored --nocapture\"\n\tUser time (seconds): 16.60\n\tSystem time (seconds): 0.23\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:16.84\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 346084\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 141173\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 101\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 24\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+      },
+      "oracle-2.log": {
+        "sha256": "187dc8593263fae08e0b99bdc4ced43a949061ac3e95d1de1b703702498b0d3d",
+        "bytes": 10907,
+        "text": null
+      },
+      "oracle-2.time": {
+        "sha256": "18a5d460239b6cebf0a54182449947c326511e819ed7f7fbd316d3513f4c5164",
+        "bytes": 888,
+        "text": "\tCommand being timed: \"target/release/deps/visloc_slam-033870405c01cac5 bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle --exact --ignored --nocapture\"\n\tUser time (seconds): 16.40\n\tSystem time (seconds): 0.21\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:16.62\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 346020\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 141171\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 106\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 24\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+      }
+    }
+  },
+  "legacy_regression": [
+    {
+      "arm": "direct-regression",
+      "baseline": "direct-serial-1",
+      "all_three_model_files_byte_identical": true,
+      "numerical_trace_identical_excluding_time_and_output_path": true,
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "7b5445164e61442b6e1c60128ac4a72b5d192dc550b09b4fb5f076c623659e06",
+        "points3D.txt": "ee82a3ad583b96179a8310f6e75224125ef83eda60ceab481304c59a7e43b8f5"
+      },
+      "summary": "solver=direct initial_cost=1.265103987573094e5 final_cost=1.174960330739301e5 lm_iterations=20 converged=false source_images=1000 source_frames=500 source_landmarks=4716 source_observations=130900 fixed_pose=0 fixed_landmarks=0 pcg_max_iterations=128 pcg_tolerance=1.0e-12 solver_seconds=44.891018 total_seconds=45.127503 out=/home/sasaki/datasets/openloris/corridor1-1-m8-real-normal-system-oracle-v1/direct-regression"
+    },
+    {
+      "arm": "matrix-free-regression",
+      "baseline": "matrix-free-128-serial-1",
+      "all_three_model_files_byte_identical": true,
+      "numerical_trace_identical_excluding_time_and_output_path": true,
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "95fb935b9e9eb4ad61bfea1d7ab94ca4ecf08521b455619944c31cd4beafe284",
+        "points3D.txt": "f69b84ef240e2a1eb5167e8df71941b9f3f154d20ef21870f610303e2ef9f8fc"
+      },
+      "summary": "solver=matrix-free initial_cost=1.265103987573094e5 final_cost=1.264190824771856e5 lm_iterations=20 converged=false source_images=1000 source_frames=500 source_landmarks=4716 source_observations=130900 fixed_pose=0 fixed_landmarks=0 pcg_max_iterations=128 pcg_tolerance=1.0e-12 solver_seconds=6.357005 total_seconds=6.581804 out=/home/sasaki/datasets/openloris/corridor1-1-m8-real-normal-system-oracle-v1/matrix-free-regression"
+    }
+  ],
+  "interpretation": [
+    "At lambda=1e-4 sparse direct and explicit lower-mirrored Schur steps agree closely, but neither meets the implicit true-residual target. Direct lower residual also exceeds that target.",
+    "Raw/lower action errors divided by unreduced arithmetic scale are not relative errors of final Schur action or solution accuracy. One deterministic probe is not proof of operator correctness.",
+    "Low-lambda PCG fails at both iteration caps. Recursive/true residuals are close at those endpoints; residual replacement alone is not established as the remedy.",
+    "The low-lambda direct/explicit trials have 880 nonpositive-depth observations. Their geometry cost and RMS cover only valid observations and cannot be treated as full-objective improvements.",
+    "At lambda=1e10 both PCG caps stop at 22 iterations and agree with direct/explicit steps and full trial cost. This does not prove agreement across the LM trajectory or at 10k.",
+    "Feasibility flags mean finite and valid geometry, not satisfaction of the PCG residual target.",
+    "No threshold relaxation, fallback, filtering, scaling, README performance promotion or 10k run was performed."
+  ],
+  "next_gate": "Test-only explicit lower-Schur PCG versus implicit PCG on the same fixture, damping, block-Jacobi preconditioner, iteration caps and true-residual rule; distinguish convergence/preconditioning from action accumulation before changing production policy.",
+  "validation": {
+  "root_library_oracle_tests": {
+    "passed": 6,
+    "ignored_real_fixture": 1
+  },
+  "root_example_tests_passed": 12,
+  "root_python_tests_passed": 46,
+  "root_library_and_example_clippy_warnings_denied": true,
+  "root_cargo_fmt_check": true,
+  "docs_links": true,
+  "registry_files_validated": 189,
+  "generated_benchmark_docs_current": true,
+  "git_diff_check": true,
+  "agent_reported_release_builds_passed": true
+},
+  "metric_conventions": {
+  "raw_schur_asymmetry": "Maximum absolute off-diagonal element difference |S_ij-S_ji|; not a Frobenius or spectral norm.",
+  "delta_errors": "Euclidean norms over concatenated deltas; pose combines rotation and translation coordinates, not a metre-only physical pose error.",
+  "geometry_rms_error": "sqrt(sum(valid observation squared pixel residual)/valid observation count); not arithmetic mean reprojection error.",
+  "action_relative_errors": "Absolute action difference norm divided by sum of base-action norm and per-landmark eliminated-action norms, not by final Schur-action norm.",
+  "pcg_true_residual": "Euclidean norm of rhs minus implicit action; lower-Schur residual separately reported.",
+  "initial_cost_bits": "Decimal u64 string to avoid JSON consumer integer rounding."
+}
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -94,6 +94,14 @@
 > 公開API/既定経路の変更や10k実行はまだ行いません。入力depthの独立確認では最小
 > 0.000110933 m、最大5,207 mの観測があり、スケール差は診断の手掛かりです。
 > これを理由に観測を除去したり、PCG失敗の原因を断定したりはしません。
+> 実normal系oracleは `3e50dc5` に実装し、1kの2回実行で全診断数値が一致。
+> [実測記録](../benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json)。
+> 低λではdirect自身のimplicit真残差も0.01848で基準7.35e-7を超え、
+> PCG128/512も未収束。高λでは22反復で成功しdirectと一致します。
+> 低λのtrialは880観測が非正深度なので部分costを改善実績と扱いません。
+> 既存direct/MF CLIのモデル3ファイル・数値traceはPR #79と一致。
+> 次は同じpreconditionerでexplicit lower-Schur PCGとimplicit PCGを比べ、
+> 蓄積誤差と収束性を切り分けます。閾値変更・10k昇格はまだ行いません。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -89,6 +89,11 @@
 > controlも各2回計測。次は同じ初期normal system/λ1e-4と1e10で作用素・真残差を
 > explicit/directと照合し、桁落ち/再帰残差のずれと収束不足を切り分けます。
 > ログのλは拒否時だけ増加後の値なので、LM0のsolve λは1e-4です。
+> PR #79は最終CI8項目（run 34116769919）通過後、`42bf86f`へmergeし旧branch整理済み。
+> 現在は `feat/m8-real-normal-system-oracle`。次の変更はtest-onlyの実normal系診断で、
+> 公開API/既定経路の変更や10k実行はまだ行いません。入力depthの独立確認では最小
+> 0.000110933 m、最大5,207 mの観測があり、スケール差は診断の手掛かりです。
+> これを理由に観測を除去したり、PCG失敗の原因を断定したりはしません。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -797,7 +797,8 @@ selected approach. If private test code needs an interchange input, prefer an
 explicit example-only export of bounded pose/point/observation records linked
 to the frozen source hashes, preserving every observation and its order; do
 not export a normal matrix or duplicate the complete source model in memory.
-The exporter/fixture is a proposed implementation mechanism, not yet built.
+The exporter/fixture was subsequently implemented in `3e50dc5`; measured results
+are recorded below.
 
 Before any explicit Schur allocation, cap variable poses at 512, points at
 8,192, observations at 262,144, scalar dimension at 3,072 and pre-count the
@@ -836,3 +837,67 @@ Primary-source context for the next diagnosis (checked 2026-09-07):
   measuring recursive/true residual gaps, but does not establish that residual
   replacement alone fixes this input or justify adopting its update rule
   without a separate numerical test.
+
+### Frozen 1k real normal-system oracle (2026-09-07)
+
+[Machine-readable evidence](../benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json)
+records the bounded private oracle implemented in `3e50dc5`. The standalone
+example export is additive; normal solver CLI behavior and the public library
+API are unchanged. Example usage (the output file must not already exist):
+
+```bash
+cargo build --release --example compare_rig_bundle_adjustment
+target/release/examples/compare_rig_bundle_adjustment \
+  --model "$MODEL" --rig-manifest "$RIG_MANIFEST" \
+  --export-oracle-fixture "$EXISTING_OUTPUT_DIR/input.fixture"
+cargo test --release -p visloc-slam --lib matrix_free_real_oracle_tests --no-run
+# Set both variables to the exported fixture and its printed combined source hash.
+RAYON_NUM_THREADS=1 \
+VISLOC_MATRIX_FREE_ORACLE_FIXTURE="$EXISTING_OUTPUT_DIR/input.fixture" \
+VISLOC_MATRIX_FREE_ORACLE_EXPECTED_SOURCE_SHA256="$SOURCE_SHA256" \
+cargo test --release -p visloc-slam --lib \
+  bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle \
+  -- --exact --ignored --nocapture
+```
+
+The 30,587,925-byte fixture preserves all 130,900 observations in source-track
+order, all 4,716 landmarks, name-to-rig mapping, fixed sensor extrinsics and
+fixed pose 0. Independent checks verified source/combined hashes, observation
+identity and coordinates, point coordinates and initial-cost bits
+`4683430141614839853` (126,510.39875730938). No observation was removed.
+The same initial normal system has 499 free pose blocks / scalar dimension 2,994.
+
+| Initial solve damping | PCG 128 / 512 | Direct step residual: lower / implicit | Trial geometry |
+|---|---|---|---|
+| `1e-4` | both fail; true residual 41,263.7 / 318.346 against `7.35e-7` | `2.75e-6` / `0.01848` | 880 nonpositive-depth observations |
+| `1e10` | both succeed at 22 iterations; `5.64e-7` against `7.38e-7` | `3.02e-9` / `4.49e-7` | all 130,900 valid |
+
+At low damping, sparse direct and explicit lower-mirrored Schur agree to
+`1.02e-10` in pose-delta norm and `1.78e-8` in landmark-delta norm, but **the
+direct solution itself does not meet the implicit residual target**. The raw
+Schur asymmetry and different accumulation orders matter to further diagnosis;
+this does not establish one sole cause of PCG failure. The deterministic probe's
+raw/lower action errors are 0.18767 / 0.13604. Their ratios of about `1e-13`
+use the **unreduced** arithmetic scale (`9.94e11`), not final `Sx` or solution
+accuracy. PCG recursive and true residuals are close at these low-damping
+iteration limits, so residual replacement alone is not established as a fix.
+
+At high damping, matrix-free/explicit pose-delta difference is `2.09e-17` and
+all trial costs are 126,477.42813448103. Low-damping trial geometry cost/RMS
+exclude 880 invalid observations and must not be called full-objective
+improvements. Reported feasibility means finite and valid geometry, not that
+the PCG residual target passed. Prediction fields distinguish half-cost damped,
+squared-cost damped and squared-cost undamped reductions.
+
+Two serial release runs produced identical numerical reports (16.84 / 16.62 s;
+346,084 / 346,020 KiB peak RSS). These are whole **diagnostic** processes with
+explicit matrices, not production solver speed/memory results. Both existing
+direct and matrix-free CLI regression runs preserved all three model files
+byte-for-byte and the numerical trace against PR #79. No README performance
+claim or 10k promotion follows from this diagnostic.
+
+Next compare test-only PCG on the lower-mirrored explicit Schur against the
+implicit action, with the same input, damping, block-Jacobi preconditioner,
+128/512 limits and true-residual rule. This isolates accumulation from
+convergence/preconditioning before selecting scaling or a different
+preconditioner. Preserve the baseline and do not silently relax its tolerance.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -808,3 +808,20 @@ keep only the small pose-diagonal copy needed by the mutating direct path.
 Record arithmetic scales and check the existing gradient/RHS sign and the
 objective's factor of two before reporting predicted reduction. No claim that
 the direct step itself meets the PCG residual target is made before measuring it.
+
+Primary-source context for the next diagnosis (checked 2026-09-07):
+
+- [Ceres nonlinear least-squares documentation](https://ceres-solver.readthedocs.io/latest/nnls_solving.html)
+  describes inexact LM for iterative solves and enables Jacobian-column scaling
+  by default. Its `eta` stopping rule uses quadratic-model progress, not this
+  prototype's fixed `1e-12` true-residual rule. These are not interchangeable
+  tolerances. Scaling or an inexact policy could be a later controlled arm,
+  not a silent reinterpretation of the current failed gate. Distinguish an
+  equivalent change of linear coordinates from changing the physical-coordinate
+  LM damping metric; neither permits scaling fixed rig extrinsics.
+- [PETSc KSPPIPECGRR](https://petsc.org/main/manualpages/KSP/KSPPIPECGRR/)
+  uses residual replacement to improve robustness of pipelined CG. That is a
+  specific recurrence, not the classical PCG implemented here. It motivates
+  measuring recursive/true residual gaps, but does not establish that residual
+  replacement alone fixes this input or justify adopting its update rule
+  without a separate numerical test.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -789,3 +789,22 @@ value `1e-3`. Separate operator cancellation/residual drift, conditioning and
 convergence hypotheses before changing preconditioning or residual updates;
 the current measurements do not prove which is the sole cause. Preserve the
 true-residual gate and keep this next diagnostic in a separate PR.
+
+The next oracle must remain library `#[cfg(test)]` code, with an explicitly
+ignored real-input test and ordinary small synthetic CI tests. A hidden or
+nondefault-feature public method still expands the public API and is not the
+selected approach. If private test code needs an interchange input, prefer an
+explicit example-only export of bounded pose/point/observation records linked
+to the frozen source hashes, preserving every observation and its order; do
+not export a normal matrix or duplicate the complete source model in memory.
+The exporter/fixture is a proposed implementation mechanism, not yet built.
+
+Before any explicit Schur allocation, cap variable poses at 512, points at
+8,192, observations at 262,144, scalar dimension at 3,072 and pre-count the
+cross-pair work against an explicit bound. A real-input test must fail clearly
+when its requested fixture is missing or over cap, not report an empty passing
+measurement. Reuse one initial normal system across the two damping values;
+keep only the small pose-diagonal copy needed by the mutating direct path.
+Record arithmetic scales and check the existing gradient/RHS sign and the
+objective's factor of two before reporting predicted reduction. No claim that
+the direct step itself meets the PCG residual target is made before measuring it.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -801,13 +801,24 @@ The exporter/fixture is a proposed implementation mechanism, not yet built.
 
 Before any explicit Schur allocation, cap variable poses at 512, points at
 8,192, observations at 262,144, scalar dimension at 3,072 and pre-count the
-cross-pair work against an explicit bound. A real-input test must fail clearly
+cross-pair work against a 64,000,000-pair bound with checked arithmetic.
+The frozen 1k input has 130,677 variable-pose cross blocks and
+`sum(cross_length²) = 28,556,575` (maximum track cross length 891), counting
+multiple sensor blocks for the same frame separately. A real-input test must fail clearly
 when its requested fixture is missing or over cap, not report an empty passing
 measurement. Reuse one initial normal system across the two damping values;
 keep only the small pose-diagonal copy needed by the mutating direct path.
 Record arithmetic scales and check the existing gradient/RHS sign and the
 objective's factor of two before reporting predicted reduction. No claim that
 the direct step itself meets the PCG residual target is made before measuring it.
+
+The direct implementation factors its lower-triangle Schur storage. Report
+raw explicit Schur asymmetry and distinguish its full matvec from the
+lower-mirrored symmetric matrix actually used by factorization. For the
+current unrobust cost `sum(||r||²)`, assembly stores `b = Jᵀr` and `H = JᵀJ`:
+the undamped linearized cost reduction is `-2 bᵀδ - δᵀHδ`. A half-cost damped
+quadratic prediction is a different quantity and must be labeled accordingly.
+Test these signs and factors independently on small systems.
 
 Primary-source context for the next diagnosis (checked 2026-09-07):
 

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -83,6 +83,10 @@ explicit/implicit actions and true residuals on the same initial normal system
 at damping `1e-4` and `1e10`; do not relax tolerances or claim equivalent-work
 acceleration from the shorter failed-PCG run. PR #79 packages the driver and
 diagnostic evidence, not a solver-performance promotion.
+PR #79 passed all eight final-head checks (run 34116769919), merged as
+`42bf86f`, and its old branch was removed. The next branch is
+`feat/m8-real-normal-system-oracle`: test-only diagnostics with an explicit
+small-system allocation cap, no production API/default change, and no 10k run.
 
 ## Historical M7 baseline
 

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -87,6 +87,14 @@ PR #79 passed all eight final-head checks (run 34116769919), merged as
 `42bf86f`, and its old branch was removed. The next branch is
 `feat/m8-real-normal-system-oracle`: test-only diagnostics with an explicit
 small-system allocation cap, no production API/default change, and no 10k run.
+The oracle is now implemented (`3e50dc5`) and measured twice with identical
+numerical reports; [evidence](../benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json).
+At `1e-4`, even the direct step fails the implicit residual target and has 880
+invalid-depth trial observations; PCG 128/512 fail. At `1e10`, PCG converges in
+22 iterations and agrees with direct/explicit. Existing CLI model bytes and
+numerical traces are unchanged. Next isolate accumulation versus convergence
+with explicit lower-Schur PCG using the same preconditioner and stopping rule;
+this is a diagnostic gate, not a tolerance relaxation or a 10k promotion.
 
 ## Historical M7 baseline
 

--- a/examples/compare_rig_bundle_adjustment.rs
+++ b/examples/compare_rig_bundle_adjustment.rs
@@ -8,11 +8,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::{BufWriter, Write};
+use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use nalgebra::{Point2, Point3, Quaternion, UnitQuaternion, Vector3};
+use sha2::{Digest, Sha256};
 use visloc_rs::io::colmap::parse_cameras_txt;
 use visloc_rs::slam::{
     BaConfig, BaRigObservation, BundleAdjustment, LinearSolver, MatrixFreeBaOptions,
@@ -21,7 +22,9 @@ use visloc_rs::slam::{
 use visloc_rs::{Camera, CameraModel, Pose, SE3};
 
 const USAGE: &str = "usage: compare_rig_bundle_adjustment --model PATH --rig-manifest PATH \\
-    --solver direct|matrix-free --out-dir PATH [--pcg-max-iterations N]";
+    --solver direct|matrix-free --out-dir PATH [--pcg-max-iterations N]\n\
+    or: compare_rig_bundle_adjustment --model PATH --rig-manifest PATH \\
+    --export-oracle-fixture PATH";
 const CENTER_TOLERANCE_M: f64 = 1.0e-4;
 const FIXED_POSE_TOLERANCE_M: f64 = 1.0e-12;
 const FIXED_POSE_TOLERANCE_DEG: f64 = 1.0e-12;
@@ -35,6 +38,11 @@ const MAX_PCG_ITERATIONS: usize = 128;
 const PCG_TOLERANCE: f64 = 1.0e-12;
 const BA_MAX_ITERATIONS: usize = 20;
 const BA_INITIAL_LAMBDA: f64 = 1.0e-4;
+const ORACLE_MAX_VARIABLE_POSES: usize = 512;
+const ORACLE_MAX_LANDMARKS: usize = 8_192;
+const ORACLE_MAX_OBSERVATIONS: usize = 262_144;
+const ORACLE_MAX_SCHUR_SCALARS: usize = 3_072;
+const ORACLE_MAX_CROSS_PAIR_WORK: usize = 64_000_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SolverArm {
@@ -65,9 +73,10 @@ impl SolverArm {
 struct Args {
     model: PathBuf,
     rig_manifest: PathBuf,
-    solver: SolverArm,
-    out_dir: PathBuf,
+    solver: Option<SolverArm>,
+    out_dir: Option<PathBuf>,
     pcg_max_iterations: usize,
+    oracle_fixture_out: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -182,6 +191,7 @@ where
     let mut rig_manifest = None;
     let mut solver = None;
     let mut out_dir = None;
+    let mut oracle_fixture_out = None;
     let mut pcg_max_iterations = MAX_PCG_ITERATIONS;
     let mut pcg_seen = false;
     while let Some(flag) = values.next() {
@@ -202,6 +212,16 @@ where
             if pcg_max_iterations == 0 {
                 return Err(format!("{flag} must be positive\n{USAGE}"));
             }
+            continue;
+        }
+        if flag == "--export-oracle-fixture" {
+            let value = values
+                .next()
+                .ok_or_else(|| format!("{flag} requires a value\n{USAGE}"))?;
+            if value.starts_with('-') {
+                return Err(format!("{flag} requires a value, got {value:?}\n{USAGE}"));
+            }
+            set_path(&mut oracle_fixture_out, &flag, value)?;
             continue;
         }
         let slot = match flag.as_str() {
@@ -230,14 +250,26 @@ where
             }
         }
     }
+    if oracle_fixture_out.is_some() && (solver.is_some() || out_dir.is_some() || pcg_seen) {
+        return Err(format!(
+            "--export-oracle-fixture is a standalone operation; do not combine it with \
+             --solver, --out-dir or --pcg-max-iterations\n{USAGE}"
+        ));
+    }
+    if oracle_fixture_out.is_none() && (solver.is_none() || out_dir.is_none()) {
+        return Err(format!(
+            "--solver and --out-dir are required unless --export-oracle-fixture is used\n{USAGE}"
+        ));
+    }
     let args = Args {
         model: model.ok_or_else(|| format!("--model is required\n{USAGE}"))?,
         rig_manifest: rig_manifest.ok_or_else(|| format!("--rig-manifest is required\n{USAGE}"))?,
-        solver: solver.ok_or_else(|| format!("--solver is required\n{USAGE}"))?,
-        out_dir: out_dir.ok_or_else(|| format!("--out-dir is required\n{USAGE}"))?,
+        solver,
+        out_dir,
         pcg_max_iterations,
+        oracle_fixture_out,
     };
-    if args.solver == SolverArm::Direct && pcg_seen {
+    if args.solver == Some(SolverArm::Direct) && pcg_seen {
         return Err(format!(
             "--pcg-max-iterations is only valid for matrix-free\n{USAGE}"
         ));
@@ -266,9 +298,44 @@ fn run(args: &Args) -> Result<(), String> {
     let manifest = parse_rig_manifest(&args.rig_manifest)?;
     let source = load_source_model(&args.model, &manifest)?;
     validate_source_model(&source, &manifest)?;
-    prepare_output_path(&args.out_dir, &args.model, &args.rig_manifest)?;
+    if args.oracle_fixture_out.is_none() {
+        let out_dir = args
+            .out_dir
+            .as_deref()
+            .ok_or_else(|| "--out-dir is required for solver mode".to_owned())?;
+        prepare_output_path(out_dir, &args.model, &args.rig_manifest)?;
+    }
 
     let mut prepared = build_problem(&source, &manifest)?;
+    if let Some(fixture_path) = &args.oracle_fixture_out {
+        let source_hashes = hash_source_inputs(&args.model, &args.rig_manifest)?;
+        export_oracle_fixture(
+            fixture_path,
+            &args.model,
+            &args.rig_manifest,
+            &source_hashes,
+            &prepared.ba,
+        )?;
+        let initial_cost = prepared.ba.cost();
+        println!(
+            "oracle_fixture={} source_sha256={} initial_cost={:.17e} initial_cost_bits={} poses={} landmarks={} rig_observations={}",
+            fixture_path.display(),
+            source_hashes.combined,
+            initial_cost,
+            initial_cost.to_bits(),
+            prepared.ba.poses.len(),
+            prepared.ba.landmarks.len(),
+            prepared.ba.rig_observations.len(),
+        );
+        return Ok(());
+    }
+    let solver = args
+        .solver
+        .ok_or_else(|| "--solver is required for solver mode".to_owned())?;
+    let out_dir = args
+        .out_dir
+        .as_deref()
+        .ok_or_else(|| "--out-dir is required for solver mode".to_owned())?;
     let initial_cost = prepared.ba.cost();
     if !initial_cost.is_finite() {
         return Err("initial BA cost is non-finite".to_owned());
@@ -284,7 +351,7 @@ fn run(args: &Args) -> Result<(), String> {
         ..BaConfig::default()
     };
     let solver_started = Instant::now();
-    let optimization = match args.solver {
+    let optimization = match solver {
         SolverArm::Direct => {
             let result = prepared
                 .ba
@@ -319,10 +386,10 @@ fn run(args: &Args) -> Result<(), String> {
     if !final_cost.is_finite() {
         return Err("final BA cost is non-finite".to_owned());
     }
-    publish_model(&args.out_dir, &source, &manifest, &prepared)?;
+    publish_model(out_dir, &source, &manifest, &prepared)?;
     let total_seconds = total_started.elapsed().as_secs_f64();
     let summary = RunSummary {
-        solver: args.solver,
+        solver,
         initial_cost,
         final_cost,
         iterations,
@@ -345,7 +412,7 @@ fn run(args: &Args) -> Result<(), String> {
         PCG_TOLERANCE,
         summary.solver_seconds,
         summary.total_seconds,
-        args.out_dir.display(),
+        out_dir.display(),
     );
     Ok(())
 }
@@ -368,10 +435,12 @@ fn validate_input_paths(args: &Args) -> Result<(), String> {
             return Err(format!("model is missing {file}: {}", args.model.display()));
         }
     }
-    if paths_overlap(&args.out_dir, &args.model)?
-        || paths_overlap(&args.out_dir, &args.rig_manifest)?
-    {
-        return Err("--out-dir overlaps an input path; refusing to publish".to_owned());
+    if let Some(fixture) = &args.oracle_fixture_out {
+        validate_fixture_output_path(fixture, &args.model, &args.rig_manifest)?;
+    } else if let Some(out_dir) = &args.out_dir {
+        if paths_overlap(out_dir, &args.model)? || paths_overlap(out_dir, &args.rig_manifest)? {
+            return Err("--out-dir overlaps an input path; refusing to publish".to_owned());
+        }
     }
     Ok(())
 }
@@ -419,6 +488,367 @@ fn paths_overlap(first: &Path, second: &Path) -> Result<bool, String> {
     let first = resolved_path(first)?;
     let second = resolved_path(second)?;
     Ok(first == second || first.starts_with(&second) || second.starts_with(&first))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceHashes {
+    cameras: String,
+    images: String,
+    points: String,
+    manifest: String,
+    combined: String,
+}
+
+fn hash_file(path: &Path) -> Result<String, String> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut file = fs::File::open(path)
+        .map_err(|error| format!("read source hash input {}: {error}", path.display()))?;
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|error| format!("read source hash input {}: {error}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn hash_source_inputs(model_dir: &Path, rig_manifest: &Path) -> Result<SourceHashes, String> {
+    let cameras = hash_file(&model_dir.join("cameras.txt"))?;
+    let images = hash_file(&model_dir.join("images.txt"))?;
+    let points = hash_file(&model_dir.join("points3D.txt"))?;
+    let manifest = hash_file(rig_manifest)?;
+    let mut combined_hasher = Sha256::new();
+    for (label, digest) in [
+        ("cameras.txt", &cameras),
+        ("images.txt", &images),
+        ("points3D.txt", &points),
+        ("rig-manifest", &manifest),
+    ] {
+        combined_hasher.update(label.as_bytes());
+        combined_hasher.update([0_u8]);
+        combined_hasher.update(digest.as_bytes());
+        combined_hasher.update([0xff_u8]);
+    }
+    Ok(SourceHashes {
+        cameras,
+        images,
+        points,
+        manifest,
+        combined: format!("{:x}", combined_hasher.finalize()),
+    })
+}
+
+fn validate_fixture_output_path(
+    fixture: &Path,
+    model_dir: &Path,
+    rig_manifest: &Path,
+) -> Result<(), String> {
+    if paths_overlap(fixture, model_dir)? || paths_overlap(fixture, rig_manifest)? {
+        return Err("fixture output overlaps an input path".to_owned());
+    }
+    let parent = fixture
+        .parent()
+        .ok_or_else(|| format!("fixture output has no parent: {}", fixture.display()))?;
+    let parent_metadata = fs::symlink_metadata(parent).map_err(|error| {
+        format!(
+            "fixture output parent is not an existing directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    if parent_metadata.file_type().is_symlink() || !parent_metadata.is_dir() {
+        return Err(format!(
+            "fixture output parent is not a real directory: {}",
+            parent.display()
+        ));
+    }
+    match fs::symlink_metadata(fixture) {
+        Ok(metadata) => Err(format!(
+            "fixture output already exists (including symlink): {} ({})",
+            fixture.display(),
+            if metadata.file_type().is_symlink() {
+                "symlink"
+            } else {
+                "path"
+            }
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "inspect fixture output {}: {error}",
+            fixture.display()
+        )),
+    }
+}
+
+fn camera_model_name(model: &CameraModel) -> Result<&'static str, String> {
+    match model {
+        CameraModel::Pinhole => Ok("PINHOLE"),
+        CameraModel::SimplePinhole => Ok("SIMPLE_PINHOLE"),
+        CameraModel::SimpleRadial => Ok("SIMPLE_RADIAL"),
+        CameraModel::Radial => Ok("RADIAL"),
+        CameraModel::OpenCv => Ok("OPENCV"),
+        CameraModel::Unknown(name) => Err(format!(
+            "oracle fixture cannot encode unknown camera model {name:?}"
+        )),
+    }
+}
+
+fn write_se3<W: Write>(writer: &mut W, transform: &SE3) -> Result<(), String> {
+    let quaternion = transform.rotation.quaternion();
+    let values = [
+        quaternion.w,
+        quaternion.i,
+        quaternion.j,
+        quaternion.k,
+        transform.translation.x,
+        transform.translation.y,
+        transform.translation.z,
+    ];
+    if !values.iter().all(|value| value.is_finite()) {
+        return Err("oracle fixture encountered non-finite SE3".to_owned());
+    }
+    for value in values {
+        write!(writer, " {:.17e}", value).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn validate_oracle_fixture_caps(ba: &BundleAdjustment) -> Result<(), String> {
+    let variable_poses = ba.poses.len().saturating_sub(ba.fixed_poses.len());
+    let variable_landmarks = ba.landmarks.len().saturating_sub(ba.fixed_landmarks.len());
+    let observations = ba.rig_observations.len();
+    let dimension = variable_poses
+        .checked_mul(6)
+        .ok_or_else(|| "oracle fixture Schur dimension overflows".to_owned())?;
+    if variable_poses > ORACLE_MAX_VARIABLE_POSES {
+        return Err(format!(
+            "oracle fixture variable-pose cap exceeded: {variable_poses}"
+        ));
+    }
+    if variable_landmarks > ORACLE_MAX_LANDMARKS {
+        return Err(format!(
+            "oracle fixture landmark cap exceeded: {variable_landmarks}"
+        ));
+    }
+    if observations > ORACLE_MAX_OBSERVATIONS {
+        return Err(format!(
+            "oracle fixture observation cap exceeded: {observations}"
+        ));
+    }
+    if dimension > ORACLE_MAX_SCHUR_SCALARS {
+        return Err(format!(
+            "oracle fixture Schur dimension cap exceeded: {dimension}"
+        ));
+    }
+    let mut per_landmark = BTreeMap::<u64, usize>::new();
+    for observation in &ba.rig_observations {
+        let count = per_landmark.entry(observation.landmark_id).or_default();
+        *count = (*count)
+            .checked_add(1)
+            .ok_or_else(|| "oracle fixture cross-pair count overflows".to_owned())?;
+    }
+    let cross_pairs = per_landmark
+        .into_values()
+        .try_fold(0_usize, |total, count| {
+            let pairs = count
+                .checked_mul(count)
+                .ok_or_else(|| "oracle fixture cross-pair count overflows".to_owned())?;
+            total
+                .checked_add(pairs)
+                .ok_or_else(|| "oracle fixture cross-pair count overflows".to_owned())
+        })?;
+    if cross_pairs > ORACLE_MAX_CROSS_PAIR_WORK {
+        return Err(format!(
+            "oracle fixture cross-pair cap exceeded: {cross_pairs}"
+        ));
+    }
+    Ok(())
+}
+
+fn export_oracle_fixture(
+    fixture: &Path,
+    model_dir: &Path,
+    rig_manifest: &Path,
+    source_hashes: &SourceHashes,
+    ba: &BundleAdjustment,
+) -> Result<(), String> {
+    if !ba.observations.is_empty()
+        || !ba.stereo_observations.is_empty()
+        || !ba.general_stereo_observations.is_empty()
+        || ba.stereo_baseline.is_some()
+        || ba.gravity_prior.is_some()
+        || ba.per_pose_gravity_prior.is_some()
+        || ba.position_prior.is_some()
+        || !ba.pairwise_pose_factors.is_empty()
+        || !ba.velocities.is_empty()
+        || !ba.biases.is_empty()
+        || !ba.imu_factors.is_empty()
+        || !ba.bias_random_walk_factors.is_empty()
+        || ba.navigation_state_prior.is_some()
+    {
+        return Err("oracle fixture requires pure rig-visual BA input".to_owned());
+    }
+    if ba.poses.is_empty() || ba.landmarks.is_empty() || ba.rig_observations.is_empty() {
+        return Err("oracle fixture requires poses, landmarks and rig observations".to_owned());
+    }
+    validate_oracle_fixture_caps(ba)?;
+    for hash in [
+        &source_hashes.cameras,
+        &source_hashes.images,
+        &source_hashes.points,
+        &source_hashes.manifest,
+        &source_hashes.combined,
+    ] {
+        if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err("invalid source SHA256 for oracle fixture".to_owned());
+        }
+    }
+    validate_fixture_output_path(fixture, model_dir, rig_manifest)?;
+
+    let parent = fixture.parent().expect("validated fixture parent");
+    let file_name = fixture
+        .file_name()
+        .ok_or_else(|| format!("fixture output has no filename: {}", fixture.display()))?
+        .to_string_lossy();
+    let staging = parent.join(format!(".{file_name}.staging-{}", std::process::id()));
+    let mut owns_staging = false;
+    let result = (|| {
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staging)
+            .map_err(|error| format!("create fixture staging {}: {error}", staging.display()))?;
+        owns_staging = true;
+        let mut writer = BufWriter::new(file);
+        writeln!(writer, "VISLOC_BA_ORACLE_FIXTURE 1").map_err(|error| error.to_string())?;
+        writeln!(writer, "SOURCE_SHA256 {}", source_hashes.combined)
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "SOURCE_SHA256_CAMERAS {}", source_hashes.cameras)
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "SOURCE_SHA256_IMAGES {}", source_hashes.images)
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "SOURCE_SHA256_POINTS {}", source_hashes.points)
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "SOURCE_SHA256_MANIFEST {}", source_hashes.manifest)
+            .map_err(|error| error.to_string())?;
+        let initial_cost = ba.cost();
+        if !initial_cost.is_finite() {
+            return Err("oracle fixture initial cost is non-finite".to_owned());
+        }
+        writeln!(writer, "INITIAL_COST {:.17e}", initial_cost)
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "INITIAL_COST_BITS {}", initial_cost.to_bits())
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "CAMERA_COUNT {}", {
+            let mut ids = BTreeSet::new();
+            for observation in &ba.rig_observations {
+                ids.insert(observation.camera.id);
+            }
+            ids.len()
+        })
+        .map_err(|error| error.to_string())?;
+        writeln!(writer, "POSE_COUNT {}", ba.poses.len()).map_err(|error| error.to_string())?;
+        writeln!(writer, "LANDMARK_COUNT {}", ba.landmarks.len())
+            .map_err(|error| error.to_string())?;
+        writeln!(writer, "OBSERVATION_COUNT {}", ba.rig_observations.len())
+            .map_err(|error| error.to_string())?;
+
+        let mut cameras = BTreeMap::<u64, Camera>::new();
+        for observation in &ba.rig_observations {
+            if let Some(previous) =
+                cameras.insert(observation.camera.id, observation.camera.clone())
+            {
+                if previous != observation.camera {
+                    return Err(format!(
+                        "camera id {} has inconsistent fixture records",
+                        observation.camera.id
+                    ));
+                }
+            }
+        }
+        for camera in cameras.values() {
+            let model = camera_model_name(&camera.model)?;
+            if !camera.params.iter().all(|value| value.is_finite()) {
+                return Err(format!("camera {} has non-finite parameters", camera.id));
+            }
+            write!(
+                writer,
+                "CAMERA {} {} {} {} {}",
+                camera.id,
+                model,
+                camera.width,
+                camera.height,
+                camera.params.len()
+            )
+            .map_err(|error| error.to_string())?;
+            for value in &camera.params {
+                write!(writer, " {:.17e}", value).map_err(|error| error.to_string())?;
+            }
+            writeln!(writer).map_err(|error| error.to_string())?;
+        }
+        for (id, pose) in &ba.poses {
+            write!(writer, "POSE {id}").map_err(|error| error.to_string())?;
+            write_se3(&mut writer, &pose.world_to_camera)?;
+            writeln!(writer).map_err(|error| error.to_string())?;
+        }
+        for id in &ba.fixed_poses {
+            writeln!(writer, "FIXED_POSE {id}").map_err(|error| error.to_string())?;
+        }
+        for (id, point) in &ba.landmarks {
+            if !point.coords.iter().all(|value| value.is_finite()) {
+                return Err(format!("landmark {id} has non-finite coordinates"));
+            }
+            writeln!(
+                writer,
+                "LANDMARK {id} {:.17e} {:.17e} {:.17e}",
+                point.x, point.y, point.z
+            )
+            .map_err(|error| error.to_string())?;
+        }
+        for observation in &ba.rig_observations {
+            if !observation.xy.x.is_finite() || !observation.xy.y.is_finite() {
+                return Err("rig observation has non-finite pixel coordinates".to_owned());
+            }
+            write!(
+                writer,
+                "RIG_OBSERVATION {} {} {:.17e} {:.17e} {}",
+                observation.keyframe_id,
+                observation.landmark_id,
+                observation.xy.x,
+                observation.xy.y,
+                observation.camera.id
+            )
+            .map_err(|error| error.to_string())?;
+            write_se3(&mut writer, &observation.sensor_from_rig)?;
+            writeln!(writer).map_err(|error| error.to_string())?;
+        }
+        writeln!(writer, "END").map_err(|error| error.to_string())?;
+        writer
+            .flush()
+            .map_err(|error| format!("flush fixture staging: {error}"))?;
+        writer
+            .into_inner()
+            .map_err(|error| format!("finish fixture staging: {error}"))?
+            .sync_all()
+            .map_err(|error| format!("sync fixture staging: {error}"))?;
+        // A hard link is a no-clobber publication on the same filesystem:
+        // unlike rename, it cannot replace a sentinel or a concurrently
+        // created destination.  The staging file is removed only after the
+        // final link is known to exist.
+        fs::hard_link(&staging, fixture)
+            .map_err(|error| format!("publish oracle fixture {}: {error}", fixture.display()))?;
+        fs::remove_file(&staging)
+            .map_err(|error| format!("remove fixture staging {}: {error}", staging.display()))?;
+        owns_staging = false;
+        Ok(())
+    })();
+    if result.is_err() && owns_staging {
+        let _ = fs::remove_file(&staging);
+    }
+    result
 }
 
 fn prepare_output_path(out_dir: &Path, model: &Path, manifest: &Path) -> Result<(), String> {
@@ -1635,7 +2065,7 @@ mod tests {
             .into_iter()
             .map(str::to_owned),
         );
-        assert_eq!(args.unwrap().solver, SolverArm::Direct);
+        assert_eq!(args.unwrap().solver, Some(SolverArm::Direct));
         let error = parse_args(
             [
                 "compare",
@@ -1655,6 +2085,46 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.contains("only valid for matrix-free"));
+    }
+
+    #[test]
+    fn parses_standalone_oracle_fixture_export() {
+        let args = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--export-oracle-fixture",
+                "fixture.txt",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(args.solver, None);
+        assert_eq!(args.out_dir, None);
+        assert_eq!(args.oracle_fixture_out, Some(PathBuf::from("fixture.txt")));
+        let error = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "direct",
+                "--out-dir",
+                "out",
+                "--export-oracle-fixture",
+                "fixture.txt",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(error.contains("standalone operation"));
     }
 
     #[test]
@@ -1931,6 +2401,65 @@ mod tests {
                     .starts_with(&staging_prefix)
             });
         assert!(!leftovers);
+    }
+
+    #[test]
+    fn oracle_fixture_export_is_no_clobber_and_stream_roundtrip_safe() {
+        let root = std::env::temp_dir().join(format!(
+            "visloc-compare-oracle-export-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("model")).unwrap();
+        fs::write(root.join("manifest.txt"), "manifest").unwrap();
+        let (source, manifest) = publication_fixture();
+        validate_source_model(&source, &manifest).unwrap();
+        let prepared = build_problem(&source, &manifest).unwrap();
+        let hashes = SourceHashes {
+            cameras: "a".repeat(64),
+            images: "b".repeat(64),
+            points: "c".repeat(64),
+            manifest: "d".repeat(64),
+            combined: "e".repeat(64),
+        };
+        let fixture = root.join("oracle.txt");
+        export_oracle_fixture(
+            &fixture,
+            &root.join("model"),
+            &root.join("manifest.txt"),
+            &hashes,
+            &prepared.ba,
+        )
+        .unwrap();
+        let text = fs::read_to_string(&fixture).unwrap();
+        assert!(text.contains("VISLOC_BA_ORACLE_FIXTURE 1\n"));
+        assert!(text.contains(&format!("SOURCE_SHA256 {}\n", hashes.combined)));
+        assert!(text.contains("INITIAL_COST "));
+        assert!(text.contains("INITIAL_COST_BITS "));
+        assert!(text.contains("POSE 0 "));
+        assert!(text.contains("RIG_OBSERVATION 0 7"));
+        let original = text.clone();
+        assert!(export_oracle_fixture(
+            &fixture,
+            &root.join("model"),
+            &root.join("manifest.txt"),
+            &hashes,
+            &prepared.ba,
+        )
+        .is_err());
+        assert_eq!(fs::read_to_string(&fixture).unwrap(), original);
+        let staging_prefix = ".oracle.txt.staging-";
+        let leftovers = fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(staging_prefix)
+            });
+        assert!(!leftovers);
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -7251,6 +7251,1546 @@ mod matrix_free_ba_api_tests {
 }
 
 #[cfg(test)]
+mod matrix_free_real_oracle_tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::env;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+    use std::path::Path;
+
+    const MAX_VARIABLE_POSES: usize = 512;
+    const MAX_LANDMARKS: usize = 8_192;
+    const MAX_OBSERVATIONS: usize = 262_144;
+    const MAX_SCHUR_SCALARS: usize = 3_072;
+    const MAX_CROSS_PAIR_WORK: usize = 64_000_000;
+    const MAX_CAMERAS: usize = 64;
+    const ORACLE_PC_TOLERANCE: f64 = 1.0e-12;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct OracleFixture {
+        source_hashes: BTreeMap<String, String>,
+        initial_cost: f64,
+        initial_cost_bits: u64,
+        ba: BundleAdjustment,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct PredictedDecrease {
+        half_damped: f64,
+        squared_damped: f64,
+        squared_undamped: f64,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Feasibility {
+        finite: bool,
+        pose_true_residual: f64,
+        implicit_pose_true_residual: Option<f64>,
+        max_landmark_backsub_residual: f64,
+        geometry_observation_count: usize,
+        geometry_invalid_observations: usize,
+        geometry_nonpositive_depth: usize,
+        geometry_cost: f64,
+        geometry_rms_error: f64,
+        geometry_max_error: f64,
+        geometry_feasible: bool,
+        feasible: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct OracleCaseReport {
+        lambda: f64,
+        pcg_max_iterations: usize,
+        pose_blocks: usize,
+        landmark_count: usize,
+        observation_count: usize,
+        schur_dimension: usize,
+        singular_landmarks: usize,
+        raw_schur_asymmetry: Option<f64>,
+        schur_base_action_norm: Option<f64>,
+        schur_eliminated_action_norm: Option<f64>,
+        schur_arithmetic_scale: Option<f64>,
+        operator_raw_action_error: Option<f64>,
+        operator_raw_action_relative_error: Option<f64>,
+        operator_lower_action_error: Option<f64>,
+        operator_lower_action_relative_error: Option<f64>,
+        operator_rhs_error: Option<f64>,
+        direct_explicit_pose_error: Option<f64>,
+        direct_explicit_landmark_error: Option<f64>,
+        direct_feasibility: Option<Feasibility>,
+        explicit_feasibility: Option<Feasibility>,
+        direct_prediction: Option<PredictedDecrease>,
+        explicit_prediction: Option<PredictedDecrease>,
+        pcg_status: String,
+        pcg_iterations: Option<usize>,
+        pcg_true_residual: Option<f64>,
+        pcg_target: Option<f64>,
+        matrix_free_pose_error: Option<f64>,
+        matrix_free_landmark_error: Option<f64>,
+        matrix_free_feasibility: Option<Feasibility>,
+        matrix_free_prediction: Option<PredictedDecrease>,
+    }
+
+    fn parse_f64(token: &str, context: &str) -> Result<f64, String> {
+        let value = token
+            .parse::<f64>()
+            .map_err(|error| format!("{context}: {error}"))?;
+        if !value.is_finite() {
+            return Err(format!("{context}: non-finite value"));
+        }
+        Ok(value)
+    }
+
+    fn parse_usize(token: &str, context: &str) -> Result<usize, String> {
+        token
+            .parse::<usize>()
+            .map_err(|error| format!("{context}: {error}"))
+    }
+
+    fn parse_u64(token: &str, context: &str) -> Result<u64, String> {
+        token
+            .parse::<u64>()
+            .map_err(|error| format!("{context}: {error}"))
+    }
+
+    fn parse_se3(fields: &[&str], start: usize, context: &str) -> Result<SE3, String> {
+        if fields.len() < start + 7 {
+            return Err(format!("{context}: expected quaternion and translation"));
+        }
+        let values = (0..7)
+            .map(|index| parse_f64(fields[start + index], context))
+            .collect::<Result<Vec<_>, _>>()?;
+        let quaternion = nalgebra::Quaternion::new(values[0], values[1], values[2], values[3]);
+        let norm = quaternion.norm();
+        if !norm.is_finite() || norm <= 1.0e-12 || (norm - 1.0).abs() > 1.0e-6 {
+            return Err(format!("{context}: quaternion norm is not one"));
+        }
+        Ok(SE3::new(
+            // The exporter already validated and emitted a unit quaternion.
+            // Preserve its f64 components exactly; normalizing here would
+            // change the initial normal system by a rounding-dependent amount.
+            // `from_quaternion` normalizes.  The fixture has already checked
+            // the norm, so use the unchecked constructor to preserve every
+            // serialized f64 bit and keep the normal system identical.
+            nalgebra::UnitQuaternion::new_unchecked(quaternion),
+            Vector3::new(values[4], values[5], values[6]),
+        ))
+    }
+
+    fn parse_fixture(path: &Path) -> Result<OracleFixture, String> {
+        let file = File::open(path).map_err(|error| format!("open fixture: {error}"))?;
+        let reader = BufReader::new(file);
+        let mut source_hashes = BTreeMap::new();
+        let mut expected_initial_cost = None;
+        let mut expected_initial_cost_bits = None;
+        let mut expected_counts = BTreeMap::<String, usize>::new();
+        let mut cameras = BTreeMap::<u64, Camera>::new();
+        let mut poses = BTreeMap::<u64, Pose>::new();
+        let mut landmarks = BTreeMap::<u64, Point3<f64>>::new();
+        let mut fixed_poses = BTreeSet::new();
+        let mut rig_observations = Vec::new();
+        let mut saw_header = false;
+        let mut saw_end = false;
+
+        for (line_index, line_result) in reader.lines().enumerate() {
+            let line_number = line_index + 1;
+            let line =
+                line_result.map_err(|error| format!("fixture line {line_number}: {error}"))?;
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            if fields.is_empty() {
+                continue;
+            }
+            if saw_end && fields[0] != "END" {
+                return Err(format!(
+                    "fixture line {line_number}: records after END are not allowed"
+                ));
+            }
+            if !saw_header && fields[0] != "VISLOC_BA_ORACLE_FIXTURE" {
+                return Err(format!(
+                    "fixture line {line_number}: header must be the first record"
+                ));
+            }
+            match fields[0] {
+                "VISLOC_BA_ORACLE_FIXTURE" => {
+                    if fields != ["VISLOC_BA_ORACLE_FIXTURE", "1"] {
+                        return Err(format!("fixture line {line_number}: unsupported version"));
+                    }
+                    if saw_header {
+                        return Err(format!("fixture line {line_number}: duplicate header"));
+                    }
+                    saw_header = true;
+                }
+                "SOURCE_SHA256"
+                | "SOURCE_SHA256_CAMERAS"
+                | "SOURCE_SHA256_IMAGES"
+                | "SOURCE_SHA256_POINTS"
+                | "SOURCE_SHA256_MANIFEST" => {
+                    if fields.len() != 2
+                        || fields[1].len() != 64
+                        || !fields[1].bytes().all(|byte| byte.is_ascii_hexdigit())
+                    {
+                        return Err(format!("fixture line {line_number}: invalid source hash"));
+                    }
+                    if source_hashes
+                        .insert(fields[0].to_owned(), fields[1].to_owned())
+                        .is_some()
+                    {
+                        return Err(format!("fixture line {line_number}: duplicate source hash"));
+                    }
+                }
+                "INITIAL_COST" => {
+                    if fields.len() != 2 || expected_initial_cost.is_some() {
+                        return Err(format!("fixture line {line_number}: invalid INITIAL_COST"));
+                    }
+                    expected_initial_cost = Some(parse_f64(fields[1], "initial cost")?);
+                }
+                "INITIAL_COST_BITS" => {
+                    if fields.len() != 2 || expected_initial_cost_bits.is_some() {
+                        return Err(format!(
+                            "fixture line {line_number}: invalid INITIAL_COST_BITS"
+                        ));
+                    }
+                    expected_initial_cost_bits = Some(parse_u64(fields[1], "initial cost bits")?);
+                }
+                "CAMERA_COUNT" | "POSE_COUNT" | "LANDMARK_COUNT" | "OBSERVATION_COUNT" => {
+                    if fields.len() != 2 {
+                        return Err(format!("fixture line {line_number}: invalid count"));
+                    }
+                    let count = parse_usize(fields[1], "fixture count")?;
+                    let cap = match fields[0] {
+                        "CAMERA_COUNT" => MAX_CAMERAS,
+                        "POSE_COUNT" => MAX_VARIABLE_POSES + 1,
+                        "LANDMARK_COUNT" => MAX_LANDMARKS,
+                        "OBSERVATION_COUNT" => MAX_OBSERVATIONS,
+                        _ => unreachable!(),
+                    };
+                    if count > cap {
+                        return Err(format!(
+                            "fixture line {line_number}: {} exceeds cap {cap}",
+                            fields[0]
+                        ));
+                    }
+                    if expected_counts
+                        .insert(fields[0].to_owned(), count)
+                        .is_some()
+                    {
+                        return Err(format!("fixture line {line_number}: duplicate count"));
+                    }
+                }
+                "CAMERA" => {
+                    if fields.len() < 6 {
+                        return Err(format!("fixture line {line_number}: short camera"));
+                    }
+                    if cameras.len() >= MAX_CAMERAS {
+                        return Err(format!("fixture line {line_number}: camera cap exceeded"));
+                    }
+                    let id = parse_u64(fields[1], "camera id")?;
+                    let model = CameraModel::from_colmap_name(fields[2]);
+                    if matches!(model, CameraModel::Unknown(_)) {
+                        return Err(format!("fixture line {line_number}: unknown camera model"));
+                    }
+                    let width = fields[3]
+                        .parse::<u32>()
+                        .map_err(|error| format!("fixture line {line_number}: width: {error}"))?;
+                    let height = fields[4]
+                        .parse::<u32>()
+                        .map_err(|error| format!("fixture line {line_number}: height: {error}"))?;
+                    let parameter_count = parse_usize(fields[5], "camera parameter count")?;
+                    if parameter_count > 16 {
+                        return Err(format!(
+                            "fixture line {line_number}: camera parameter cap exceeded"
+                        ));
+                    }
+                    if fields.len() != 6 + parameter_count {
+                        return Err(format!(
+                            "fixture line {line_number}: camera parameter count mismatch"
+                        ));
+                    }
+                    let params = fields[6..]
+                        .iter()
+                        .map(|token| parse_f64(token, "camera parameter"))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    if cameras
+                        .insert(
+                            id,
+                            Camera {
+                                id,
+                                model,
+                                width,
+                                height,
+                                params,
+                            },
+                        )
+                        .is_some()
+                    {
+                        return Err(format!("fixture line {line_number}: duplicate camera"));
+                    }
+                }
+                "POSE" => {
+                    if fields.len() != 9 {
+                        return Err(format!("fixture line {line_number}: invalid pose"));
+                    }
+                    if poses.len() > MAX_VARIABLE_POSES {
+                        return Err(format!("fixture line {line_number}: pose cap exceeded"));
+                    }
+                    let id = parse_u64(fields[1], "pose id")?;
+                    let pose = Pose {
+                        world_to_camera: parse_se3(&fields, 2, "pose")?,
+                    };
+                    if poses.insert(id, pose).is_some() {
+                        return Err(format!("fixture line {line_number}: duplicate pose"));
+                    }
+                }
+                "FIXED_POSE" => {
+                    if fields.len() != 2 {
+                        return Err(format!("fixture line {line_number}: invalid fixed pose"));
+                    }
+                    if !fixed_poses.insert(parse_u64(fields[1], "fixed pose id")?) {
+                        return Err(format!("fixture line {line_number}: duplicate fixed pose"));
+                    }
+                }
+                "LANDMARK" => {
+                    if fields.len() != 5 {
+                        return Err(format!("fixture line {line_number}: invalid landmark"));
+                    }
+                    if landmarks.len() >= MAX_LANDMARKS {
+                        return Err(format!("fixture line {line_number}: landmark cap exceeded"));
+                    }
+                    let id = parse_u64(fields[1], "landmark id")?;
+                    let point = Point3::new(
+                        parse_f64(fields[2], "landmark x")?,
+                        parse_f64(fields[3], "landmark y")?,
+                        parse_f64(fields[4], "landmark z")?,
+                    );
+                    if landmarks.insert(id, point).is_some() {
+                        return Err(format!("fixture line {line_number}: duplicate landmark"));
+                    }
+                }
+                "RIG_OBSERVATION" => {
+                    if fields.len() != 13 {
+                        return Err(format!(
+                            "fixture line {line_number}: invalid rig observation"
+                        ));
+                    }
+                    if rig_observations.len() >= MAX_OBSERVATIONS {
+                        return Err(format!(
+                            "fixture line {line_number}: observation cap exceeded"
+                        ));
+                    }
+                    let frame_id = parse_u64(fields[1], "observation frame id")?;
+                    let landmark_id = parse_u64(fields[2], "observation landmark id")?;
+                    let xy = Point2::new(
+                        parse_f64(fields[3], "observation x")?,
+                        parse_f64(fields[4], "observation y")?,
+                    );
+                    let camera_id = parse_u64(fields[5], "observation camera id")?;
+                    let sensor_from_rig = parse_se3(&fields, 6, "sensor extrinsic")?;
+                    rig_observations.push((frame_id, landmark_id, xy, camera_id, sensor_from_rig));
+                }
+                "END" => {
+                    if fields.len() != 1 || saw_end {
+                        return Err(format!("fixture line {line_number}: invalid END"));
+                    }
+                    saw_end = true;
+                }
+                other => {
+                    return Err(format!(
+                        "fixture line {line_number}: unknown record {other:?}"
+                    ));
+                }
+            }
+        }
+        if !saw_header || !saw_end {
+            return Err("fixture is missing header or END".to_owned());
+        }
+        let expected_initial_cost =
+            expected_initial_cost.ok_or_else(|| "fixture is missing INITIAL_COST".to_owned())?;
+        let expected_initial_cost_bits = expected_initial_cost_bits
+            .ok_or_else(|| "fixture is missing INITIAL_COST_BITS".to_owned())?;
+        for key in [
+            "SOURCE_SHA256",
+            "SOURCE_SHA256_CAMERAS",
+            "SOURCE_SHA256_IMAGES",
+            "SOURCE_SHA256_POINTS",
+            "SOURCE_SHA256_MANIFEST",
+        ] {
+            if !source_hashes.contains_key(key) {
+                return Err(format!("fixture is missing {key}"));
+            }
+        }
+        if cameras.is_empty()
+            || poses.is_empty()
+            || landmarks.is_empty()
+            || rig_observations.is_empty()
+        {
+            return Err("fixture has no BA records".to_owned());
+        }
+        if fixed_poses.len() != 1 || !fixed_poses.iter().all(|id| poses.contains_key(id)) {
+            return Err("fixture fixed pose set is invalid".to_owned());
+        }
+        let first_camera = cameras
+            .values()
+            .next()
+            .cloned()
+            .ok_or_else(|| "fixture has no camera".to_owned())?;
+        let mut ba = BundleAdjustment::new(first_camera);
+        for (id, pose) in poses {
+            ba.add_pose(id, pose);
+        }
+        for id in fixed_poses {
+            ba.fix_pose(id);
+        }
+        for (id, point) in landmarks {
+            ba.add_landmark(id, point);
+        }
+        for (frame_id, landmark_id, xy, camera_id, sensor_from_rig) in rig_observations {
+            let camera = cameras
+                .get(&camera_id)
+                .cloned()
+                .ok_or_else(|| format!("observation references unknown camera {camera_id}"))?;
+            if !ba.poses.contains_key(&frame_id) {
+                return Err(format!("observation references unknown pose {frame_id}"));
+            }
+            if !ba.landmarks.contains_key(&landmark_id) {
+                return Err(format!(
+                    "observation references unknown landmark {landmark_id}"
+                ));
+            }
+            ba.add_rig_observation(BaRigObservation {
+                keyframe_id: frame_id,
+                landmark_id,
+                xy,
+                camera,
+                sensor_from_rig,
+            });
+        }
+        let expected = [
+            ("CAMERA_COUNT", cameras.len()),
+            ("POSE_COUNT", ba.poses.len()),
+            ("LANDMARK_COUNT", ba.landmarks.len()),
+            ("OBSERVATION_COUNT", ba.rig_observations.len()),
+        ];
+        for (key, actual) in expected {
+            if expected_counts.get(key).copied() != Some(actual) {
+                return Err(format!("fixture {key} does not match records"));
+            }
+        }
+        let actual_initial_cost = ba.cost();
+        if !actual_initial_cost.is_finite()
+            || actual_initial_cost.to_bits() != expected_initial_cost_bits
+            || actual_initial_cost.to_bits() != expected_initial_cost.to_bits()
+        {
+            return Err(format!(
+                "fixture initial cost bit mismatch: expected {} ({expected_initial_cost:.17e}), actual {} ({actual_initial_cost:.17e})",
+                expected_initial_cost_bits,
+                actual_initial_cost.to_bits(),
+            ));
+        }
+        Ok(OracleFixture {
+            source_hashes,
+            initial_cost: expected_initial_cost,
+            initial_cost_bits: expected_initial_cost_bits,
+            ba,
+        })
+    }
+
+    fn variable_indices(ba: &BundleAdjustment) -> (BTreeMap<u64, usize>, BTreeMap<u64, usize>) {
+        let pose_index = ba
+            .poses
+            .keys()
+            .copied()
+            .filter(|id| !ba.fixed_poses.contains(id))
+            .enumerate()
+            .map(|(index, id)| (id, index))
+            .collect();
+        let landmark_index = ba
+            .landmarks
+            .keys()
+            .copied()
+            .filter(|id| !ba.fixed_landmarks.contains(id))
+            .enumerate()
+            .map(|(index, id)| (id, index))
+            .collect();
+        (pose_index, landmark_index)
+    }
+
+    fn observation_count(ba: &BundleAdjustment) -> usize {
+        ba.observations.len()
+            + ba.stereo_observations.len()
+            + ba.general_stereo_observations.len()
+            + ba.rig_observations.len()
+    }
+
+    fn cross_pair_work(system: &NormalEquationsBa) -> Result<usize, String> {
+        system
+            .landmarks
+            .iter()
+            .try_fold(0_usize, |total, landmark| {
+                let pairs = landmark
+                    .cross
+                    .len()
+                    .checked_mul(landmark.cross.len())
+                    .ok_or_else(|| "cross-pair work overflows".to_owned())?;
+                total
+                    .checked_add(pairs)
+                    .ok_or_else(|| "cross-pair work overflows".to_owned())
+            })
+    }
+
+    fn check_caps(
+        pose_blocks: usize,
+        landmarks: usize,
+        observations: usize,
+        cross_pairs: usize,
+    ) -> Result<usize, String> {
+        if pose_blocks > MAX_VARIABLE_POSES {
+            return Err(format!("oracle variable-pose cap exceeded: {pose_blocks}"));
+        }
+        if landmarks > MAX_LANDMARKS {
+            return Err(format!("oracle landmark cap exceeded: {landmarks}"));
+        }
+        if observations > MAX_OBSERVATIONS {
+            return Err(format!("oracle observation cap exceeded: {observations}"));
+        }
+        if cross_pairs > MAX_CROSS_PAIR_WORK {
+            return Err(format!("oracle cross-pair cap exceeded: {cross_pairs}"));
+        }
+        let dimension = pose_blocks
+            .checked_mul(6)
+            .ok_or_else(|| "oracle Schur dimension overflows".to_owned())?;
+        if dimension > MAX_SCHUR_SCALARS {
+            return Err(format!("oracle Schur dimension cap exceeded: {dimension}"));
+        }
+        Ok(dimension)
+    }
+
+    fn build_oracle_system(
+        ba: &BundleAdjustment,
+    ) -> Result<(NormalEquationsBa, usize, usize, usize), String> {
+        if ba.observations.is_empty()
+            && ba.stereo_observations.is_empty()
+            && ba.general_stereo_observations.is_empty()
+            && ba.rig_observations.is_empty()
+        {
+            return Err("oracle requires visual observations".to_owned());
+        }
+        if ba.velocities.is_empty()
+            && ba.biases.is_empty()
+            && ba.imu_factors.is_empty()
+            && ba.bias_random_walk_factors.is_empty()
+            && ba.gravity_prior.is_none()
+            && ba.per_pose_gravity_prior.is_none()
+            && ba.position_prior.is_none()
+            && ba.pairwise_pose_factors.is_empty()
+            && ba.navigation_state_prior.is_none()
+        {
+            // Pure-visual eligibility is intentionally explicit.  The empty
+            // branch is only a guard; all actual work follows below.
+        } else {
+            return Err("oracle only accepts pure visual input".to_owned());
+        }
+        let se3_is_finite = |transform: &SE3| {
+            transform
+                .rotation
+                .quaternion()
+                .coords
+                .iter()
+                .all(|value| value.is_finite())
+                && transform.translation.iter().all(|value| value.is_finite())
+        };
+        if !ba
+            .poses
+            .values()
+            .all(|pose| se3_is_finite(&pose.world_to_camera))
+            || !ba
+                .landmarks
+                .values()
+                .all(|point| point.coords.iter().all(|v| v.is_finite()))
+        {
+            return Err("oracle input pose or landmark is non-finite".to_owned());
+        }
+        for observation in &ba.rig_observations {
+            if !matches!(
+                observation.camera.model,
+                CameraModel::Pinhole | CameraModel::SimplePinhole
+            ) {
+                return Err("oracle requires distortion-free pinhole cameras".to_owned());
+            }
+            if observation
+                .camera
+                .radial_distortion()
+                .is_some_and(|(k1, k2)| k1 != 0.0 || k2 != 0.0)
+            {
+                return Err("oracle rejects nonzero camera distortion".to_owned());
+            }
+            let Some(intrinsics) = observation.camera.intrinsics() else {
+                return Err("oracle camera has no pinhole intrinsics".to_owned());
+            };
+            if ![intrinsics.0, intrinsics.1, intrinsics.2, intrinsics.3]
+                .iter()
+                .all(|value| value.is_finite())
+            {
+                return Err("oracle camera intrinsics are non-finite".to_owned());
+            }
+            if !se3_is_finite(&observation.sensor_from_rig) {
+                return Err("oracle sensor extrinsic is non-finite".to_owned());
+            }
+        }
+        let intrinsics = ba
+            .camera
+            .intrinsics()
+            .ok_or_else(|| "oracle camera has no pinhole intrinsics".to_owned())?;
+        let (pose_index, landmark_index) = variable_indices(ba);
+        if pose_index.is_empty() {
+            return Err("oracle requires at least one variable pose".to_owned());
+        }
+        let mut system = build_normal_equations(
+            ba,
+            &intrinsics,
+            &pose_index,
+            &landmark_index,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &RobustKernel::None,
+            None,
+            false,
+            true,
+        );
+        constrain_fixed_pose_rotations(&ba.fixed_pose_rotations, &pose_index, &mut system);
+        let observations = observation_count(ba);
+        let pairs = cross_pair_work(&system)?;
+        check_caps(pose_index.len(), landmark_index.len(), observations, pairs)?;
+        Ok((system, pose_index.len(), landmark_index.len(), observations))
+    }
+
+    fn explicit_schur_rhs(
+        system: &NormalEquationsBa,
+        lambda: f64,
+    ) -> Result<(DMatrix<f64>, DVector<f64>, usize), String> {
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            return Err("oracle requires pose-diagonal system".to_owned());
+        };
+        let dimension = diagonal.len() * 6;
+        let mut schur = DMatrix::zeros(dimension, dimension);
+        for (pose, block) in diagonal.iter().enumerate() {
+            let mut damped = *block;
+            for component in 0..6 {
+                damped[(component, component)] += lambda;
+            }
+            schur
+                .fixed_view_mut::<6, 6>(pose * 6, pose * 6)
+                .copy_from(&damped);
+        }
+        let mut rhs = -&system.b_p;
+        let mut singular_landmarks = 0;
+        for landmark in &system.landmarks {
+            let mut h_ll = landmark.h_ll;
+            for component in 0..3 {
+                h_ll[(component, component)] += lambda;
+            }
+            let Some(inverse) = h_ll.try_inverse() else {
+                singular_landmarks += 1;
+                continue;
+            };
+            for (pose, cross) in &landmark.cross {
+                let update: Vector6<f64> = cross * inverse * landmark.b_l;
+                for component in 0..6 {
+                    rhs[pose * 6 + component] += update[component];
+                }
+                for (other_pose, other_cross) in &landmark.cross {
+                    let block: Matrix6<f64> = cross * inverse * other_cross.transpose();
+                    for row in 0..6 {
+                        for column in 0..6 {
+                            schur[(pose * 6 + row, other_pose * 6 + column)] -=
+                                block[(row, column)];
+                        }
+                    }
+                }
+            }
+        }
+        if !schur.iter().all(|value| value.is_finite())
+            || !rhs.iter().all(|value| value.is_finite())
+        {
+            return Err("oracle explicit Schur is non-finite".to_owned());
+        }
+        Ok((schur, rhs, singular_landmarks))
+    }
+
+    fn schur_asymmetry(matrix: &DMatrix<f64>) -> f64 {
+        let mut max_difference: f64 = 0.0;
+        for row in 0..matrix.nrows() {
+            for column in (row + 1)..matrix.ncols() {
+                max_difference =
+                    max_difference.max((matrix[(row, column)] - matrix[(column, row)]).abs());
+            }
+        }
+        max_difference
+    }
+
+    fn mirror_lower_triangle(matrix: &mut DMatrix<f64>) {
+        for row in 0..matrix.nrows() {
+            for column in (row + 1)..matrix.ncols() {
+                matrix[(row, column)] = matrix[(column, row)];
+            }
+        }
+    }
+
+    fn predicted_decrease(
+        system: &NormalEquationsBa,
+        lambda: f64,
+        delta_pose: &DVector<f64>,
+        delta_landmarks: &DVector<f64>,
+    ) -> Result<PredictedDecrease, String> {
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            return Err("predicted-decrease oracle requires pose blocks".to_owned());
+        };
+        if delta_pose.len() != diagonal.len() * 6
+            || delta_landmarks.len() != system.landmarks.len() * 3
+        {
+            return Err("predicted-decrease delta dimensions mismatch".to_owned());
+        }
+        let mut gradient_dot = system.b_p.dot(delta_pose);
+        let mut hessian_quadratic = 0.0;
+        let mut delta_squared = delta_pose.norm_squared();
+        for (pose, block) in diagonal.iter().enumerate() {
+            let delta: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+            hessian_quadratic += delta.dot(&(block * delta));
+        }
+        for (landmark_index, landmark) in system.landmarks.iter().enumerate() {
+            let delta: Vector3<f64> = delta_landmarks
+                .fixed_rows::<3>(landmark_index * 3)
+                .into_owned();
+            gradient_dot += landmark.b_l.dot(&delta);
+            hessian_quadratic += delta.dot(&(landmark.h_ll * delta));
+            delta_squared += delta.norm_squared();
+            for (pose, cross) in &landmark.cross {
+                let pose_delta: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+                hessian_quadratic += 2.0 * pose_delta.dot(&(cross * delta));
+            }
+        }
+        let damped_quadratic = hessian_quadratic + lambda * delta_squared;
+        let half_damped = -gradient_dot - 0.5 * damped_quadratic;
+        let squared_damped = -2.0 * gradient_dot - damped_quadratic;
+        let squared_undamped = -2.0 * gradient_dot - hessian_quadratic;
+        let values = [half_damped, squared_damped, squared_undamped];
+        if !values.iter().all(|value| value.is_finite()) {
+            return Err("predicted decrease is non-finite".to_owned());
+        }
+        Ok(PredictedDecrease {
+            half_damped,
+            squared_damped,
+            squared_undamped,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn feasibility(
+        ba: &BundleAdjustment,
+        system: &NormalEquationsBa,
+        lambda: f64,
+        schur: &DMatrix<f64>,
+        rhs: &DVector<f64>,
+        delta_pose: &DVector<f64>,
+        delta_landmarks: &DVector<f64>,
+        implicit_pose_true_residual: Option<f64>,
+    ) -> Feasibility {
+        let finite = delta_pose.iter().all(|value| value.is_finite())
+            && delta_landmarks.iter().all(|value| value.is_finite());
+        let pose_residual = rhs - schur * delta_pose;
+        let pose_true_residual = pose_residual.norm();
+        let mut max_landmark = 0.0_f64;
+        for (index, landmark) in system.landmarks.iter().enumerate() {
+            let delta_l: Vector3<f64> = delta_landmarks.fixed_rows::<3>(index * 3).into_owned();
+            let mut h_ll = landmark.h_ll;
+            for component in 0..3 {
+                h_ll[(component, component)] += lambda;
+            }
+            if h_ll.try_inverse().is_none() {
+                continue;
+            }
+            let mut residual = h_ll * delta_l + landmark.b_l;
+            for (pose, cross) in &landmark.cross {
+                let delta_p: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+                residual += cross.transpose() * delta_p;
+            }
+            max_landmark = max_landmark.max(residual.norm());
+        }
+        let (pose_index, landmark_index) = variable_indices(ba);
+        let mut geometry_cost = 0.0_f64;
+        let mut geometry_max_error = 0.0_f64;
+        let mut geometry_observation_count = 0_usize;
+        let mut geometry_invalid_observations = 0_usize;
+        let mut geometry_nonpositive_depth = 0_usize;
+        for observation in &ba.rig_observations {
+            let Some(pose) = ba.poses.get(&observation.keyframe_id) else {
+                geometry_invalid_observations += 1;
+                continue;
+            };
+            let Some(point) = ba.landmarks.get(&observation.landmark_id) else {
+                geometry_invalid_observations += 1;
+                continue;
+            };
+            let mut updated_pose = pose.world_to_camera.clone();
+            if let Some(&index) = pose_index.get(&observation.keyframe_id) {
+                let xi: Vector6<f64> = delta_pose.fixed_rows::<6>(index * 6).into_owned();
+                if xi.iter().all(|value| value.is_finite()) {
+                    updated_pose = updated_pose.compose(&SE3::exp(&xi));
+                } else {
+                    geometry_invalid_observations += 1;
+                    continue;
+                }
+            }
+            let mut updated_point = *point;
+            if let Some(&index) = landmark_index.get(&observation.landmark_id) {
+                let delta: Vector3<f64> = delta_landmarks.fixed_rows::<3>(index * 3).into_owned();
+                if delta.iter().all(|value| value.is_finite()) {
+                    updated_point = Point3::from(point.coords + delta);
+                } else {
+                    geometry_invalid_observations += 1;
+                    continue;
+                }
+            }
+            let point_camera = observation
+                .sensor_from_rig
+                .compose(&updated_pose)
+                .transform_point(&updated_point);
+            if !point_camera.z.is_finite() || point_camera.z <= 0.0 {
+                geometry_nonpositive_depth += 1;
+                geometry_invalid_observations += 1;
+                continue;
+            }
+            let Some(projected) = observation.camera.project(&point_camera) else {
+                geometry_invalid_observations += 1;
+                continue;
+            };
+            let residual = projected - observation.xy;
+            let squared = residual.norm_squared();
+            if !point_camera.coords.iter().all(|value| value.is_finite())
+                || !projected.coords.iter().all(|value| value.is_finite())
+                || !squared.is_finite()
+            {
+                geometry_invalid_observations += 1;
+                continue;
+            }
+            let error = squared.sqrt();
+            if !error.is_finite() {
+                geometry_invalid_observations += 1;
+                continue;
+            }
+            geometry_observation_count += 1;
+            geometry_cost += squared;
+            geometry_max_error = geometry_max_error.max(error);
+        }
+        let geometry_rms_error = if geometry_observation_count == 0 {
+            f64::NAN
+        } else {
+            (geometry_cost / geometry_observation_count as f64).sqrt()
+        };
+        let geometry_feasible = geometry_observation_count > 0
+            && geometry_invalid_observations == 0
+            && geometry_cost.is_finite()
+            && geometry_rms_error.is_finite()
+            && geometry_max_error.is_finite();
+        Feasibility {
+            finite,
+            pose_true_residual,
+            implicit_pose_true_residual,
+            max_landmark_backsub_residual: max_landmark,
+            geometry_observation_count,
+            geometry_invalid_observations,
+            geometry_nonpositive_depth,
+            geometry_cost,
+            geometry_rms_error,
+            geometry_max_error,
+            geometry_feasible,
+            feasible: finite
+                && pose_true_residual.is_finite()
+                && max_landmark.is_finite()
+                && geometry_feasible,
+        }
+    }
+
+    fn schur_action_scales(
+        system: &NormalEquationsBa,
+        lambda: f64,
+        x: &DVector<f64>,
+    ) -> Result<(f64, f64, f64), String> {
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            return Err("Schur scale oracle requires pose blocks".to_owned());
+        };
+        if x.len() != diagonal.len() * 6 {
+            return Err("Schur scale probe has the wrong dimension".to_owned());
+        }
+        let mut base = DVector::<f64>::zeros(x.len());
+        for (pose, block) in diagonal.iter().enumerate() {
+            let mut damped = *block;
+            for component in 0..6 {
+                damped[(component, component)] += lambda;
+            }
+            let value: Vector6<f64> = damped * x.fixed_rows::<6>(pose * 6).into_owned();
+            base.fixed_rows_mut::<6>(pose * 6).copy_from(&value);
+        }
+        let mut eliminated = DVector::<f64>::zeros(x.len());
+        for landmark in &system.landmarks {
+            let mut h_ll = landmark.h_ll;
+            for component in 0..3 {
+                h_ll[(component, component)] += lambda;
+            }
+            let Some(inverse) = h_ll.try_inverse() else {
+                continue;
+            };
+            let mut projected = Vector3::zeros();
+            for (pose, cross) in &landmark.cross {
+                let x_pose: Vector6<f64> = x.fixed_rows::<6>(pose * 6).into_owned();
+                projected += cross.transpose() * x_pose;
+            }
+            let reduced = inverse * projected;
+            for (pose, cross) in &landmark.cross {
+                let value: Vector6<f64> = cross * reduced;
+                for component in 0..6 {
+                    eliminated[pose * 6 + component] += value[component];
+                }
+            }
+        }
+        let base_norm = base.norm();
+        let eliminated_norm = eliminated.norm();
+        let arithmetic_scale = (base_norm + eliminated_norm).max(1.0);
+        if ![base_norm, eliminated_norm, arithmetic_scale]
+            .iter()
+            .all(|value| value.is_finite())
+        {
+            return Err("Schur arithmetic scale is non-finite".to_owned());
+        }
+        Ok((base_norm, eliminated_norm, arithmetic_scale))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn oracle_failure_reports(
+        lambda: f64,
+        pose_blocks: usize,
+        landmark_count: usize,
+        observation_count: usize,
+        dimension: usize,
+        singular_landmarks: usize,
+        raw_schur_asymmetry: Option<f64>,
+        schur_base_action_norm: Option<f64>,
+        schur_eliminated_action_norm: Option<f64>,
+        schur_arithmetic_scale: Option<f64>,
+        status: String,
+    ) -> Vec<OracleCaseReport> {
+        [128_usize, 512_usize]
+            .into_iter()
+            .map(|pcg_max_iterations| OracleCaseReport {
+                lambda,
+                pcg_max_iterations,
+                pose_blocks,
+                landmark_count,
+                observation_count,
+                schur_dimension: dimension,
+                singular_landmarks,
+                raw_schur_asymmetry,
+                schur_base_action_norm,
+                schur_eliminated_action_norm,
+                schur_arithmetic_scale,
+                operator_raw_action_error: None,
+                operator_raw_action_relative_error: None,
+                operator_lower_action_error: None,
+                operator_lower_action_relative_error: None,
+                operator_rhs_error: None,
+                direct_explicit_pose_error: None,
+                direct_explicit_landmark_error: None,
+                direct_feasibility: None,
+                explicit_feasibility: None,
+                direct_prediction: None,
+                explicit_prediction: None,
+                pcg_status: status.clone(),
+                pcg_iterations: None,
+                pcg_true_residual: None,
+                pcg_target: None,
+                matrix_free_pose_error: None,
+                matrix_free_landmark_error: None,
+                matrix_free_feasibility: None,
+                matrix_free_prediction: None,
+            })
+            .collect()
+    }
+
+    fn run_oracle(ba: &BundleAdjustment) -> Result<Vec<OracleCaseReport>, String> {
+        let (system, pose_blocks, landmark_count, observation_count) = build_oracle_system(ba)?;
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            return Err("oracle system did not retain pose blocks".to_owned());
+        };
+        let mut reports = Vec::new();
+        for lambda in [1.0e-4, 1.0e10] {
+            let (raw_schur, explicit_rhs, singular_landmarks) =
+                match explicit_schur_rhs(&system, lambda) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        reports.extend(oracle_failure_reports(
+                            lambda,
+                            pose_blocks,
+                            landmark_count,
+                            observation_count,
+                            pose_blocks * 6,
+                            0,
+                            None,
+                            None,
+                            None,
+                            None,
+                            format!("oracle_failure:explicit_schur:{error}"),
+                        ));
+                        continue;
+                    }
+                };
+            let raw_asymmetry = schur_asymmetry(&raw_schur);
+            let dimension = raw_schur.nrows();
+            let probe = DVector::from_iterator(
+                dimension,
+                (0..dimension)
+                    .map(|index| 0.001 * ((index % 17) as f64 - 8.0) + 0.00001 * index as f64),
+            );
+            let mut lower_schur = raw_schur.clone();
+            mirror_lower_triangle(&mut lower_schur);
+            let lower_action = &lower_schur * &probe;
+            let raw_action = &raw_schur * &probe;
+            let scale_metrics = schur_action_scales(&system, lambda, &probe).ok();
+            let schur_base_action_norm = scale_metrics.map(|metrics| metrics.0);
+            let schur_eliminated_action_norm = scale_metrics.map(|metrics| metrics.1);
+            let schur_arithmetic_scale = scale_metrics.map(|metrics| metrics.2);
+            let mut solve_failures = Vec::new();
+            let explicit_pose = match solve_normal_equations(&lower_schur, &explicit_rhs) {
+                Ok(solution) => Some(solution),
+                Err(error) => {
+                    solve_failures.push(format!("explicit_schur_factor:{error:?}"));
+                    None
+                }
+            };
+            let explicit_operator =
+                match implicit_schur::ImplicitSchurOperator::new(&system, lambda) {
+                    Ok(operator) => operator,
+                    Err(error) => {
+                        reports.extend(oracle_failure_reports(
+                            lambda,
+                            pose_blocks,
+                            landmark_count,
+                            observation_count,
+                            dimension,
+                            singular_landmarks,
+                            Some(raw_asymmetry),
+                            schur_base_action_norm,
+                            schur_eliminated_action_norm,
+                            schur_arithmetic_scale,
+                            format!("oracle_failure:implicit_operator:{error:?}"),
+                        ));
+                        continue;
+                    }
+                };
+            let operator_action = match explicit_operator.apply(&probe) {
+                Ok(action) => action,
+                Err(error) => {
+                    reports.extend(oracle_failure_reports(
+                        lambda,
+                        pose_blocks,
+                        landmark_count,
+                        observation_count,
+                        dimension,
+                        singular_landmarks,
+                        Some(raw_asymmetry),
+                        schur_base_action_norm,
+                        schur_eliminated_action_norm,
+                        schur_arithmetic_scale,
+                        format!("oracle_failure:implicit_apply:{error:?}"),
+                    ));
+                    continue;
+                }
+            };
+            let operator_rhs_error = (explicit_operator.rhs() - &explicit_rhs).norm();
+            let operator_raw_action_error = (&operator_action - &raw_action).norm();
+            let operator_lower_action_error = (&operator_action - &lower_action).norm();
+            let operator_raw_action_relative_error =
+                schur_arithmetic_scale.map(|scale| operator_raw_action_error / scale);
+            let operator_lower_action_relative_error =
+                schur_arithmetic_scale.map(|scale| operator_lower_action_error / scale);
+            let mut direct_cache = None;
+            let direct_solution = match solve_step_pose_blocks(
+                &system,
+                diagonal.clone(),
+                pose_blocks,
+                landmark_count,
+                lambda,
+                &mut direct_cache,
+            ) {
+                Ok(solution) => Some(solution),
+                Err(error) => {
+                    solve_failures.push(format!("direct_schur_factor:{error:?}"));
+                    None
+                }
+            };
+            let direct_pose = direct_solution.as_ref().map(|solution| &solution.0);
+            let direct_landmarks = direct_solution.as_ref().map(|solution| &solution.1);
+            let explicit_landmarks = explicit_pose
+                .as_ref()
+                .and_then(|pose| explicit_operator.complete_delta(pose).ok());
+            let direct_implicit_true_residual = direct_pose.and_then(|pose| {
+                explicit_operator
+                    .apply(pose)
+                    .ok()
+                    .map(|applied| (explicit_operator.rhs() - applied).norm())
+            });
+            let explicit_implicit_true_residual = explicit_pose.as_ref().and_then(|pose| {
+                explicit_operator
+                    .apply(pose)
+                    .ok()
+                    .map(|applied| (explicit_operator.rhs() - applied).norm())
+            });
+            let direct_feasibility = match (direct_pose, direct_landmarks) {
+                (Some(pose), Some(landmarks)) => Some(feasibility(
+                    ba,
+                    &system,
+                    lambda,
+                    &lower_schur,
+                    &explicit_rhs,
+                    pose,
+                    landmarks,
+                    direct_implicit_true_residual,
+                )),
+                _ => None,
+            };
+            let explicit_feasibility = match (explicit_pose.as_ref(), explicit_landmarks.as_ref()) {
+                (Some(pose), Some(landmarks)) => Some(feasibility(
+                    ba,
+                    &system,
+                    lambda,
+                    &lower_schur,
+                    &explicit_rhs,
+                    pose,
+                    landmarks,
+                    explicit_implicit_true_residual,
+                )),
+                _ => None,
+            };
+            let direct_prediction = match (direct_pose, direct_landmarks) {
+                (Some(pose), Some(landmarks)) => {
+                    predicted_decrease(&system, lambda, pose, landmarks).ok()
+                }
+                _ => None,
+            };
+            let explicit_prediction = match (explicit_pose.as_ref(), explicit_landmarks.as_ref()) {
+                (Some(pose), Some(landmarks)) => {
+                    predicted_decrease(&system, lambda, pose, landmarks).ok()
+                }
+                _ => None,
+            };
+            let direct_explicit_pose_error = match (direct_pose, explicit_pose.as_ref()) {
+                (Some(direct), Some(explicit)) => Some((direct - explicit).norm()),
+                _ => None,
+            };
+            let direct_explicit_landmark_error =
+                match (direct_landmarks, explicit_landmarks.as_ref()) {
+                    (Some(direct), Some(explicit)) => Some((direct - explicit).norm()),
+                    _ => None,
+                };
+            for pcg_max_iterations in [128_usize, 512_usize] {
+                let pcg_result = explicit_operator.solve_pcg(
+                    explicit_operator.rhs(),
+                    implicit_schur::PcgOptions {
+                        max_iterations: pcg_max_iterations,
+                        relative_tolerance: ORACLE_PC_TOLERANCE,
+                        absolute_tolerance: ORACLE_PC_TOLERANCE,
+                    },
+                );
+                let (
+                    pcg_status,
+                    pcg_iterations,
+                    pcg_true_residual,
+                    pcg_target,
+                    matrix_free_pose_error,
+                    matrix_free_landmark_error,
+                    matrix_free_feasibility,
+                    matrix_free_prediction,
+                ) = match pcg_result {
+                    Ok(result) => match explicit_operator.apply(&result.solution) {
+                        Err(error) => (
+                            format!("failure:recheck_true_residual:{error:?}"),
+                            Some(result.iterations),
+                            None,
+                            Some(result.target),
+                            None,
+                            None,
+                            None,
+                            None,
+                        ),
+                        Ok(applied) => {
+                            let true_residual = explicit_operator.rhs() - applied;
+                            match explicit_operator.complete_delta(&result.solution) {
+                                Err(error) => (
+                                    format!("failure:landmark_backsub:{error:?}"),
+                                    Some(result.iterations),
+                                    Some(true_residual.norm()),
+                                    Some(result.target),
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                ),
+                                Ok(matrix_free_landmarks) => {
+                                    let feasibility = feasibility(
+                                        ba,
+                                        &system,
+                                        lambda,
+                                        &lower_schur,
+                                        &explicit_rhs,
+                                        &result.solution,
+                                        &matrix_free_landmarks,
+                                        Some(true_residual.norm()),
+                                    );
+                                    match predicted_decrease(
+                                        &system,
+                                        lambda,
+                                        &result.solution,
+                                        &matrix_free_landmarks,
+                                    ) {
+                                        Err(error) => (
+                                            format!("failure:prediction:{error}"),
+                                            Some(result.iterations),
+                                            Some(true_residual.norm()),
+                                            Some(result.target),
+                                            explicit_pose
+                                                .as_ref()
+                                                .map(|pose| (&result.solution - pose).norm()),
+                                            explicit_landmarks.as_ref().map(|landmarks| {
+                                                (&matrix_free_landmarks - landmarks).norm()
+                                            }),
+                                            Some(feasibility),
+                                            None,
+                                        ),
+                                        Ok(prediction) => (
+                                            "success".to_owned(),
+                                            Some(result.iterations),
+                                            Some(true_residual.norm()),
+                                            Some(result.target),
+                                            explicit_pose
+                                                .as_ref()
+                                                .map(|pose| (&result.solution - pose).norm()),
+                                            explicit_landmarks.as_ref().map(|landmarks| {
+                                                (&matrix_free_landmarks - landmarks).norm()
+                                            }),
+                                            Some(feasibility),
+                                            Some(prediction),
+                                        ),
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Err(error) => {
+                        let (iterations, residual, target) = error.diagnostics();
+                        (
+                            format!("failure:{error:?}"),
+                            iterations,
+                            residual,
+                            target,
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                    }
+                };
+                let pcg_status = if solve_failures.is_empty() {
+                    pcg_status
+                } else {
+                    format!("{};pcg={}", solve_failures.join(","), pcg_status)
+                };
+                reports.push(OracleCaseReport {
+                    lambda,
+                    pcg_max_iterations,
+                    pose_blocks,
+                    landmark_count,
+                    observation_count,
+                    schur_dimension: dimension,
+                    singular_landmarks,
+                    raw_schur_asymmetry: Some(raw_asymmetry),
+                    schur_base_action_norm,
+                    schur_eliminated_action_norm,
+                    schur_arithmetic_scale,
+                    operator_raw_action_error: Some(operator_raw_action_error),
+                    operator_raw_action_relative_error,
+                    operator_lower_action_error: Some(operator_lower_action_error),
+                    operator_lower_action_relative_error,
+                    operator_rhs_error: Some(operator_rhs_error),
+                    direct_explicit_pose_error,
+                    direct_explicit_landmark_error,
+                    direct_feasibility: direct_feasibility.clone(),
+                    explicit_feasibility: explicit_feasibility.clone(),
+                    direct_prediction: direct_prediction.clone(),
+                    explicit_prediction: explicit_prediction.clone(),
+                    pcg_status,
+                    pcg_iterations,
+                    pcg_true_residual,
+                    pcg_target,
+                    matrix_free_pose_error,
+                    matrix_free_landmark_error,
+                    matrix_free_feasibility,
+                    matrix_free_prediction,
+                });
+            }
+        }
+        Ok(reports)
+    }
+
+    fn synthetic_rig_problem() -> BundleAdjustment {
+        let camera = Camera::pinhole(1, 640, 480, 420.0, 418.0, 320.0, 240.0);
+        let sensor_one = SE3::new(
+            nalgebra::UnitQuaternion::from_euler_angles(0.01, -0.02, 0.03),
+            Vector3::new(0.2, -0.01, 0.02),
+        );
+        let truth_poses = [
+            Pose::identity(),
+            Pose::from_world_to_camera(
+                nalgebra::UnitQuaternion::from_euler_angles(0.01, -0.015, 0.02),
+                Vector3::new(-0.18, 0.01, 0.03),
+            ),
+        ];
+        let mut ba = BundleAdjustment::new(camera.clone());
+        ba.add_pose(0, truth_poses[0].clone());
+        ba.add_pose(
+            1,
+            Pose::from_world_to_camera(
+                nalgebra::UnitQuaternion::from_euler_angles(0.013, -0.012, 0.018),
+                Vector3::new(-0.20, 0.02, 0.04),
+            ),
+        );
+        ba.fix_pose(0);
+        for id in 0..8_u64 {
+            let truth = Point3::new(
+                -0.8 + 0.23 * id as f64,
+                -0.4 + 0.11 * (id % 4) as f64,
+                4.0 + 0.3 * id as f64,
+            );
+            ba.add_landmark(
+                id,
+                Point3::from(truth.coords + Vector3::new(0.004, -0.003, 0.006)),
+            );
+            for (frame_id, pose) in truth_poses.iter().enumerate() {
+                for sensor_from_rig in [SE3::identity(), sensor_one.clone()] {
+                    let sensor_pose = sensor_from_rig.compose(&pose.world_to_camera);
+                    let xy = camera
+                        .project(&sensor_pose.transform_point(&truth))
+                        .expect("synthetic rig point must project");
+                    ba.add_rig_observation(BaRigObservation {
+                        keyframe_id: frame_id as u64,
+                        landmark_id: id,
+                        xy,
+                        camera: camera.clone(),
+                        sensor_from_rig,
+                    });
+                }
+            }
+        }
+        ba
+    }
+
+    #[test]
+    fn synthetic_oracle_compares_both_damping_values_and_coefficients() {
+        let reports = run_oracle(&synthetic_rig_problem()).unwrap();
+        assert_eq!(reports.len(), 4);
+        for report in reports {
+            assert!(report.raw_schur_asymmetry.unwrap().is_finite());
+            assert!(report.operator_rhs_error.unwrap() < 1.0e-8);
+            assert!(report.operator_raw_action_relative_error.unwrap() < 1.0e-8);
+            assert!(
+                report.operator_lower_action_error.unwrap().is_finite(),
+                "lower-mirrored operator comparison must remain finite: {report:?}"
+            );
+            assert!(report.direct_explicit_pose_error.unwrap() < 1.0e-7);
+            assert!(report.direct_explicit_landmark_error.unwrap() < 1.0e-7);
+            let direct_feasibility = report
+                .direct_feasibility
+                .as_ref()
+                .expect("synthetic direct arm should succeed");
+            let explicit_feasibility = report
+                .explicit_feasibility
+                .as_ref()
+                .expect("synthetic explicit arm should succeed");
+            assert!(direct_feasibility.feasible);
+            assert!(explicit_feasibility.feasible);
+            assert!(direct_feasibility.geometry_feasible);
+            assert!(explicit_feasibility.geometry_feasible);
+            assert_eq!(direct_feasibility.geometry_invalid_observations, 0);
+            assert_eq!(explicit_feasibility.geometry_invalid_observations, 0);
+            assert!(direct_feasibility
+                .implicit_pose_true_residual
+                .is_some_and(f64::is_finite));
+            assert!(explicit_feasibility
+                .implicit_pose_true_residual
+                .is_some_and(f64::is_finite));
+            let direct_prediction = report
+                .direct_prediction
+                .as_ref()
+                .expect("synthetic direct prediction should succeed");
+            let explicit_prediction = report
+                .explicit_prediction
+                .as_ref()
+                .expect("synthetic explicit prediction should succeed");
+            assert!(
+                (direct_prediction.squared_damped - 2.0 * direct_prediction.half_damped).abs()
+                    < 1.0e-9
+            );
+            assert!(
+                (explicit_prediction.squared_damped - 2.0 * explicit_prediction.half_damped).abs()
+                    < 1.0e-9
+            );
+            if let Some(prediction) = report.matrix_free_prediction {
+                assert!((prediction.squared_damped - 2.0 * prediction.half_damped).abs() < 1.0e-9);
+            }
+        }
+    }
+
+    #[test]
+    fn predicted_decrease_matches_independent_squared_cost_fixture() {
+        let mut cross = Matrix6x3::zeros();
+        for index in 0..3 {
+            cross[(index, index)] = 0.5;
+        }
+        let mut h_pp = Matrix6::identity();
+        h_pp *= 2.0;
+        let mut h_ll = Matrix3::identity();
+        h_ll *= 3.0;
+        let system = NormalEquationsBa {
+            h_pp: CameraHessian::PoseDiagonal(vec![h_pp]),
+            b_p: DVector::from_element(6, 1.0),
+            landmarks: vec![LandmarkBlock {
+                h_ll,
+                b_l: Vector3::from_element(2.0),
+                cross: vec![(0, cross)],
+            }],
+        };
+        let delta_pose = DVector::from_element(6, 0.1);
+        let delta_landmark = DVector::from_element(3, -0.2);
+        let prediction = predicted_decrease(&system, 0.5, &delta_pose, &delta_landmark).unwrap();
+        assert!((prediction.squared_undamped - 0.78).abs() < 1.0e-12);
+        assert!((prediction.half_damped - 0.345).abs() < 1.0e-12);
+        assert!((prediction.squared_damped - 0.69).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn fixture_quaternion_reader_preserves_serialized_bits() {
+        let values = [
+            0.9238795325112867_f64,
+            0.0_f64,
+            0.3826834323650898_f64,
+            0.0_f64,
+            0.125_f64,
+            -0.25_f64,
+            0.5_f64,
+        ];
+        let serialized = values
+            .iter()
+            .map(|value| format!("{value:.17e}"))
+            .collect::<Vec<_>>();
+        let fields = serialized.iter().map(String::as_str).collect::<Vec<_>>();
+        let parsed = parse_se3(&fields, 0, "bit-roundtrip").unwrap();
+        let quaternion = parsed.rotation.quaternion();
+        assert_eq!(quaternion.w.to_bits(), values[0].to_bits());
+        assert_eq!(quaternion.i.to_bits(), values[1].to_bits());
+        assert_eq!(quaternion.j.to_bits(), values[2].to_bits());
+        assert_eq!(quaternion.k.to_bits(), values[3].to_bits());
+        assert_eq!(parsed.translation.x.to_bits(), values[4].to_bits());
+        assert_eq!(parsed.translation.y.to_bits(), values[5].to_bits());
+        assert_eq!(parsed.translation.z.to_bits(), values[6].to_bits());
+
+        let near_unit = [
+            1.0 + f64::EPSILON,
+            -0.0_f64,
+            0.0_f64,
+            0.0_f64,
+            0.0_f64,
+            0.0_f64,
+            0.0_f64,
+        ];
+        let serialized = near_unit
+            .iter()
+            .map(|value| format!("{value:.17e}"))
+            .collect::<Vec<_>>();
+        let fields = serialized.iter().map(String::as_str).collect::<Vec<_>>();
+        let parsed = parse_se3(&fields, 0, "near-unit-bit-roundtrip").unwrap();
+        let quaternion = parsed.rotation.quaternion();
+        assert_eq!(quaternion.w.to_bits(), near_unit[0].to_bits());
+        assert_eq!(quaternion.i.to_bits(), near_unit[1].to_bits());
+    }
+
+    #[test]
+    fn fixture_reader_rejects_bad_order_and_oversized_header() {
+        let base =
+            std::env::temp_dir().join(format!("visloc-ba-oracle-parser-{}", std::process::id()));
+        let _ = std::fs::remove_file(&base);
+        std::fs::write(&base, "END\n").unwrap();
+        let error = parse_fixture(&base).unwrap_err();
+        assert!(error.contains("header must be the first record"));
+        std::fs::write(&base, "VISLOC_BA_ORACLE_FIXTURE 1\nPOSE_COUNT 514\nEND\n").unwrap();
+        let error = parse_fixture(&base).unwrap_err();
+        assert!(error.contains("exceeds cap"));
+        std::fs::write(&base, "VISLOC_BA_ORACLE_FIXTURE 1\nEND\nPOSE_COUNT 1\n").unwrap();
+        let error = parse_fixture(&base).unwrap_err();
+        assert!(error.contains("records after END"));
+        let _ = std::fs::remove_file(base);
+    }
+
+    #[test]
+    fn fixture_reader_roundtrips_initial_cost_bits() {
+        let path = std::env::temp_dir().join(format!(
+            "visloc-ba-oracle-valid-parser-{}",
+            std::process::id()
+        ));
+        let hash = "0".repeat(64);
+        let fixture = format!(
+            "VISLOC_BA_ORACLE_FIXTURE 1\nSOURCE_SHA256 {hash}\nSOURCE_SHA256_CAMERAS {hash}\nSOURCE_SHA256_IMAGES {hash}\nSOURCE_SHA256_POINTS {hash}\nSOURCE_SHA256_MANIFEST {hash}\nINITIAL_COST 0.00000000000000000e+00\nINITIAL_COST_BITS 0\nCAMERA_COUNT 1\nPOSE_COUNT 1\nLANDMARK_COUNT 1\nOBSERVATION_COUNT 1\nCAMERA 1 PINHOLE 10 10 4 2 2 0 0\nPOSE 0 1 0 0 0 0 0 0\nFIXED_POSE 0\nLANDMARK 0 0 0 2\nRIG_OBSERVATION 0 0 0 0 1 1 0 0 0 0 0 0\nEND\n"
+        );
+        std::fs::write(&path, fixture).unwrap();
+        let parsed = parse_fixture(&path).unwrap();
+        assert_eq!(parsed.initial_cost.to_bits(), 0);
+        assert_eq!(parsed.initial_cost_bits, 0);
+        assert_eq!(parsed.ba.cost().to_bits(), 0);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn oracle_caps_reject_before_dense_dimension_allocation() {
+        assert!(check_caps(512, 8_192, 262_144, MAX_CROSS_PAIR_WORK).is_ok());
+        assert!(check_caps(513, 1, 1, 1).is_err());
+        assert!(check_caps(1, 8_193, 1, 1).is_err());
+        assert!(check_caps(1, 1, 262_145, 1).is_err());
+        assert!(check_caps(1, 1, 1, MAX_CROSS_PAIR_WORK + 1).is_err());
+        assert!(check_caps(513, 1, 1, 1).is_err());
+    }
+
+    #[test]
+    #[ignore = "requires an explicitly exported frozen 1k fixture and source hash"]
+    fn ignored_real_fixture_runs_bounded_damping_oracle() {
+        let path = env::var_os("VISLOC_MATRIX_FREE_ORACLE_FIXTURE")
+            .expect("VISLOC_MATRIX_FREE_ORACLE_FIXTURE is required; fixture absence is failure");
+        let fixture = parse_fixture(Path::new(&path)).unwrap();
+        let expected_hash = env::var("VISLOC_MATRIX_FREE_ORACLE_EXPECTED_SOURCE_SHA256")
+            .expect("VISLOC_MATRIX_FREE_ORACLE_EXPECTED_SOURCE_SHA256 is required");
+        assert_eq!(
+            fixture.source_hashes["SOURCE_SHA256"], expected_hash,
+            "fixture source hash does not match the requested frozen input"
+        );
+        let reports = run_oracle(&fixture.ba).unwrap();
+        assert_eq!(reports.len(), 4);
+        println!(
+            "matrix_free_oracle_input_cost={:.17e} bits={}",
+            fixture.initial_cost, fixture.initial_cost_bits
+        );
+        for report in reports {
+            println!("matrix_free_oracle {report:?}");
+        }
+    }
+}
+
+#[cfg(test)]
 mod visual_jacobian_audit_tests {
     use super::*;
     use nalgebra::UnitQuaternion;


### PR DESCRIPTION
## Summary

- Add a standalone no-clobber streamed fixture exporter and bounded private test-only real normal-system oracle. No production solver, public API, default policy, observation filtering or tolerance changes.
- Measure the identical frozen 1k initial normal system at damping 1e-4 and 1e10 with direct/explicit/implicit actions, true residuals, predictions and geometry checks.
- Record two numerically identical serial release runs and byte-identical existing direct/MF CLI regression outputs against PR #79.

## Findings and limits

At low damping, direct and explicit lower-Schur solutions agree but the direct step itself fails the implicit residual target; PCG 128/512 fail and trial steps have 880 invalid-depth observations. At high damping, both PCG caps converge in 22 iterations and agree with direct. Unreduced action-scale ratios are not final-action relative errors. Partial valid-only geometry cost is not a full-objective improvement. No COLMAP performance claim or 10k promotion.

Next diagnostic: explicit lower-Schur PCG versus implicit PCG using identical block-Jacobi preconditioning and stopping rules, before selecting numerical scaling or preconditioner changes.

## Validation

- Library oracle: 6 passed, 1 explicit real-input test ignored by default; real test ran twice, exactly one test passed per run.
- Example: 12 passed; Python: 46 passed.
- Library/example clippy with warnings denied; cargo fmt; doc links; 189 registry JSON records; generated docs; diff check.
- Release exporter and library test binaries built. Full numerical evidence, artifact hashes and replay instructions committed.
- Final-head CI run 34122318818: all eight checks passed on b294bab62f5d558c7d244984e1f7d652149cccb9.
- Luna Max independently reviewed the committed numerical evidence: no blockers.
- Re-exporting the fixture to another output filename also produced identical bytes.
- Squash merged as 2b4ef997f105063588fd68c5c8a2e08ece6112e1 at 2026-09-07T12:36:21Z; local and remote topic branches removed, main clean.