### PR TITLE
test(sfm): isolate Schur representation effects with matched PCG

### DIFF
--- a/benchmarks/electro/m8-openloris-explicit-pcg-isolation-v1.json
+++ b/benchmarks/electro/m8-openloris-explicit-pcg-isolation-v1.json
@@ -1,0 +1,283 @@
+{
+  "schema_version": 1,
+  "experiment": "m8-openloris-explicit-pcg-isolation-v1",
+  "date": "2026-09-07",
+  "status": "diagnostic_complete_no_quality_or_speed_promotion",
+  "implementation_commit": "cb14bdce460fbbf39bb28a794aeffe82bab4e951",
+  "source_sha256": {
+    "pipelines/slam/src/bundle.rs": "4c79baf15880d26c10844bcca8bf8b774b7b0ad1a84bbf9a0760191d6396290f"
+  },
+  "binary": {
+    "path": "target/release/deps/visloc_slam-033870405c01cac5",
+    "sha256": "702181caa906e813a69869706d229b5029c2e0ebc3b6af00da0f9f7ebcc0cd61",
+    "build_command": "cargo test --release -p visloc-slam --lib matrix_free_real_oracle_tests --no-run",
+    "rustc": "1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-explicit-pcg-isolation-v1",
+  "input": {
+    "baseline_evidence": "m8-openloris-real-normal-system-oracle-v1.json",
+    "fixture": "/home/sasaki/datasets/openloris/corridor1-1-m8-real-normal-system-oracle-v1/input.fixture",
+    "fixture_sha256": "a71ef3401ea6d75a06f18ded0d475ad48fd929202a64fecaeaa790ee964da1ea",
+    "combined_source_sha256": "ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829",
+    "initial_cost": 126510.39875730938,
+    "initial_cost_bits": "4683430141614839853",
+    "poses": 500,
+    "variable_poses": 499,
+    "landmarks": 4716,
+    "observations": 130900,
+    "scalar_dimension": 2994,
+    "fixed_pose": 0,
+    "observations_removed": 0,
+    "ground_truth_used": false
+  },
+  "execution": {
+    "rayon_num_threads": 1,
+    "ignored_test": "bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle",
+    "arguments": [
+      "--exact",
+      "--ignored",
+      "--nocapture"
+    ],
+    "relative_tolerance": 1e-12,
+    "absolute_tolerance": 1e-12,
+    "zero_initial_iterate": true,
+    "matched_preconditioner": "Both arms call the same ImplicitSchurOperator::apply_preconditioner on the same operator instance.",
+    "normal_assembly": "The legacy four-case oracle and new six-case isolation each assemble their own initial normal system sequentially. All six isolation cases share one normal system; the implicit/explicit pair shares RHS and preconditioner. No simultaneous full BA clone.",
+    "storage": "Same bounded caps as PR80. Each isolation damping materializes raw Schur once, then mirrors its lower triangle in place; explicit matvec borrows it. Dense solve may allocate its factorization. Production remains matrix-free.",
+    "failed_iterate_policy": "No failed iterate retained or applied; failure delta, geometry and cross-operator residual fields are null rather than fabricated.",
+    "recurrence_validation": "Synthetic success and failure cases compare callback-PCG results exactly with production implicit PCG. Real isolation implicit arm directly calls production PCG.",
+    "both_runs_exactly_one_test_passed": true,
+    "production_solver_and_api_unchanged": true
+  },
+  "practical_damping_control": {
+    "lambda": 100000,
+    "reason": "PR79 direct serial runs both reject LM0..8 and first accept LM9 at solve lambda=1e5. Initial model is therefore unchanged.",
+    "direct_trial_cost": 118084.4047208355,
+    "implicit_128_and_512_failure_diagnostics_match_pr79_lm9": true
+  },
+  "reports": [
+    {
+      "lambda": 0.0001,
+      "pcg_max_iterations": 128,
+      "status": "failure:MaxIterations { iterations: 128, recursive_norm: 5614.685150147594, residual_norm: 5614.685150144676, target: 7.354716589947665e-7 }",
+      "iterations": 128,
+      "recursive_residual": 5614.685150147594,
+      "lower_true_residual": 5614.685150144676,
+      "implicit_true_residual": null,
+      "target": 7.354716589947665e-7,
+      "dense_lower_true_residual": 0.000004919094885193126,
+      "dense_implicit_true_residual": 0.016225321613743043,
+      "pose_error_vs_dense": null,
+      "landmark_error_vs_dense": null,
+      "implicit_pcg_status": "failure:MaxIterations { iterations: 128, recursive_norm: 41263.72612053205, residual_norm: 41263.7264460946, target: 7.354716589947665e-7 }",
+      "implicit_pcg_iterations": 128,
+      "implicit_pcg_true_residual": 41263.7264460946,
+      "implicit_pcg_target": 7.354716589947665e-7,
+      "explicit_vs_implicit_pose_error": null,
+      "explicit_vs_implicit_landmark_error": null,
+      "feasibility": null,
+      "prediction": null
+    },
+    {
+      "lambda": 0.0001,
+      "pcg_max_iterations": 512,
+      "status": "failure:MaxIterations { iterations: 512, recursive_norm: 0.03551121035436136, residual_norm: 0.0355110880209856, target: 7.354716589947665e-7 }",
+      "iterations": 512,
+      "recursive_residual": 0.03551121035436136,
+      "lower_true_residual": 0.0355110880209856,
+      "implicit_true_residual": null,
+      "target": 7.354716589947665e-7,
+      "dense_lower_true_residual": 0.000004919094885193126,
+      "dense_implicit_true_residual": 0.016225321613743043,
+      "pose_error_vs_dense": null,
+      "landmark_error_vs_dense": null,
+      "implicit_pcg_status": "failure:MaxIterations { iterations: 512, recursive_norm: 318.34634181495545, residual_norm: 318.3459481943091, target: 7.354716589947665e-7 }",
+      "implicit_pcg_iterations": 512,
+      "implicit_pcg_true_residual": 318.3459481943091,
+      "implicit_pcg_target": 7.354716589947665e-7,
+      "explicit_vs_implicit_pose_error": null,
+      "explicit_vs_implicit_landmark_error": null,
+      "feasibility": null,
+      "prediction": null
+    },
+    {
+      "lambda": 100000,
+      "pcg_max_iterations": 128,
+      "status": "failure:MaxIterations { iterations: 128, recursive_norm: 1411.6841560913065, residual_norm: 1411.6841560871692, target: 7.363379620295508e-7 }",
+      "iterations": 128,
+      "recursive_residual": 1411.6841560913065,
+      "lower_true_residual": 1411.6841560871692,
+      "implicit_true_residual": null,
+      "target": 7.363379620295508e-7,
+      "dense_lower_true_residual": 0.000002143103419796261,
+      "dense_implicit_true_residual": 0.002572261272662248,
+      "pose_error_vs_dense": null,
+      "landmark_error_vs_dense": null,
+      "implicit_pcg_status": "failure:MaxIterations { iterations: 128, recursive_norm: 1673.762060680569, residual_norm: 1673.7620609788628, target: 7.363379620295508e-7 }",
+      "implicit_pcg_iterations": 128,
+      "implicit_pcg_true_residual": 1673.7620609788628,
+      "implicit_pcg_target": 7.363379620295508e-7,
+      "explicit_vs_implicit_pose_error": null,
+      "explicit_vs_implicit_landmark_error": null,
+      "feasibility": null,
+      "prediction": null
+    },
+    {
+      "lambda": 100000,
+      "pcg_max_iterations": 512,
+      "status": "failure:ResidualCheckFailed { iterations: 316, recursive_norm: 7.537022014962387e-8, true_norm: 8.94701210815861e-7, target: 7.363379620295508e-7 }",
+      "iterations": 316,
+      "recursive_residual": 7.537022014962387e-8,
+      "lower_true_residual": 8.94701210815861e-7,
+      "implicit_true_residual": null,
+      "target": 7.363379620295508e-7,
+      "dense_lower_true_residual": 0.000002143103419796261,
+      "dense_implicit_true_residual": 0.002572261272662248,
+      "pose_error_vs_dense": null,
+      "landmark_error_vs_dense": null,
+      "implicit_pcg_status": "failure:MaxIterations { iterations: 512, recursive_norm: 4.633822922386621e-6, residual_norm: 0.000907864069961008, target: 7.363379620295508e-7 }",
+      "implicit_pcg_iterations": 512,
+      "implicit_pcg_true_residual": 0.000907864069961008,
+      "implicit_pcg_target": 7.363379620295508e-7,
+      "explicit_vs_implicit_pose_error": null,
+      "explicit_vs_implicit_landmark_error": null,
+      "feasibility": null,
+      "prediction": null
+    },
+    {
+      "lambda": 10000000000,
+      "pcg_max_iterations": 128,
+      "status": "success_lower_pcg",
+      "iterations": 23,
+      "recursive_residual": null,
+      "lower_true_residual": 3.335572318726032e-8,
+      "implicit_true_residual": 1.2746686061017883e-7,
+      "target": 7.377914999757461e-7,
+      "dense_lower_true_residual": 6.4945806084734065e-9,
+      "dense_implicit_true_residual": 1.28800155078187e-7,
+      "pose_error_vs_dense": 6.62946019847548e-19,
+      "landmark_error_vs_dense": 2.0556738867015618e-19,
+      "implicit_pcg_status": "success",
+      "implicit_pcg_iterations": 22,
+      "implicit_pcg_true_residual": 5.639331821966476e-7,
+      "implicit_pcg_target": 7.377914999757461e-7,
+      "explicit_vs_implicit_pose_error": 2.088742323214711e-17,
+      "explicit_vs_implicit_landmark_error": 9.918305796957192e-18,
+      "feasibility": {
+        "finite": true,
+        "pose_true_residual": 3.335572318726032e-8,
+        "implicit_pose_true_residual": 1.2746686061017883e-7,
+        "max_landmark_backsub_residual": 5.474058784210968e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "prediction": {
+        "half_damped": 8.783279833568201,
+        "squared_damped": 17.566559667136403,
+        "squared_undamped": 32.970815975305435
+      }
+    },
+    {
+      "lambda": 10000000000,
+      "pcg_max_iterations": 512,
+      "status": "success_lower_pcg",
+      "iterations": 23,
+      "recursive_residual": null,
+      "lower_true_residual": 3.335572318726032e-8,
+      "implicit_true_residual": 1.2746686061017883e-7,
+      "target": 7.377914999757461e-7,
+      "dense_lower_true_residual": 6.4945806084734065e-9,
+      "dense_implicit_true_residual": 1.28800155078187e-7,
+      "pose_error_vs_dense": 6.62946019847548e-19,
+      "landmark_error_vs_dense": 2.0556738867015618e-19,
+      "implicit_pcg_status": "success",
+      "implicit_pcg_iterations": 22,
+      "implicit_pcg_true_residual": 5.639331821966476e-7,
+      "implicit_pcg_target": 7.377914999757461e-7,
+      "explicit_vs_implicit_pose_error": 2.088742323214711e-17,
+      "explicit_vs_implicit_landmark_error": 9.918305796957192e-18,
+      "feasibility": {
+        "finite": true,
+        "pose_true_residual": 3.335572318726032e-8,
+        "implicit_pose_true_residual": 1.2746686061017883e-7,
+        "max_landmark_backsub_residual": 5.474058784210968e-7,
+        "geometry_observation_count": 130900,
+        "geometry_invalid_observations": 0,
+        "geometry_nonpositive_depth": 0,
+        "geometry_cost": 126477.42813448103,
+        "geometry_rms_error": 0.9829619111005349,
+        "geometry_max_error": 3.9989838349986138,
+        "geometry_feasible": true,
+        "feasible": true
+      },
+      "prediction": {
+        "half_damped": 8.783279833568201,
+        "squared_damped": 17.566559667136403,
+        "squared_undamped": 32.970815975305435
+      }
+    }
+  ],
+  "repeats": {
+    "all_eleven_numerical_lines_identical": true,
+    "old_initial_cost_and_four_reports_match_pr80_exactly": true,
+    "wall_seconds": [
+      45.02,
+      44.77
+    ],
+    "peak_rss_kib": [
+      346196,
+      346148
+    ],
+    "scope": "Whole combined diagnostic process, not separate solver timings or production memory measurement. Warm shared host; unrelated cc1plus was observed during first run. No own concurrent builds.",
+    "files": {
+      "isolation-1.log": {
+        "sha256": "a0ea442e92a68f8ea639a5e6cddf02345d9cc6e1d7034d4660c846103f8d23bf",
+        "bytes": 17895,
+        "text": null
+      },
+      "isolation-1.time": {
+        "sha256": "72d787198c88226f8e406fe2fec1b7c346ce9ac5bebf86fdad7eb7c572779e6d",
+        "bytes": 888,
+        "text": "\tCommand being timed: \"target/release/deps/visloc_slam-033870405c01cac5 bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle --exact --ignored --nocapture\"\n\tUser time (seconds): 44.53\n\tSystem time (seconds): 0.47\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:45.02\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 346196\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 246404\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 248\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 48\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+      },
+      "isolation-2.log": {
+        "sha256": "d4ac1a082145913be32c38aa2f3994750d393e9c376b60fc043d8352a5cf09c7",
+        "bytes": 17895,
+        "text": null
+      },
+      "isolation-2.time": {
+        "sha256": "e69e718365edc3143daa489e4faf9913037f1b07656fa6dcf049b802bf2255d7",
+        "bytes": 888,
+        "text": "\tCommand being timed: \"target/release/deps/visloc_slam-033870405c01cac5 bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle --exact --ignored --nocapture\"\n\tUser time (seconds): 44.36\n\tSystem time (seconds): 0.40\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:44.77\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 346148\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 246405\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 143\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 48\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+      }
+    }
+  },
+  "interpretation": [
+    "At low damping both PCGs fail, but the explicit lower representation progresses much further by 512 iterations. Failure of both does not isolate preconditioning as the sole cause.",
+    "At practical lambda=1e5 the explicit PCG recursively crosses target at iteration316 but fails true-residual recheck (8.947e-7 versus7.363e-7). The implicit arm remains at9.079e-4 after512.",
+    "At lambda=1e5 dense reference residual is2.143e-6 in lower representation and0.002572 in implicit representation. Neither proves attainment of the fixed true-residual target; this does not mathematically prove that target is unattainable.",
+    "At high damping explicit and implicit PCG succeed at23 and22 iterations, agree closely and preserve valid trial geometry.",
+    "Same preconditioner and recurrence do not eliminate representation/roundoff effects. Residuals from different finite-precision actions are not interchangeable.",
+    "No low/intermediate-damping explicit trial geometry is available because failed iterates are intentionally discarded; no full-objective quality claim is made.",
+    "The fixed1e-12 rule is a baseline diagnostic contract, not the user goal itself. A separately labeled stability or inexact-policy arm can be evaluated without rewriting this baseline; quality and resource gates still apply."
+  ],
+  "validation": {
+  "root_library_oracle_tests_passed": 7,
+  "ignored_real_input_test": 1,
+  "root_example_tests_passed": 12,
+  "root_python_tests_passed": 46,
+  "root_library_clippy_warnings_denied": true,
+  "root_cargo_fmt_check": true,
+  "docs_links": true,
+  "registry_json_files_validated": 189,
+  "generated_benchmark_docs_current": true,
+  "fixture_sha256_rechecked_after_runs": true
+},
+  "next_gate": "Test-only A/B: general inverse versus symmetry-audited Cholesky construction of the damped 3x3 landmark blocks, used consistently in implicit action, explicit reference and preconditioner. Preserve physical damping and observations; measure before selecting a nonlinear production arm."
+}

--- a/benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json
+++ b/benchmarks/electro/m8-openloris-real-normal-system-oracle-v1.json
@@ -463,7 +463,7 @@
   "raw_schur_asymmetry": "Maximum absolute off-diagonal element difference |S_ij-S_ji|; not a Frobenius or spectral norm.",
   "delta_errors": "Euclidean norms over concatenated deltas; pose combines rotation and translation coordinates, not a metre-only physical pose error.",
   "geometry_rms_error": "sqrt(sum(valid observation squared pixel residual)/valid observation count); not arithmetic mean reprojection error.",
-  "action_relative_errors": "Absolute action difference norm divided by sum of base-action norm and per-landmark eliminated-action norms, not by final Schur-action norm.",
+  "action_relative_errors": "Absolute action difference norm divided by max(1, norm(base action) + norm(accumulated eliminated action)), not by final Schur-action norm and not by a sum of per-landmark norms.",
   "pcg_true_residual": "Euclidean norm of rhs minus implicit action; lower-Schur residual separately reported.",
   "initial_cost_bits": "Decimal u64 string to avoid JSON consumer integer rounding."
 }

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -104,6 +104,12 @@
 > 蓄積誤差と収束性を切り分けます。閾値変更・10k昇格はまだ行いません。
 > PR #80は最終CI8項目（run 34122318818）通過後、`2b4ef99`へmergeし旧branch整理済み。
 > 現在は `feat/m8-explicit-pcg-isolation` で同前処理のPCG切り分けを進めています。
+> 切り分けは `cb14bdc` に実装・1k実測済み、2回の全数値一致を確認。
+> [実測記録](../benchmarks/electro/m8-openloris-explicit-pcg-isolation-v1.json)。
+> λ1e5でexplicit PCGは316反復の真残差再確認に失敗（8.947e-7 > 7.363e-7）、
+> implicit512は9.079e-4。dense参照解も同基準未達で、前処理だけが原因とは断定できません。
+> 次は物理座標・dampingを変えず、3x3 landmarkブロックのCholesky構成を別armで比較。
+> 現1e-12は診断baselineで、ユーザーの最終目的は精度・速度・省メモリです。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -102,6 +102,8 @@
 > 既存direct/MF CLIのモデル3ファイル・数値traceはPR #79と一致。
 > 次は同じpreconditionerでexplicit lower-Schur PCGとimplicit PCGを比べ、
 > 蓄積誤差と収束性を切り分けます。閾値変更・10k昇格はまだ行いません。
+> PR #80は最終CI8項目（run 34122318818）通過後、`2b4ef99`へmergeし旧branch整理済み。
+> 現在は `feat/m8-explicit-pcg-isolation` で同前処理のPCG切り分けを進めています。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -867,7 +867,7 @@ identity and coordinates, point coordinates and initial-cost bits
 `4683430141614839853` (126,510.39875730938). No observation was removed.
 The same initial normal system has 499 free pose blocks / scalar dimension 2,994.
 
-| Initial solve damping | PCG 128 / 512 | Direct step residual: lower / implicit | Trial geometry |
+| Initial solve damping | Matrix-free PCG 128 / 512 | Direct step residual: lower / implicit | Trial geometry |
 |---|---|---|---|
 | `1e-4` | both fail; true residual 41,263.7 / 318.346 against `7.35e-7` | `2.75e-6` / `0.01848` | 880 nonpositive-depth observations |
 | `1e10` | both succeed at 22 iterations; `5.64e-7` against `7.38e-7` | `3.02e-9` / `4.49e-7` | all 130,900 valid |
@@ -883,7 +883,7 @@ accuracy. PCG recursive and true residuals are close at these low-damping
 iteration limits, so residual replacement alone is not established as a fix.
 
 At high damping, matrix-free/explicit pose-delta difference is `2.09e-17` and
-all trial costs are 126,477.42813448103. Low-damping trial geometry cost/RMS
+all trial geometry costs are 126,477.42813448103. Low-damping trial geometry cost/RMS
 exclude 880 invalid observations and must not be called full-objective
 improvements. Reported feasibility means finite and valid geometry, not that
 the PCG residual target passed. Prediction fields distinguish half-cost damped,
@@ -901,3 +901,10 @@ implicit action, with the same input, damping, block-Jacobi preconditioner,
 128/512 limits and true-residual rule. This isolates accumulation from
 convergence/preconditioning before selecting scaling or a different
 preconditioner. Preserve the baseline and do not silently relax its tolerance.
+
+PR #80 passed all eight final-head CI checks (run `34122318818`, head
+`b294bab`) and merged as `2b4ef99`; its local and remote topic branches were
+removed. The fixture also re-exported byte-identically to a second filename.
+The arithmetic-scale denominator above is specifically
+`max(1, ||base_action|| + ||accumulated_eliminated_action||)`, not a sum of
+individual landmark-action norms.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -908,3 +908,35 @@ removed. The fixture also re-exported byte-identically to a second filename.
 The arithmetic-scale denominator above is specifically
 `max(1, ||base_action|| + ||accumulated_eliminated_action||)`, not a sum of
 individual landmark-action norms.
+
+### Explicit-PCG isolation contract
+
+The next test-only arm borrows the existing lower-mirrored Schur matrix and
+calls the **same existing implicit operator's preconditioner application**.
+It must not substitute an independently recomputed block diagonal: that would
+change two numerical components at once. Preserve RHS, zero initial iterate,
+PCG recurrence, true-residual recheck, damping and iteration caps. A test-only
+callback recurrence must reproduce the production PCG when given the implicit
+action, including failure diagnostics, before interpreting its explicit-action
+comparison. This leaves production APIs and defaults untouched.
+
+For explicit PCG, report both its own lower-Schur residual and a re-evaluation
+with the implicit action; convergence for one finite-precision representation
+does not establish convergence for the other. Report successful complete steps
+and trial geometry separately from failed numerical trials. Retain both damping
+values and the previous oracle report as controls. Reuse the existing bounded
+matrix and fixture, not an additional model clone or a new production dense path.
+
+If both representations stall, investigate preconditioning and conditioning;
+if only the implicit representation stalls, prioritize accumulation and
+symmetry. These are hypotheses to refine with the measured residuals, not a
+binary proof of a unique cause. Do not turn a shorter failed solve into a speed
+claim, relax the stopping threshold, or promote to 10k from this experiment.
+
+[Ceres' official solver FAQ](https://ceres-solver.readthedocs.io/latest/solving_faqs.html)
+(checked 2026-09-07) discusses explicit Schur for smaller problems and stronger
+cluster preconditioners when Schur-Jacobi is insufficient. This supports testing
+the representations/preconditioner separately; it does not establish that a
+cluster implementation will fit this project's memory budget or solve its
+current numerical failure. Any later cluster arm needs an explicit bounded
+storage/work design and an unchanged-quality comparison.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -959,3 +959,13 @@ is a reference, not a dependency added here. Our inference is that such a
 representation may merit a bounded experiment if accumulation is limiting;
 its reported BAL results do not prove a win for this calibrated rig or justify
 replacing the current linear-storage design without a track-length memory audit.
+
+An independent frozen-fixture count illustrates that constraint: storing a
+naive dense `2 * observation_count` by `6 * unique_free_pose_count` camera
+Jacobian for every landmark would require 232,363,908 f64 entries,
+1,858,911,264 bytes (1.731 GiB), already at 1k and before damping, RHS or
+workspace. Same-frame sensor observations share pose columns; fixed pose 0
+is excluded from columns but its observation rows remain. Maximum track length
+is 893 observations. This is a hypothetical storage warning, **not** measured
+RootBA memory or a lower bound for implicit/streamed QR. Do not select that
+naive layout for the 10k implementation.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -949,3 +949,13 @@ the representations/preconditioner separately; it does not establish that a
 cluster implementation will fit this project's memory budget or solve its
 current numerical failure. Any later cluster arm needs an explicit bounded
 storage/work design and an unchanged-quality comparison.
+
+A separate numerical-stability candidate, not selected for this isolation PR,
+is [Demmel et al., CVPR 2021, Square Root Bundle Adjustment](https://openaccess.thecvf.com/content/CVPR2021/html/Demmel_Square_Root_Bundle_Adjustment_for_Large-Scale_Reconstruction_CVPR_2021_paper.html).
+It eliminates landmark variables with QR/nullspace operations and reports
+better numerical stability than normal-equation Schur elimination, but also
+larger memory requirements on dense problems. The authors' [RootBA OSS](https://github.com/nikolausdemmel/rootba)
+is a reference, not a dependency added here. Our inference is that such a
+representation may merit a bounded experiment if accumulation is limiting;
+its reported BAL results do not prove a win for this calibrated rig or justify
+replacing the current linear-storage design without a track-length memory audit.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -927,6 +927,15 @@ and trial geometry separately from failed numerical trials. Retain both damping
 values and the previous oracle report as controls. Reuse the existing bounded
 matrix and fixture, not an additional model clone or a new production dense path.
 
+Include `lambda=1e5` in the new isolation report in addition to the two endpoint
+controls. The frozen PR #79 `direct-serial-1.log` rejects LM0 through LM8 and
+first accepts LM9 at solve damping `1e5`, with trial cost
+118,084.4047208355. Thus this third damping also uses the unchanged initial
+model and tests a step that actually improved the baseline optimizer, rather
+than only a geometrically invalid low-damping step and a tiny high-damping
+step. Preserve the original four-case oracle report for direct comparison;
+the isolation report has six cases (three damping values, two iteration caps).
+
 If both representations stall, investigate preconditioning and conditioning;
 if only the implicit representation stalls, prioritize accumulation and
 symmetry. These are hypotheses to refine with the measured residuals, not a

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -969,3 +969,57 @@ is excluded from columns but its observation rows remain. Maximum track length
 is 893 observations. This is a hypothetical storage warning, **not** measured
 RootBA memory or a lower bound for implicit/streamed QR. Do not select that
 naive layout for the 10k implementation.
+
+### Explicit-PCG isolation results (2026-09-07)
+
+[Evidence](../benchmarks/electro/m8-openloris-explicit-pcg-isolation-v1.json)
+records implementation `cb14bdc`. Both arms use the same normal system, RHS,
+existing block-Jacobi preconditioner and stopping rule. The original four-case
+oracle is assembled separately first and reproduces all PR #80 numerical lines
+exactly. The new isolation system is then assembled once for all six cases.
+
+| Damping | Cap | Explicit lower-PCG true residual | Implicit-PCG true residual | Outcome |
+|---|---:|---:|---:|---|
+| `1e-4` | 128 | 5,614.69 | 41,263.7 | both hit cap |
+| `1e-4` | 512 | 0.0355111 | 318.346 | both hit cap |
+| `1e5` | 128 | 1,411.68 | 1,673.76 | both hit cap |
+| `1e5` | 512 | `8.947e-7` | `9.079e-4` | explicit recheck fails at 316; implicit hits cap |
+| `1e10` | 128 / 512 | `3.336e-8` | `5.639e-7` | explicit 23 / implicit 22 iterations, both pass |
+
+Targets are approximately `7.35e-7` to `7.38e-7`. At the useful `1e5` damping,
+explicit recursive residual reaches `7.537e-8`, but its true residual exceeds
+the target, so rejection is correct under this baseline contract. The dense
+reference itself has lower/implicit residuals `2.143e-6` / `0.002572` there.
+This does not prove the target is mathematically unattainable. It does show
+that replacing the operator with an explicit matrix is not sufficient to pass
+the current gate, and that both failures cannot be attributed solely to the
+preconditioner. Failed iterates are discarded, so their cross-operator
+residuals, deltas and trial geometry are unavailable, not zero.
+
+At high damping, the explicit solution also passes the implicit-action recheck
+(`1.275e-7`); its pose/landmark delta differences from the implicit solution are
+`2.09e-17` / `9.92e-18`. All 130,900 trial observations remain valid and trial
+geometry cost is unchanged from PR #80. Two serial release executions reproduce
+all eleven numerical lines exactly. Whole diagnostic process wall times are
+45.02 / 44.77 s and peak RSS 346,196 / 346,148 KiB; these include reference
+factorizations and repeated arms, are from a shared host, and are not solver
+speed or production memory results. No new model or README claim is promoted.
+
+The next bounded improvement candidate is a test-only damped-landmark-block
+Cholesky construction versus the current general 3x3 inverse, used consistently
+by the implicit action, explicit reference and preconditioner. First measure
+the input-block and inverse asymmetry; do not assume it is nonzero. Keep
+physical coordinates, damping, observations, caps and stopping rule unchanged,
+then compare actual residuals, convergence and valid-step quality. A win here
+must still pass a full nonlinear 1k comparison before production promotion.
+
+[Ceres' Schur implementation](https://ceres-solver.googlesource.com/ceres-solver/+/master/internal/ceres/schur_eliminator.h)
+discusses Cholesky inversion for SPD landmark blocks but uses a general inverse
+in its small fixed-size specialization for speed. Thus it supports considering
+the stability/speed tradeoff, not claiming that Cholesky is always faster or
+that the existing inverse is inherently incorrect. Separately labeled
+coordinate scaling or an inexact LM policy remain options after this A/B;
+the fixed `1e-12` rule is a diagnostic baseline, not the user's ultimate goal.
+Any changed policy must retain honest true-residual reporting and demonstrate
+the requested trajectory/reprojection/resource quality, not merely report more
+linear solves as successful.

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -95,6 +95,9 @@ invalid-depth trial observations; PCG 128/512 fail. At `1e10`, PCG converges in
 numerical traces are unchanged. Next isolate accumulation versus convergence
 with explicit lower-Schur PCG using the same preconditioner and stopping rule;
 this is a diagnostic gate, not a tolerance relaxation or a 10k promotion.
+PR #80 passed all eight final-head CI checks (run `34122318818`) and merged
+as `2b4ef99`; its old branch was removed. Work continues on
+`feat/m8-explicit-pcg-isolation` with the identical frozen fixture.
 
 ## Historical M7 baseline
 

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -98,6 +98,15 @@ this is a diagnostic gate, not a tolerance relaxation or a 10k promotion.
 PR #80 passed all eight final-head CI checks (run `34122318818`) and merged
 as `2b4ef99`; its old branch was removed. Work continues on
 `feat/m8-explicit-pcg-isolation` with the identical frozen fixture.
+That isolation is implemented (`cb14bdc`) and measured twice with all numerical
+lines identical; [evidence](../benchmarks/electro/m8-openloris-explicit-pcg-isolation-v1.json).
+At the first useful direct damping (`1e5`), explicit PCG nearly reaches but fails
+its true-residual target, while implicit PCG has a larger residual; the dense
+reference also fails that target. The next bounded stability candidate compares
+Cholesky-based damped landmark elimination with the current small general
+inverse, before any nonlinear/10k promotion. Scaling and a separately defined
+inexact policy remain available: the diagnostic tolerance is not a substitute
+for the user's actual quality, speed and memory requirements.
 
 ## Historical M7 baseline
 

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -7332,6 +7332,34 @@ mod matrix_free_real_oracle_tests {
         matrix_free_prediction: Option<PredictedDecrease>,
     }
 
+    /// Result of the test-only PCG recurrence when the explicitly materialized
+    /// lower-mirrored Schur matrix is used as the action.  A failed solve does
+    /// not retain its last iterate: in particular, no failed trial is passed
+    /// to the geometry or prediction checks below.
+    #[derive(Debug, Clone, PartialEq)]
+    struct ExplicitPcgIsolationReport {
+        lambda: f64,
+        pcg_max_iterations: usize,
+        status: String,
+        iterations: Option<usize>,
+        recursive_residual: Option<f64>,
+        lower_true_residual: Option<f64>,
+        implicit_true_residual: Option<f64>,
+        target: Option<f64>,
+        dense_lower_true_residual: Option<f64>,
+        dense_implicit_true_residual: Option<f64>,
+        pose_error_vs_dense: Option<f64>,
+        landmark_error_vs_dense: Option<f64>,
+        implicit_pcg_status: String,
+        implicit_pcg_iterations: Option<usize>,
+        implicit_pcg_true_residual: Option<f64>,
+        implicit_pcg_target: Option<f64>,
+        explicit_vs_implicit_pose_error: Option<f64>,
+        explicit_vs_implicit_landmark_error: Option<f64>,
+        feasibility: Option<Feasibility>,
+        prediction: Option<PredictedDecrease>,
+    }
+
     fn parse_f64(token: &str, context: &str) -> Result<f64, String> {
         let value = token
             .parse::<f64>()
@@ -7915,6 +7943,470 @@ mod matrix_free_real_oracle_tests {
             return Err("oracle explicit Schur is non-finite".to_owned());
         }
         Ok((schur, rhs, singular_landmarks))
+    }
+
+    fn explicit_lower_action(
+        schur: &DMatrix<f64>,
+        x: &DVector<f64>,
+    ) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError> {
+        if schur.nrows() != schur.ncols() {
+            return Err(implicit_schur::ImplicitSchurError::DimensionMismatch {
+                expected: schur.nrows(),
+                actual: schur.ncols(),
+            });
+        }
+        if x.len() != schur.nrows() {
+            return Err(implicit_schur::ImplicitSchurError::DimensionMismatch {
+                expected: schur.nrows(),
+                actual: x.len(),
+            });
+        }
+        if !x.iter().all(|value| value.is_finite()) {
+            return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                "operator input",
+            ));
+        }
+        let output = schur * x;
+        if !output.iter().all(|value| value.is_finite()) {
+            return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                "operator output",
+            ));
+        }
+        Ok(output)
+    }
+
+    fn checked_test_pcg_result<Apply>(
+        rhs: &DVector<f64>,
+        solution: DVector<f64>,
+        iterations: usize,
+        recursive_norm: f64,
+        target: f64,
+        apply: &mut Apply,
+    ) -> Result<implicit_schur::PcgResult, implicit_schur::ImplicitSchurError>
+    where
+        Apply: FnMut(&DVector<f64>) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError>,
+    {
+        let applied = apply(&solution)?;
+        let true_residual = rhs - &applied;
+        let true_norm = true_residual.norm();
+        if !true_norm.is_finite() {
+            return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                "true PCG residual",
+            ));
+        }
+        if true_norm > target {
+            return Err(implicit_schur::ImplicitSchurError::ResidualCheckFailed {
+                iterations,
+                recursive_norm,
+                true_norm,
+                target,
+            });
+        }
+        Ok(implicit_schur::PcgResult {
+            solution,
+            iterations,
+            residual_norm: true_norm,
+            target,
+        })
+    }
+
+    /// Test-only generic PCG recurrence copied from the production implicit
+    /// operator.  The callbacks make it possible to run the exact recurrence
+    /// against either the implicit action or a borrowed explicit lower-Schur
+    /// matrix, while keeping the production solver/API untouched.
+    fn solve_test_pcg<Apply, Preconditioner>(
+        rhs: &DVector<f64>,
+        dimension: usize,
+        options: implicit_schur::PcgOptions,
+        mut apply: Apply,
+        mut apply_preconditioner: Preconditioner,
+    ) -> Result<implicit_schur::PcgResult, implicit_schur::ImplicitSchurError>
+    where
+        Apply: FnMut(&DVector<f64>) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError>,
+        Preconditioner:
+            FnMut(&DVector<f64>) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError>,
+    {
+        if rhs.len() != dimension {
+            return Err(implicit_schur::ImplicitSchurError::DimensionMismatch {
+                expected: dimension,
+                actual: rhs.len(),
+            });
+        }
+        if !rhs.iter().all(|value| value.is_finite()) {
+            return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                "PCG right hand side",
+            ));
+        }
+        if !options.relative_tolerance.is_finite()
+            || options.relative_tolerance < 0.0
+            || !options.absolute_tolerance.is_finite()
+            || options.absolute_tolerance < 0.0
+        {
+            return Err(implicit_schur::ImplicitSchurError::InvalidTolerance);
+        }
+        let rhs_norm = rhs.norm();
+        let target = options
+            .absolute_tolerance
+            .max(options.relative_tolerance * rhs_norm);
+        if !target.is_finite() {
+            return Err(implicit_schur::ImplicitSchurError::NonFinite("PCG target"));
+        }
+        let mut solution = DVector::zeros(dimension);
+        let mut residual = rhs.clone();
+        let mut residual_norm = residual.norm();
+        if !residual_norm.is_finite() {
+            return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                "initial residual",
+            ));
+        }
+        if residual_norm <= target {
+            return checked_test_pcg_result(rhs, solution, 0, residual_norm, target, &mut apply);
+        }
+        if options.max_iterations == 0 {
+            return Err(implicit_schur::ImplicitSchurError::MaxIterations {
+                iterations: 0,
+                recursive_norm: residual_norm,
+                residual_norm,
+                target,
+            });
+        }
+
+        let mut preconditioned = apply_preconditioner(&residual)?;
+        let mut direction = preconditioned.clone();
+        let mut rho = residual.dot(&preconditioned);
+        if !rho.is_finite() || rho <= 0.0 {
+            return Err(implicit_schur::ImplicitSchurError::NonPositiveCurvature);
+        }
+
+        for iteration in 1..=options.max_iterations {
+            let applied = apply(&direction)?;
+            let curvature = direction.dot(&applied);
+            if !curvature.is_finite() || curvature <= 0.0 {
+                return Err(implicit_schur::ImplicitSchurError::NonPositiveCurvature);
+            }
+            let alpha = rho / curvature;
+            if !alpha.is_finite() {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite("PCG step"));
+            }
+            solution += alpha * &direction;
+            residual -= alpha * applied;
+            residual_norm = residual.norm();
+            if !solution.iter().all(|value| value.is_finite()) || !residual_norm.is_finite() {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite("PCG iterate"));
+            }
+            if residual_norm <= target {
+                return checked_test_pcg_result(
+                    rhs,
+                    solution,
+                    iteration,
+                    residual_norm,
+                    target,
+                    &mut apply,
+                );
+            }
+            if iteration == options.max_iterations {
+                let true_residual = rhs - &apply(&solution)?;
+                let true_norm = true_residual.norm();
+                if !true_norm.is_finite() {
+                    return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                        "true PCG residual",
+                    ));
+                }
+                if true_norm <= target {
+                    return Ok(implicit_schur::PcgResult {
+                        solution,
+                        iterations: iteration,
+                        residual_norm: true_norm,
+                        target,
+                    });
+                }
+                return Err(implicit_schur::ImplicitSchurError::MaxIterations {
+                    iterations: iteration,
+                    recursive_norm: residual_norm,
+                    residual_norm: true_norm,
+                    target,
+                });
+            }
+            preconditioned = apply_preconditioner(&residual)?;
+            let next_rho = residual.dot(&preconditioned);
+            if !next_rho.is_finite() || next_rho <= 0.0 {
+                return Err(implicit_schur::ImplicitSchurError::NonPositiveCurvature);
+            }
+            let beta = next_rho / rho;
+            if !beta.is_finite() {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                    "PCG direction",
+                ));
+            }
+            direction = &preconditioned + beta * direction;
+            rho = next_rho;
+        }
+        unreachable!("the max-iteration branch returns above");
+    }
+
+    fn pcg_error_details(
+        error: &implicit_schur::ImplicitSchurError,
+    ) -> (Option<usize>, Option<f64>, Option<f64>, Option<f64>) {
+        match *error {
+            implicit_schur::ImplicitSchurError::ResidualCheckFailed {
+                iterations,
+                recursive_norm,
+                true_norm,
+                target,
+            }
+            | implicit_schur::ImplicitSchurError::MaxIterations {
+                iterations,
+                recursive_norm,
+                residual_norm: true_norm,
+                target,
+            } => (
+                Some(iterations),
+                Some(recursive_norm),
+                Some(true_norm),
+                Some(target),
+            ),
+            _ => (None, None, None, None),
+        }
+    }
+
+    fn failed_explicit_pcg_reports(lambda: f64, status: String) -> Vec<ExplicitPcgIsolationReport> {
+        [128_usize, 512_usize]
+            .into_iter()
+            .map(|pcg_max_iterations| ExplicitPcgIsolationReport {
+                lambda,
+                pcg_max_iterations,
+                status: status.clone(),
+                iterations: None,
+                recursive_residual: None,
+                lower_true_residual: None,
+                implicit_true_residual: None,
+                target: None,
+                dense_lower_true_residual: None,
+                dense_implicit_true_residual: None,
+                pose_error_vs_dense: None,
+                landmark_error_vs_dense: None,
+                implicit_pcg_status: "not_run".to_owned(),
+                implicit_pcg_iterations: None,
+                implicit_pcg_true_residual: None,
+                implicit_pcg_target: None,
+                explicit_vs_implicit_pose_error: None,
+                explicit_vs_implicit_landmark_error: None,
+                feasibility: None,
+                prediction: None,
+            })
+            .collect()
+    }
+
+    fn run_explicit_pcg_isolation(
+        ba: &BundleAdjustment,
+    ) -> Result<Vec<ExplicitPcgIsolationReport>, String> {
+        let (system, pose_blocks, _landmark_count, _observation_count) = build_oracle_system(ba)?;
+        let CameraHessian::PoseDiagonal(_diagonal) = &system.h_pp else {
+            return Err("explicit PCG oracle requires pose blocks".to_owned());
+        };
+        let dimension = pose_blocks * 6;
+        let mut reports = Vec::new();
+
+        // Keep the two PR #80 damping cases and add the measured practical
+        // acceptance-region case without changing the legacy four reports.
+        for lambda in [1.0e-4, 1.0e5, 1.0e10] {
+            let (raw_schur, rhs, _singular_landmarks) = match explicit_schur_rhs(&system, lambda) {
+                Ok(value) => value,
+                Err(error) => {
+                    reports.extend(failed_explicit_pcg_reports(
+                        lambda,
+                        format!("failure:explicit_schur:{error}"),
+                    ));
+                    continue;
+                }
+            };
+            let mut lower_schur = raw_schur;
+            mirror_lower_triangle(&mut lower_schur);
+            let operator = match implicit_schur::ImplicitSchurOperator::new(&system, lambda) {
+                Ok(operator) => operator,
+                Err(error) => {
+                    reports.extend(failed_explicit_pcg_reports(
+                        lambda,
+                        format!("failure:implicit_operator:{error:?}"),
+                    ));
+                    continue;
+                }
+            };
+
+            let explicit_pose = solve_normal_equations(&lower_schur, &rhs).ok();
+            let explicit_landmarks = explicit_pose
+                .as_ref()
+                .and_then(|pose| operator.complete_delta(pose).ok());
+            let dense_lower_true_residual = explicit_pose.as_ref().and_then(|pose| {
+                explicit_lower_action(&lower_schur, pose)
+                    .ok()
+                    .map(|applied| (&rhs - applied).norm())
+            });
+            let dense_implicit_true_residual = explicit_pose.as_ref().and_then(|pose| {
+                operator
+                    .apply(pose)
+                    .ok()
+                    .map(|applied| (&rhs - applied).norm())
+            });
+
+            for pcg_max_iterations in [128_usize, 512_usize] {
+                let options = implicit_schur::PcgOptions {
+                    max_iterations: pcg_max_iterations,
+                    relative_tolerance: ORACLE_PC_TOLERANCE,
+                    absolute_tolerance: ORACLE_PC_TOLERANCE,
+                };
+
+                // Both arms consume this same rhs and preconditioner from one
+                // assembled normal system.  The production arm is retained as
+                // the recurrence/diagnostic comparison for the generic test
+                // recurrence used by the explicit action.
+                let implicit_result = operator.solve_pcg(&rhs, options);
+                let (
+                    implicit_pcg_status,
+                    implicit_pcg_iterations,
+                    implicit_pcg_true_residual,
+                    implicit_pcg_target,
+                    implicit_solution,
+                ) = match implicit_result {
+                    Ok(result) => (
+                        "success".to_owned(),
+                        Some(result.iterations),
+                        Some(result.residual_norm),
+                        Some(result.target),
+                        Some(result.solution),
+                    ),
+                    Err(error) => {
+                        let (iterations, _recursive, residual, target) = pcg_error_details(&error);
+                        (
+                            format!("failure:{error:?}"),
+                            iterations,
+                            residual,
+                            target,
+                            None,
+                        )
+                    }
+                };
+
+                let explicit_result = solve_test_pcg(
+                    &rhs,
+                    dimension,
+                    options,
+                    |x| explicit_lower_action(&lower_schur, x),
+                    |residual| operator.apply_preconditioner(residual),
+                );
+                let (
+                    explicit_status,
+                    explicit_iterations,
+                    explicit_recursive_residual,
+                    explicit_lower_true_residual,
+                    explicit_implicit_true_residual,
+                    explicit_target,
+                    explicit_solution,
+                ) = match explicit_result {
+                    Ok(result) => {
+                        let lower_true_residual =
+                            explicit_lower_action(&lower_schur, &result.solution)
+                                .ok()
+                                .map(|applied| (&rhs - applied).norm());
+                        let implicit_true_residual = operator
+                            .apply(&result.solution)
+                            .ok()
+                            .map(|applied| (&rhs - applied).norm());
+                        (
+                            "success_lower_pcg".to_owned(),
+                            Some(result.iterations),
+                            None,
+                            lower_true_residual,
+                            implicit_true_residual,
+                            Some(result.target),
+                            Some(result.solution),
+                        )
+                    }
+                    Err(error) => {
+                        let (iterations, recursive_residual, lower_true_residual, target) =
+                            pcg_error_details(&error);
+                        (
+                            format!("failure:{error:?}"),
+                            iterations,
+                            recursive_residual,
+                            lower_true_residual,
+                            None,
+                            target,
+                            None,
+                        )
+                    }
+                };
+
+                let delta_landmarks = explicit_solution
+                    .as_ref()
+                    .and_then(|pose| operator.complete_delta(pose).ok());
+                let feasibility = explicit_solution.as_ref().and_then(|pose| {
+                    delta_landmarks.as_ref().map(|landmarks| {
+                        feasibility(
+                            ba,
+                            &system,
+                            lambda,
+                            &lower_schur,
+                            &rhs,
+                            pose,
+                            landmarks,
+                            explicit_implicit_true_residual,
+                        )
+                    })
+                });
+                let prediction = explicit_solution.as_ref().and_then(|pose| {
+                    delta_landmarks.as_ref().and_then(|landmarks| {
+                        predicted_decrease(&system, lambda, pose, landmarks).ok()
+                    })
+                });
+                let pose_error_vs_dense = explicit_solution
+                    .as_ref()
+                    .and_then(|pose| explicit_pose.as_ref().map(|dense| (pose - dense).norm()));
+                let landmark_error_vs_dense = delta_landmarks.as_ref().and_then(|landmarks| {
+                    explicit_landmarks
+                        .as_ref()
+                        .map(|dense| (landmarks - dense).norm())
+                });
+                let explicit_vs_implicit_pose_error =
+                    explicit_solution.as_ref().and_then(|explicit| {
+                        implicit_solution
+                            .as_ref()
+                            .map(|implicit| (explicit - implicit).norm())
+                    });
+                let implicit_landmarks = implicit_solution
+                    .as_ref()
+                    .and_then(|pose| operator.complete_delta(pose).ok());
+                let explicit_vs_implicit_landmark_error =
+                    delta_landmarks.as_ref().and_then(|explicit| {
+                        implicit_landmarks
+                            .as_ref()
+                            .map(|implicit| (explicit - implicit).norm())
+                    });
+                reports.push(ExplicitPcgIsolationReport {
+                    lambda,
+                    pcg_max_iterations,
+                    status: explicit_status,
+                    iterations: explicit_iterations,
+                    recursive_residual: explicit_recursive_residual,
+                    lower_true_residual: explicit_lower_true_residual,
+                    implicit_true_residual: explicit_implicit_true_residual,
+                    target: explicit_target,
+                    dense_lower_true_residual,
+                    dense_implicit_true_residual,
+                    pose_error_vs_dense,
+                    landmark_error_vs_dense,
+                    implicit_pcg_status,
+                    implicit_pcg_iterations,
+                    implicit_pcg_true_residual,
+                    implicit_pcg_target,
+                    explicit_vs_implicit_pose_error,
+                    explicit_vs_implicit_landmark_error,
+                    feasibility,
+                    prediction,
+                });
+            }
+        }
+        Ok(reports)
     }
 
     fn schur_asymmetry(matrix: &DMatrix<f64>) -> f64 {
@@ -8646,6 +9138,92 @@ mod matrix_free_real_oracle_tests {
                 assert!((prediction.squared_damped - 2.0 * prediction.half_damped).abs() < 1.0e-9);
             }
         }
+
+        let isolation_reports = run_explicit_pcg_isolation(&synthetic_rig_problem()).unwrap();
+        assert_eq!(isolation_reports.len(), 6);
+        let mut successful_explicit_arms = 0;
+        for report in isolation_reports {
+            assert!(report.target.is_some_and(f64::is_finite));
+            assert!(report.implicit_pcg_target.is_some_and(f64::is_finite));
+            if report.status == "success_lower_pcg" {
+                successful_explicit_arms += 1;
+                assert!(report.lower_true_residual.is_some_and(f64::is_finite));
+                assert!(report.implicit_true_residual.is_some_and(f64::is_finite));
+                assert!(report.feasibility.is_some());
+                assert!(report.prediction.is_some());
+            }
+            if report.implicit_pcg_status == "success" {
+                assert!(report
+                    .implicit_pcg_true_residual
+                    .is_some_and(f64::is_finite));
+            }
+            if report.lambda == 1.0e10 {
+                assert_eq!(report.status, "success_lower_pcg");
+                assert_eq!(report.implicit_pcg_status, "success");
+                let explicit_target = report.target.expect("high-lambda explicit target");
+                let explicit_lower_residual = report
+                    .lower_true_residual
+                    .expect("high-lambda explicit lower residual");
+                assert!(explicit_lower_residual <= explicit_target);
+                assert!(report
+                    .implicit_true_residual
+                    .expect("high-lambda explicit implicit residual")
+                    .is_finite());
+                assert!(report
+                    .dense_lower_true_residual
+                    .expect("high-lambda dense lower residual")
+                    .is_finite());
+                assert!(report
+                    .dense_implicit_true_residual
+                    .expect("high-lambda dense implicit residual")
+                    .is_finite());
+                let implicit_target = report
+                    .implicit_pcg_target
+                    .expect("high-lambda implicit target");
+                let implicit_residual = report
+                    .implicit_pcg_true_residual
+                    .expect("high-lambda implicit residual");
+                assert!(implicit_residual <= implicit_target);
+                assert!(
+                    report
+                        .pose_error_vs_dense
+                        .expect("high-lambda explicit dense pose delta")
+                        < 1.0e-7
+                );
+                assert!(
+                    report
+                        .landmark_error_vs_dense
+                        .expect("high-lambda explicit dense landmark delta")
+                        < 1.0e-7
+                );
+                assert!(
+                    report
+                        .explicit_vs_implicit_pose_error
+                        .expect("high-lambda pose arm comparison")
+                        < 1.0e-7
+                );
+                assert!(
+                    report
+                        .explicit_vs_implicit_landmark_error
+                        .expect("high-lambda landmark arm comparison")
+                        < 1.0e-7
+                );
+                assert!(
+                    report
+                        .feasibility
+                        .as_ref()
+                        .expect("high-lambda explicit feasibility")
+                        .feasible
+                );
+                assert!(report
+                    .prediction
+                    .as_ref()
+                    .expect("high-lambda explicit prediction")
+                    .squared_damped
+                    .is_finite());
+            }
+        }
+        assert!(successful_explicit_arms > 0);
     }
 
     #[test]
@@ -8767,6 +9345,59 @@ mod matrix_free_real_oracle_tests {
     }
 
     #[test]
+    fn generic_test_pcg_matches_implicit_recurrence_and_failure_diagnostics() {
+        let diagonal = vec![
+            Matrix6::from_diagonal(&Vector6::from_element(20.0)),
+            Matrix6::from_diagonal(&Vector6::from_element(22.0)),
+        ];
+        let mut cross = Matrix6x3::zeros();
+        for component in 0..3 {
+            cross[(component, component)] = 0.25;
+        }
+        let system = NormalEquationsBa {
+            h_pp: CameraHessian::PoseDiagonal(diagonal),
+            b_p: DVector::from_iterator(12, (0..12).map(|index| 0.03 * (index + 1) as f64)),
+            landmarks: vec![LandmarkBlock {
+                h_ll: Matrix3::from_diagonal(&Vector3::new(7.0, 8.0, 9.0)),
+                b_l: Vector3::new(0.2, -0.1, 0.3),
+                cross: vec![(0, cross), (1, -cross)],
+            }],
+        };
+        let operator = implicit_schur::ImplicitSchurOperator::new(&system, 0.25).unwrap();
+        let options = [
+            implicit_schur::PcgOptions::default(),
+            implicit_schur::PcgOptions {
+                max_iterations: 1,
+                relative_tolerance: 0.0,
+                absolute_tolerance: 1.0e-30,
+            },
+        ];
+        let mut saw_success = false;
+        let mut saw_failure = false;
+        for options in options {
+            let expected = operator.solve_pcg(operator.rhs(), options);
+            let actual = solve_test_pcg(
+                operator.rhs(),
+                operator.dimension(),
+                options,
+                |x| operator.apply(x),
+                |residual| operator.apply_preconditioner(residual),
+            );
+            assert_eq!(actual, expected);
+            match expected {
+                Ok(_) => saw_success = true,
+                Err(implicit_schur::ImplicitSchurError::MaxIterations { .. })
+                | Err(implicit_schur::ImplicitSchurError::ResidualCheckFailed { .. }) => {
+                    saw_failure = true;
+                }
+                Err(error) => panic!("unexpected PCG diagnostic: {error:?}"),
+            }
+        }
+        assert!(saw_success);
+        assert!(saw_failure);
+    }
+
+    #[test]
     #[ignore = "requires an explicitly exported frozen 1k fixture and source hash"]
     fn ignored_real_fixture_runs_bounded_damping_oracle() {
         let path = env::var_os("VISLOC_MATRIX_FREE_ORACLE_FIXTURE")
@@ -8786,6 +9417,11 @@ mod matrix_free_real_oracle_tests {
         );
         for report in reports {
             println!("matrix_free_oracle {report:?}");
+        }
+        let isolation_reports = run_explicit_pcg_isolation(&fixture.ba).unwrap();
+        assert_eq!(isolation_reports.len(), 6);
+        for report in isolation_reports {
+            println!("explicit_pcg_isolation {report:?}");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add only cfg(test) Rust code: explicit lower-Schur PCG with the same RHS, existing block-Jacobi preconditioner, recurrence and stopping rule as implicit PCG.
- Preserve the PR #80 four-case oracle; add six isolation cases at damping 1e-4, 1e5, 1e10 and caps 128/512. The middle damping is the first accepted direct step on the frozen input.
- Compare explicit and implicit residuals, dense-reference residuals, successful deltas, geometry and predictions. Failed iterates are discarded.
- Record two identical numerical runs, unchanged baseline reports, and bounded memory considerations. No production solver/API/README performance change or 10k promotion.

## Findings

At damping 1e5 explicit PCG fails the true-residual recheck at iteration316 (8.947e-7 versus7.363e-7); implicit512 remains at9.079e-4. The dense reference also misses that target. At high damping both representations pass. Both failures do not isolate the preconditioner as the sole cause. No shorter failed solve is called a speedup.

Next bounded stability candidate: Cholesky versus general inversion for damped landmark blocks, with unchanged physical damping and observations, before nonlinear promotion. Inexact stopping remains a separately defined possible arm, not a silent rewrite of this baseline.

## Validation

- Root targeted library tests: 7 passed, 1 ignored; real ignored test explicitly ran twice, exactly one passed each time.
- Synthetic callback-PCG success/failure results equal production PCG; explicit six-case wiring and high-damping solution agreement tested in ordinary CI tests.
- Example tests:12 passed; Python tests:46 passed; library clippy warnings denied; fmt; docs links; registry189; generated docs; diff check.
- Source and release-test binary hashes, fixture SHA, raw run hashes and all reports committed.
- Final-head CI run 34125303050: all eight checks passed on 7b4b6cbbac5ad8d5b1582070a284fe0a8c2e0680.
- Luna Max independently audited all six reports, hashes and documented limits: no blockers.
- Squash merged as 06ca2e1424d1874275a847eb23bc4c59ad239336 at 2026-09-07T13:09:00Z. Local and remote topic branches removed; main clean.