### PR TITLE
test(sfm): measure Cholesky elimination and explicit PCG tolerance

### DIFF
--- a/benchmarks/electro/m8-openloris-cholesky-landmark-elimination-v1.json
+++ b/benchmarks/electro/m8-openloris-cholesky-landmark-elimination-v1.json
@@ -1,0 +1,493 @@
+{
+  "schema_version": 1,
+  "experiment": "m8-openloris-cholesky-landmark-elimination-v1",
+  "date": "2026-09-07",
+  "status": "diagnostic_complete_no_production_promotion",
+  "implementation_commit": "05500bf5d8d48ea56d1603d5d40c8289ab84716e",
+  "source_sha256": {
+    "pipelines/slam/src/bundle.rs": "0b0a4e1b4985eebeb39a87c29af0c38838ff06e1bc2981425a681e090e517a65"
+  },
+  "binary": {
+    "path": "target/release/deps/visloc_slam-033870405c01cac5",
+    "sha256": "af4173ff0df43bc4a89b42c5395e82d7e63906b1eb159d29b5c11e1afa3f7e04",
+    "build_command": "cargo test --release -p visloc-slam --lib matrix_free_real_oracle_tests --no-run"
+  },
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-cholesky-landmark-elimination-v1",
+  "input": {
+    "baseline_evidence": "m8-openloris-real-normal-system-oracle-v1.json",
+    "fixture": "/home/sasaki/datasets/openloris/corridor1-1-m8-real-normal-system-oracle-v1/input.fixture",
+    "fixture_sha256": "a71ef3401ea6d75a06f18ded0d475ad48fd929202a64fecaeaa790ee964da1ea",
+    "combined_source_sha256": "ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829",
+    "initial_cost": 126510.39875730938,
+    "initial_cost_bits": "4683430141614839853",
+    "poses": 500,
+    "variable_poses": 499,
+    "landmarks": 4716,
+    "observations": 130900,
+    "scalar_dimension": 2994,
+    "ground_truth_used": false
+  },
+  "execution": {
+    "rayon_num_threads": 1,
+    "relative_tolerance": 1e-12,
+    "absolute_tolerance": 1e-12,
+    "ignored_test": "bundle::matrix_free_real_oracle_tests::ignored_real_fixture_runs_bounded_damping_oracle",
+    "arguments": [
+      "--exact",
+      "--ignored",
+      "--nocapture"
+    ],
+    "normal_assembly": "Legacy four-case, explicit six-case and Cholesky six-case groups each assemble an initial normal system sequentially. Within the new group, cases share one normal and borrow cross blocks.",
+    "cholesky_policy": "Audit original symmetry at 1e-12*max(1,maxabs(Hll)); mirror lower triangle; no averaging, substitute diagonal or fallback. Same triangular solves construct RHS, action, preconditioner and back-substitution. Diagnostic inverse is not used for the operator.",
+    "failed_iterate_policy": "Failed PCG iterates are discarded; unavailable deltas, geometry and cross-residuals are null.",
+    "setup_failure_limitation": "General inverse metrics/operator/explicit setup failure aborts this diagnostic runner. Cholesky setup failures are reported. Frozen input has no setup failure.",
+    "storage": "Test-only bounded dense references; same PR80 caps. Borrow landmark/cross data; no full second BA model retained.",
+    "production_solver_unchanged": true
+  },
+  "reproducibility": {
+    "runs": 2,
+    "all_17_numerical_report_lines_exact": true,
+    "legacy_11_lines_exact_with_pr81": true,
+    "both_runs_one_test_passed": true
+  },
+  "runs": [
+    {
+      "name": "cholesky-1",
+      "wall_seconds": 80.44,
+      "peak_rss_kib": 349472
+    },
+    {
+      "name": "cholesky-2",
+      "wall_seconds": 90.64,
+      "peak_rss_kib": 349540
+    }
+  ],
+  "artifacts": {
+    "cholesky-1.log": {
+      "sha256": "0d98daf71da8312e6dcda2760d6d61278583994b01d591ad94c9eebfa4a98b7a",
+      "bytes": 33675
+    },
+    "cholesky-1.time": {
+      "sha256": "4e4f0815c10c5a132e45cdf83b95c319926a3d3014b6e61c296cd0c9598539cd",
+      "bytes": 888
+    },
+    "cholesky-2.log": {
+      "sha256": "65e22d3ecb16a0b0a5db4c11d367da1c3dff383cf596a37d0be0d7ef72407ae5",
+      "bytes": 33675
+    },
+    "cholesky-2.time": {
+      "sha256": "9226905275f3e5d251840f06208a3d11ca800f5f4876fb66192d031d5872b647",
+      "bytes": 888
+    }
+  },
+  "measurements": [
+    {
+      "lambda": 0.0001,
+      "pcg_max_iterations": 128,
+      "general_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347216659.193,
+        "inverse_max_asymmetry": 0,
+        "inverse_max_scale": 9656.533732050944,
+        "h_ll_inverse_identity_residual": 1.9996343696102396e-8
+      },
+      "cholesky_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347216659.193,
+        "inverse_max_asymmetry": 1.3642420526593924e-12,
+        "inverse_max_scale": 9656.533732075859,
+        "h_ll_inverse_identity_residual": 2.634178031930877e-8
+      },
+      "general": {
+        "status": "failure:MaxIterations { iterations: 128, recursive_norm: 41263.72612053205, residual_norm: 41263.7264460946, target: 7.354716589947665e-7 }",
+        "iterations": 128,
+        "recursive_residual": 41263.72612053205,
+        "action_true_residual": 41263.7264460946,
+        "target": 7.354716589947665e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.000004919094885193126,
+        "dense_reference_action_true_residual": 0.016225321613743043,
+        "dense_reference_original_pose_equation_residual": 0.009733015676715463,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "cholesky": {
+        "status": "failure:MaxIterations { iterations: 128, recursive_norm: 5715.673228313901, residual_norm: 5715.673230831875, target: 7.354716589948483e-7 }",
+        "iterations": 128,
+        "recursive_residual": 5715.673228313901,
+        "action_true_residual": 5715.673230831875,
+        "target": 7.354716589948483e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.000004243451547724146,
+        "dense_reference_action_true_residual": 0.0004625243341533646,
+        "dense_reference_original_pose_equation_residual": 0.00020542703468644496,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "general_vs_cholesky_pose_error": null,
+      "general_vs_cholesky_landmark_error": null,
+      "rhs_error": 0.000003983229186736744,
+      "probe_action_error": 0.2345071616941995,
+      "probe_preconditioner_error": 8.926410798608598e-15
+    },
+    {
+      "lambda": 0.0001,
+      "pcg_max_iterations": 512,
+      "general_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347216659.193,
+        "inverse_max_asymmetry": 0,
+        "inverse_max_scale": 9656.533732050944,
+        "h_ll_inverse_identity_residual": 1.9996343696102396e-8
+      },
+      "cholesky_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347216659.193,
+        "inverse_max_asymmetry": 1.3642420526593924e-12,
+        "inverse_max_scale": 9656.533732075859,
+        "h_ll_inverse_identity_residual": 2.634178031930877e-8
+      },
+      "general": {
+        "status": "failure:MaxIterations { iterations: 512, recursive_norm: 318.34634181495545, residual_norm: 318.3459481943091, target: 7.354716589947665e-7 }",
+        "iterations": 512,
+        "recursive_residual": 318.34634181495545,
+        "action_true_residual": 318.3459481943091,
+        "target": 7.354716589947665e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.000004919094885193126,
+        "dense_reference_action_true_residual": 0.016225321613743043,
+        "dense_reference_original_pose_equation_residual": 0.009733015676715463,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "cholesky": {
+        "status": "failure:MaxIterations { iterations: 512, recursive_norm: 5.384826671199339, residual_norm: 5.384827028564624, target: 7.354716589948483e-7 }",
+        "iterations": 512,
+        "recursive_residual": 5.384826671199339,
+        "action_true_residual": 5.384827028564624,
+        "target": 7.354716589948483e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.000004243451547724146,
+        "dense_reference_action_true_residual": 0.0004625243341533646,
+        "dense_reference_original_pose_equation_residual": 0.00020542703468644496,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "general_vs_cholesky_pose_error": null,
+      "general_vs_cholesky_landmark_error": null,
+      "rhs_error": 0.000003983229186736744,
+      "probe_action_error": 0.2345071616941995,
+      "probe_preconditioner_error": 8.926410798608598e-15
+    },
+    {
+      "lambda": 100000,
+      "pcg_max_iterations": 128,
+      "general_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347316659.193,
+        "inverse_max_asymmetry": 0,
+        "inverse_max_scale": 0.000009999999536993552,
+        "h_ll_inverse_identity_residual": 2.000888343900442e-11
+      },
+      "cholesky_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347316659.193,
+        "inverse_max_asymmetry": 2.541098841762901e-21,
+        "inverse_max_scale": 0.000009999999536993552,
+        "h_ll_inverse_identity_residual": 1.8639094861936606e-11
+      },
+      "general": {
+        "status": "failure:MaxIterations { iterations: 128, recursive_norm: 1673.762060680569, residual_norm: 1673.7620609788628, target: 7.363379620295508e-7 }",
+        "iterations": 128,
+        "recursive_residual": 1673.762060680569,
+        "action_true_residual": 1673.7620609788628,
+        "target": 7.363379620295508e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.000002143103419796261,
+        "dense_reference_action_true_residual": 0.002572261272662248,
+        "dense_reference_original_pose_equation_residual": 0.0012322092488736053,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "cholesky": {
+        "status": "failure:MaxIterations { iterations: 128, recursive_norm: 1698.1763605015146, residual_norm: 1698.1763611891236, target: 7.36337962029554e-7 }",
+        "iterations": 128,
+        "recursive_residual": 1698.1763605015146,
+        "action_true_residual": 1698.1763611891236,
+        "target": 7.36337962029554e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.0000010906007117797441,
+        "dense_reference_action_true_residual": 0.000010756773267141792,
+        "dense_reference_original_pose_equation_residual": 0.000008358640687523163,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "general_vs_cholesky_pose_error": null,
+      "general_vs_cholesky_landmark_error": null,
+      "rhs_error": 1.4864285126174735e-7,
+      "probe_action_error": 0.4165489896098382,
+      "probe_preconditioner_error": 3.8130088282709313e-16
+    },
+    {
+      "lambda": 100000,
+      "pcg_max_iterations": 512,
+      "general_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347316659.193,
+        "inverse_max_asymmetry": 0,
+        "inverse_max_scale": 0.000009999999536993552,
+        "h_ll_inverse_identity_residual": 2.000888343900442e-11
+      },
+      "cholesky_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16834347316659.193,
+        "inverse_max_asymmetry": 2.541098841762901e-21,
+        "inverse_max_scale": 0.000009999999536993552,
+        "h_ll_inverse_identity_residual": 1.8639094861936606e-11
+      },
+      "general": {
+        "status": "failure:MaxIterations { iterations: 512, recursive_norm: 4.633822922386621e-6, residual_norm: 0.000907864069961008, target: 7.363379620295508e-7 }",
+        "iterations": 512,
+        "recursive_residual": 0.000004633822922386621,
+        "action_true_residual": 0.000907864069961008,
+        "target": 7.363379620295508e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.000002143103419796261,
+        "dense_reference_action_true_residual": 0.002572261272662248,
+        "dense_reference_original_pose_equation_residual": 0.0012322092488736053,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "cholesky": {
+        "status": "failure:ResidualCheckFailed { iterations: 322, recursive_norm: 5.935936186269838e-7, true_norm: 1.2149831240003597e-5, target: 7.36337962029554e-7 }",
+        "iterations": 322,
+        "recursive_residual": 5.935936186269838e-7,
+        "action_true_residual": 0.000012149831240003597,
+        "target": 7.36337962029554e-7,
+        "lower_true_residual": null,
+        "dense_reference_lower_true_residual": 0.0000010906007117797441,
+        "dense_reference_action_true_residual": 0.000010756773267141792,
+        "dense_reference_original_pose_equation_residual": 0.000008358640687523163,
+        "original_pose_equation_residual": null,
+        "pose_error_vs_dense": null,
+        "landmark_error_vs_dense": null,
+        "feasibility": null,
+        "prediction": null
+      },
+      "general_vs_cholesky_pose_error": null,
+      "general_vs_cholesky_landmark_error": null,
+      "rhs_error": 1.4864285126174735e-7,
+      "probe_action_error": 0.4165489896098382,
+      "probe_preconditioner_error": 3.8130088282709313e-16
+    },
+    {
+      "lambda": 10000000000,
+      "pcg_max_iterations": 128,
+      "general_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16844347216659.193,
+        "inverse_max_asymmetry": 0,
+        "inverse_max_scale": 9.999999999995371e-11,
+        "h_ll_inverse_identity_residual": 1.3603997225709525e-13
+      },
+      "cholesky_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16844347216659.193,
+        "inverse_max_asymmetry": 6.462348535570529e-27,
+        "inverse_max_scale": 9.99999999999537e-11,
+        "h_ll_inverse_identity_residual": 1.0805156823142815e-14
+      },
+      "general": {
+        "status": "general_pcg",
+        "iterations": 22,
+        "recursive_residual": null,
+        "action_true_residual": 5.639331821966476e-7,
+        "target": 7.377914999757461e-7,
+        "lower_true_residual": 5.248398232638574e-7,
+        "dense_reference_lower_true_residual": 6.4945806084734065e-9,
+        "dense_reference_action_true_residual": 1.28800155078187e-7,
+        "dense_reference_original_pose_equation_residual": 2.4457371213538693e-7,
+        "original_pose_equation_residual": 6.145139982320029e-7,
+        "pose_error_vs_dense": 2.0919877485600968e-17,
+        "landmark_error_vs_dense": 9.871189290876146e-18,
+        "feasibility": {
+          "finite": true,
+          "pose_true_residual": 5.248398232638574e-7,
+          "implicit_pose_true_residual": 5.639331821966476e-7,
+          "max_landmark_backsub_residual": 2.469834459723764e-7,
+          "geometry_observation_count": 130900,
+          "geometry_invalid_observations": 0,
+          "geometry_nonpositive_depth": 0,
+          "geometry_cost": 126477.42813448103,
+          "geometry_rms_error": 0.9829619111005349,
+          "geometry_max_error": 3.9989838349986138,
+          "geometry_feasible": true,
+          "feasible": true
+        },
+        "prediction": {
+          "half_damped": 8.783279833568196,
+          "squared_damped": 17.566559667136392,
+          "squared_undamped": 32.97081597530536
+        }
+      },
+      "cholesky": {
+        "status": "cholesky_pcg",
+        "iterations": 23,
+        "recursive_residual": null,
+        "action_true_residual": 1.5387753420012324e-8,
+        "target": 7.377914999757461e-7,
+        "lower_true_residual": 1.646443836696794e-8,
+        "dense_reference_lower_true_residual": 6.6976897203643895e-9,
+        "dense_reference_action_true_residual": 9.255624798049736e-9,
+        "dense_reference_original_pose_equation_residual": 7.917266175735718e-9,
+        "original_pose_equation_residual": 1.4282111275872047e-8,
+        "pose_error_vs_dense": 7.751562987913234e-19,
+        "landmark_error_vs_dense": 2.14243935352818e-19,
+        "feasibility": {
+          "finite": true,
+          "pose_true_residual": 1.646443836696794e-8,
+          "implicit_pose_true_residual": 1.5387753420012324e-8,
+          "max_landmark_backsub_residual": 5.468113297845684e-10,
+          "geometry_observation_count": 130900,
+          "geometry_invalid_observations": 0,
+          "geometry_nonpositive_depth": 0,
+          "geometry_cost": 126477.42813448103,
+          "geometry_rms_error": 0.9829619111005349,
+          "geometry_max_error": 3.9989838349986138,
+          "geometry_feasible": true,
+          "feasible": true
+        },
+        "prediction": {
+          "half_damped": 8.783279833568207,
+          "squared_damped": 17.566559667136413,
+          "squared_undamped": 32.9708159753056
+        }
+      },
+      "general_vs_cholesky_pose_error": 2.5391123445570576e-17,
+      "general_vs_cholesky_landmark_error": 1.5372211169631732e-17,
+      "rhs_error": 1.45884685975491e-11,
+      "probe_action_error": 0.011112227291183076,
+      "probe_preconditioner_error": 2.30936045125709e-24
+    },
+    {
+      "lambda": 10000000000,
+      "pcg_max_iterations": 512,
+      "general_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16844347216659.193,
+        "inverse_max_asymmetry": 0,
+        "inverse_max_scale": 9.999999999995371e-11,
+        "h_ll_inverse_identity_residual": 1.3603997225709525e-13
+      },
+      "cholesky_metrics": {
+        "h_ll_max_asymmetry": 0,
+        "h_ll_max_scale": 16844347216659.193,
+        "inverse_max_asymmetry": 6.462348535570529e-27,
+        "inverse_max_scale": 9.99999999999537e-11,
+        "h_ll_inverse_identity_residual": 1.0805156823142815e-14
+      },
+      "general": {
+        "status": "general_pcg",
+        "iterations": 22,
+        "recursive_residual": null,
+        "action_true_residual": 5.639331821966476e-7,
+        "target": 7.377914999757461e-7,
+        "lower_true_residual": 5.248398232638574e-7,
+        "dense_reference_lower_true_residual": 6.4945806084734065e-9,
+        "dense_reference_action_true_residual": 1.28800155078187e-7,
+        "dense_reference_original_pose_equation_residual": 2.4457371213538693e-7,
+        "original_pose_equation_residual": 6.145139982320029e-7,
+        "pose_error_vs_dense": 2.0919877485600968e-17,
+        "landmark_error_vs_dense": 9.871189290876146e-18,
+        "feasibility": {
+          "finite": true,
+          "pose_true_residual": 5.248398232638574e-7,
+          "implicit_pose_true_residual": 5.639331821966476e-7,
+          "max_landmark_backsub_residual": 2.469834459723764e-7,
+          "geometry_observation_count": 130900,
+          "geometry_invalid_observations": 0,
+          "geometry_nonpositive_depth": 0,
+          "geometry_cost": 126477.42813448103,
+          "geometry_rms_error": 0.9829619111005349,
+          "geometry_max_error": 3.9989838349986138,
+          "geometry_feasible": true,
+          "feasible": true
+        },
+        "prediction": {
+          "half_damped": 8.783279833568196,
+          "squared_damped": 17.566559667136392,
+          "squared_undamped": 32.97081597530536
+        }
+      },
+      "cholesky": {
+        "status": "cholesky_pcg",
+        "iterations": 23,
+        "recursive_residual": null,
+        "action_true_residual": 1.5387753420012324e-8,
+        "target": 7.377914999757461e-7,
+        "lower_true_residual": 1.646443836696794e-8,
+        "dense_reference_lower_true_residual": 6.6976897203643895e-9,
+        "dense_reference_action_true_residual": 9.255624798049736e-9,
+        "dense_reference_original_pose_equation_residual": 7.917266175735718e-9,
+        "original_pose_equation_residual": 1.4282111275872047e-8,
+        "pose_error_vs_dense": 7.751562987913234e-19,
+        "landmark_error_vs_dense": 2.14243935352818e-19,
+        "feasibility": {
+          "finite": true,
+          "pose_true_residual": 1.646443836696794e-8,
+          "implicit_pose_true_residual": 1.5387753420012324e-8,
+          "max_landmark_backsub_residual": 5.468113297845684e-10,
+          "geometry_observation_count": 130900,
+          "geometry_invalid_observations": 0,
+          "geometry_nonpositive_depth": 0,
+          "geometry_cost": 126477.42813448103,
+          "geometry_rms_error": 0.9829619111005349,
+          "geometry_max_error": 3.9989838349986138,
+          "geometry_feasible": true,
+          "feasible": true
+        },
+        "prediction": {
+          "half_damped": 8.783279833568207,
+          "squared_damped": 17.566559667136413,
+          "squared_undamped": 32.9708159753056
+        }
+      },
+      "general_vs_cholesky_pose_error": 2.5391123445570576e-17,
+      "general_vs_cholesky_landmark_error": 1.5372211169631732e-17,
+      "rhs_error": 1.45884685975491e-11,
+      "probe_action_error": 0.011112227291183076,
+      "probe_preconditioner_error": 2.30936045125709e-24
+    }
+  ],
+  "interpretation": [
+    "Original damped blocks and general inverses have zero measured asymmetry at all three lambdas; an asymmetric-general-inverse diagnosis is unsupported.",
+    "Cholesky changes finite-precision behavior and improves several residuals, but its maximum inverse identity residual is slightly worse at lambda=1e-4. No uniform superiority claim.",
+    "At lambda=1e5, cap512 Cholesky fails true-residual check at iteration322: 1.2149831240003597e-5 versus target7.36337962029554e-7. No successful nonlinear step or quality evidence at this damping.",
+    "At lambda=1e10 both methods pass; all130900 trial observations valid and trial cost126477.42813448103 identical. This is a heavily damped initial-system diagnostic, not full nonlinear optimization.",
+    "Original-pose-equation residual is ||(Hpp+lambdaI)delta_p + E delta_l + b_p||, distinct from Schur residual and its stopping target.",
+    "Hll inverse identity metric is the maximum per-landmark Frobenius norm. Scale/asymmetry maxima can occur at different landmarks. Probe differences are cross-method discrepancies, not errors against exact arithmetic.",
+    "Whole diagnostic wall/RSS include many factorization/PCG arms on a shared host, not production solver speed/memory or COLMAP end-to-end results."
+  ],
+  "next_experiment": "Separately labeled full nonlinear 1k production-general-inverse PCG512 relative1e-8 absolute1e-12 versus unchanged strict baseline and direct control; preserve observations/calibration and independently audit trajectory, reprojection, time and RSS before any promotion."
+}

--- a/benchmarks/electro/m8-openloris-relative-pcg-tolerance-v1.json
+++ b/benchmarks/electro/m8-openloris-relative-pcg-tolerance-v1.json
@@ -1,0 +1,749 @@
+{
+  "schema_version": 1,
+  "experiment": "m8-openloris-relative-pcg-tolerance-v1",
+  "date": "2026-09-07",
+  "status": "measured_improved_over_strict_but_not_direct_equivalent_no_10k_promotion",
+  "implementation_commit": "7b6056ab0568fcf9cc41f780ca6089cb72052a4f",
+  "earlier_flag_commit": "5c933d6f55580b0299519eba29310c64d0f33fc6",
+  "source": "examples/compare_rig_bundle_adjustment.rs",
+  "source_sha256": "16993280d5a58c7f8ccd4d51a12d70eea60d48cb9d088a892caff00b34818c6a",
+  "binary": {
+    "path": "target/release/examples/compare_rig_bundle_adjustment",
+    "sha256": "9eb784dc5ce56cf4c051adc87145680af4ef148f743c2bf80fe5431678732ff2",
+    "build_command": "cargo build --release --example compare_rig_bundle_adjustment",
+    "rustc": "1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1",
+  "input_evidence": "m8-openloris-matrix-free-1k-input-v1.json",
+  "baseline_evidence": "m8-openloris-matrix-free-rig-ba-comparison-v1.json",
+  "preceding_diagnostic": "m8-openloris-cholesky-landmark-elimination-v1.json",
+  "configuration": {
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+    "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+    "lm_max_iterations": 20,
+    "initial_lambda": 0.0001,
+    "lambda_increase_factor": 10,
+    "lambda_decrease_factor": 0.1,
+    "min_lambda": 1e-9,
+    "max_lambda": 1000000000000,
+    "step_tolerance": 1e-7,
+    "cost_tolerance": 1e-9,
+    "relative_cost_tolerance": null,
+    "robust_kernel": "None",
+    "refine_intrinsics": false,
+    "refine_distortion": false,
+    "ba_parallel": false,
+    "linear_solver_config": "Sparse; explicit matrix-free entry always uses implicit PCG",
+    "fixed_pose_ids": [
+      0
+    ],
+    "fixed_landmark_ids": [],
+    "observation_order": "Original points3D file order, then original track pair order",
+    "input_observations_removed": 0,
+    "pcg_absolute_tolerance": 1e-12,
+    "pcg_max_iterations_arms": [
+      512
+    ],
+    "gt_passed_to_optimizer": false,
+    "pcg_relative_tolerance_arms": [
+      1e-12,
+      1e-8
+    ],
+    "rayon_num_threads": 1
+  },
+  "accounting": {
+    "scope": "Whole-process post-map BA including load, validation, solve and staged text publication; solver time separately logged. Excludes frontend, mapping and atlas construction.",
+    "run_order": [
+      "matrix-free-512-rel1e8-v2-1",
+      "direct-v2-1",
+      "matrix-free-512-strict-v2-1",
+      "matrix-free-512-rel1e8-v2-2",
+      "direct-v2-2",
+      "matrix-free-512-strict-v2-2"
+    ],
+    "serial_processes": true,
+    "concurrent_project_build_or_benchmark": false,
+    "host": "Shared host with unrelated long-lived CPU tasks; warm/reused inputs, no cache dropping. Two repetitions, no statistical confidence or E2E claim.",
+    "timing_command": "RAYON_NUM_THREADS=1 /usr/bin/time -v -o ROOT/ARM.time target/release/examples/compare_rig_bundle_adjustment --model MODEL --rig-manifest RIG --solver direct|matrix-free --out-dir ROOT/ARM/model [--pcg-max-iterations 512] [--pcg-relative-tolerance 1e-8] > ROOT/ARM.log 2>&1",
+    "default_solver_and_tolerances_unchanged": true,
+    "cholesky_used_in_nonlinear_runs": false,
+    "readme_changed": false
+  },
+  "runs": [
+    {
+      "arm": "matrix-free-512-rel1e8-v2-1",
+      "summary": {
+        "solver": "matrix-free",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.180705543689159e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "512",
+        "pcg_relative_tolerance": "1.00000000000000002e-8",
+        "pcg_absolute_tolerance": "9.99999999999999980e-13",
+        "solver_seconds": "19.948862",
+        "total_seconds": "20.179719",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-rel1e8-v2-1/model"
+      },
+      "wall_seconds": 20.19,
+      "peak_rss_kib": 84564,
+      "exit_status": 0,
+      "accepted_lm": 3,
+      "successful_pcg": 3,
+      "pcg_failure_counts": {
+        "MaxIterations": 10,
+        "ResidualCheckFailed": 7,
+        "NonPositiveCurvature": 0
+      },
+      "output_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "dfc2dba4c21f4d5f31ffd8ac40f405c17476e4251ec630cd9806668e81252425",
+        "points3D.txt": "86242e11eb98dd920eda04af59f17c6fab4d79f257cbd7679421281e03a43e10"
+      },
+      "log_sha256": "14b5633a4e73e285ec9a1871d95aa8cef7dd3187e0000cd1c83e57ce223f62ce",
+      "time_sha256": "9ffae61a2f8b48e8e66556fe13be9b891dd3ed432b1f25cafc6e1e5ad21e55a8"
+    },
+    {
+      "arm": "direct-v2-1",
+      "summary": {
+        "solver": "direct",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.174960330739301e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "128",
+        "pcg_tolerance": "1.0e-12",
+        "solver_seconds": "45.254083",
+        "total_seconds": "45.473137",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/direct-v2-1/model"
+      },
+      "wall_seconds": 45.49,
+      "peak_rss_kib": 161692,
+      "exit_status": 0,
+      "accepted_lm": 5,
+      "successful_pcg": 0,
+      "pcg_failure_counts": {
+        "MaxIterations": 0,
+        "ResidualCheckFailed": 0,
+        "NonPositiveCurvature": 0
+      },
+      "output_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "7b5445164e61442b6e1c60128ac4a72b5d192dc550b09b4fb5f076c623659e06",
+        "points3D.txt": "ee82a3ad583b96179a8310f6e75224125ef83eda60ceab481304c59a7e43b8f5"
+      },
+      "log_sha256": "a4dab9f44baaee9e67e3e77fb30e5234b67942566a7ff08526f08c15b35c5957",
+      "time_sha256": "e7651fd3a53b1ee8f112597d0aa7b924aa7ab794add2598a03758d89933d1220"
+    },
+    {
+      "arm": "matrix-free-512-strict-v2-1",
+      "summary": {
+        "solver": "matrix-free",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.264190824771856e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "512",
+        "pcg_tolerance": "1.0e-12",
+        "solver_seconds": "17.587501",
+        "total_seconds": "17.809432",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-strict-v2-1/model"
+      },
+      "wall_seconds": 17.81,
+      "peak_rss_kib": 84568,
+      "exit_status": 0,
+      "accepted_lm": 3,
+      "successful_pcg": 3,
+      "pcg_failure_counts": {
+        "MaxIterations": 10,
+        "ResidualCheckFailed": 7,
+        "NonPositiveCurvature": 0
+      },
+      "output_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "95fb935b9e9eb4ad61bfea1d7ab94ca4ecf08521b455619944c31cd4beafe284",
+        "points3D.txt": "f69b84ef240e2a1eb5167e8df71941b9f3f154d20ef21870f610303e2ef9f8fc"
+      },
+      "log_sha256": "c440ecf29af54fc3c5a8e4d5db9009fa0cf7796cf9e29570ae8d320a8d86cfb4",
+      "time_sha256": "5891350185bb98347e96c75bc78f1a34f1a53011d14c1f74e8a66ce820d4f365"
+    },
+    {
+      "arm": "matrix-free-512-rel1e8-v2-2",
+      "summary": {
+        "solver": "matrix-free",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.180705543689159e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "512",
+        "pcg_relative_tolerance": "1.00000000000000002e-8",
+        "pcg_absolute_tolerance": "9.99999999999999980e-13",
+        "solver_seconds": "20.057566",
+        "total_seconds": "20.282478",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-rel1e8-v2-2/model"
+      },
+      "wall_seconds": 20.29,
+      "peak_rss_kib": 84564,
+      "exit_status": 0,
+      "accepted_lm": 3,
+      "successful_pcg": 3,
+      "pcg_failure_counts": {
+        "MaxIterations": 10,
+        "ResidualCheckFailed": 7,
+        "NonPositiveCurvature": 0
+      },
+      "output_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "dfc2dba4c21f4d5f31ffd8ac40f405c17476e4251ec630cd9806668e81252425",
+        "points3D.txt": "86242e11eb98dd920eda04af59f17c6fab4d79f257cbd7679421281e03a43e10"
+      },
+      "log_sha256": "3d1706c602dc47c93e8686b117d6298465c142585ad20595f0ddce2112d6589c",
+      "time_sha256": "86c58520d3ba10dc2e4416e66c8ce50aae8ea5f7f93f6381088cc2d119ce3546"
+    },
+    {
+      "arm": "direct-v2-2",
+      "summary": {
+        "solver": "direct",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.174960330739301e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "128",
+        "pcg_tolerance": "1.0e-12",
+        "solver_seconds": "45.128237",
+        "total_seconds": "45.354299",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/direct-v2-2/model"
+      },
+      "wall_seconds": 45.37,
+      "peak_rss_kib": 161932,
+      "exit_status": 0,
+      "accepted_lm": 5,
+      "successful_pcg": 0,
+      "pcg_failure_counts": {
+        "MaxIterations": 0,
+        "ResidualCheckFailed": 0,
+        "NonPositiveCurvature": 0
+      },
+      "output_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "7b5445164e61442b6e1c60128ac4a72b5d192dc550b09b4fb5f076c623659e06",
+        "points3D.txt": "ee82a3ad583b96179a8310f6e75224125ef83eda60ceab481304c59a7e43b8f5"
+      },
+      "log_sha256": "f42c00f6bf724afeb19106b8ed014c78279e31126f51930bcbd477c6e3494d05",
+      "time_sha256": "46fd43ba723eb093633d448b4c660a4aa2d09af483bd7279463e950a4ee3a729"
+    },
+    {
+      "arm": "matrix-free-512-strict-v2-2",
+      "summary": {
+        "solver": "matrix-free",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.264190824771856e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "512",
+        "pcg_tolerance": "1.0e-12",
+        "solver_seconds": "18.069048",
+        "total_seconds": "18.290045",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-strict-v2-2/model"
+      },
+      "wall_seconds": 18.3,
+      "peak_rss_kib": 84400,
+      "exit_status": 0,
+      "accepted_lm": 3,
+      "successful_pcg": 3,
+      "pcg_failure_counts": {
+        "MaxIterations": 10,
+        "ResidualCheckFailed": 7,
+        "NonPositiveCurvature": 0
+      },
+      "output_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "95fb935b9e9eb4ad61bfea1d7ab94ca4ecf08521b455619944c31cd4beafe284",
+        "points3D.txt": "f69b84ef240e2a1eb5167e8df71941b9f3f154d20ef21870f610303e2ef9f8fc"
+      },
+      "log_sha256": "23ad34adf75c85bc8d6ee0bc7fae2d80ee74cebb65ed54e6910f6611088ccab5",
+      "time_sha256": "4c6f1a731035a0ee08ddb26239316beb8630aa7752f514944947a9f89e53fb63"
+    }
+  ],
+  "unique_numerical_traces": {
+    "matrix-free-512-rel1e8-v2-1": [
+      "lm_trace solver=matrix-free iteration=0 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e-3 accepted=false",
+      "lm_trace solver=matrix-free iteration=1 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e-2 accepted=false",
+      "lm_trace solver=matrix-free iteration=2 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e-1 accepted=false",
+      "lm_trace solver=matrix-free iteration=3 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e0 accepted=false",
+      "lm_trace solver=matrix-free iteration=4 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e1 accepted=false",
+      "lm_trace solver=matrix-free iteration=5 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e2 accepted=false",
+      "lm_trace solver=matrix-free iteration=6 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e3 accepted=false",
+      "lm_trace solver=matrix-free iteration=7 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e4 accepted=false",
+      "lm_trace solver=matrix-free iteration=8 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e5 accepted=false",
+      "lm_trace solver=matrix-free iteration=9 cost_before=1.265103987573094e5 cost_after=1.180844045450868e5 pose_step=4.224871206904906e-3 landmark_step=2.631544399717766e-2 lambda=1.000000000000000e5 accepted=true",
+      "lm_trace solver=matrix-free iteration=10 cost_before=1.180844045450868e5 cost_after=1.180844045450868e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e5 accepted=false",
+      "lm_trace solver=matrix-free iteration=11 cost_before=1.180844045450868e5 cost_after=1.180844045450868e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e6 accepted=false",
+      "lm_trace solver=matrix-free iteration=12 cost_before=1.180844045450868e5 cost_after=1.180844045450868e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e7 accepted=false",
+      "lm_trace solver=matrix-free iteration=13 cost_before=1.180844045450868e5 cost_after=1.180844045450868e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e8 accepted=false",
+      "lm_trace solver=matrix-free iteration=14 cost_before=1.180844045450868e5 cost_after=1.180844045450868e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e9 accepted=false",
+      "lm_trace solver=matrix-free iteration=15 cost_before=1.180844045450868e5 cost_after=1.180844045450868e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "lm_trace solver=matrix-free iteration=16 cost_before=1.180844045450868e5 cost_after=1.180705732385068e5 pose_step=1.915888014496327e-7 landmark_step=3.714249122399901e-7 lambda=1.000000000000000e10 accepted=true",
+      "lm_trace solver=matrix-free iteration=17 cost_before=1.180705732385068e5 cost_after=1.180705732385068e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "lm_trace solver=matrix-free iteration=18 cost_before=1.180705732385068e5 cost_after=1.180705543689159e5 pose_step=1.132389546225329e-7 landmark_step=3.696489205215167e-7 lambda=1.000000000000000e10 accepted=true",
+      "lm_trace solver=matrix-free iteration=19 cost_before=1.180705543689159e5 cost_after=1.180705543689159e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "pcg_trace solver=matrix-free iteration=0 pcg_iterations=512 residual=3.183459481943091e2 target=7.354716589947665e-3 failure=MaxIterations { iterations: 512, recursive_norm: 318.34634181495545, residual_norm: 318.3459481943091, target: 0.007354716589947665 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=1 pcg_iterations=512 residual=2.844788866066306e2 target=7.354098809332720e-3 failure=MaxIterations { iterations: 512, recursive_norm: 284.47890916139613, residual_norm: 284.4788866066306, target: 0.00735409880933272 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=2 pcg_iterations=512 residual=2.169265982217514e2 target=7.354410841836482e-3 failure=MaxIterations { iterations: 512, recursive_norm: 216.92485350372925, residual_norm: 216.92659822175145, target: 0.007354410841836482 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=3 pcg_iterations=512 residual=1.705613019339233e1 target=7.354387668322976e-3 failure=MaxIterations { iterations: 512, recursive_norm: 17.056026567242803, residual_norm: 17.056130193392327, target: 0.0073543876683229755 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=4 pcg_iterations=512 residual=5.991331616682434e0 target=7.355181943007929e-3 failure=MaxIterations { iterations: 512, recursive_norm: 5.990926086468494, residual_norm: 5.991331616682434, target: 0.007355181943007929 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=5 pcg_iterations=512 residual=6.229435210169789e2 target=7.360127322637582e-3 failure=MaxIterations { iterations: 512, recursive_norm: 622.943795690782, residual_norm: 622.9435210169789, target: 0.007360127322637582 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=6 pcg_iterations=512 residual=3.555112520606723e1 target=7.365750907511965e-3 failure=MaxIterations { iterations: 512, recursive_norm: 35.551112473132186, residual_norm: 35.55112520606723, target: 0.007365750907511965 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=7 pcg_iterations=512 residual=3.237583323469034e-1 target=7.370199471449998e-3 failure=MaxIterations { iterations: 512, recursive_norm: 0.3237785392035484, residual_norm: 0.32375833234690343, target: 0.007370199471449998 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=8 pcg_iterations=421 residual=8.727104293979233e-3 target=7.370397691026571e-3 failure=ResidualCheckFailed { iterations: 421, recursive_norm: 0.005504151043863519, true_norm: 0.008727104293979233, target: 0.007370397691026571 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=9 pcg_iterations=319 residual=3.364104038915995e-3 target=7.363379620295508e-3 failure=none max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=10 pcg_iterations=512 residual=1.902124975725595e1 target=1.548074619934223e-3 failure=MaxIterations { iterations: 512, recursive_norm: 5.283437810753204, residual_norm: 19.02124975725595, target: 0.001548074619934223 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=11 pcg_iterations=512 residual=5.934134241791719e0 target=1.506266137372246e-3 failure=MaxIterations { iterations: 512, recursive_norm: 0.11583186588125434, residual_norm: 5.934134241791719, target: 0.0015062661373722456 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=12 pcg_iterations=484 residual=1.164026433164512e-1 target=1.490407389686785e-3 failure=ResidualCheckFailed { iterations: 484, recursive_norm: 0.001371141421110788, true_norm: 0.1164026433164512, target: 0.0014904073896867848 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=13 pcg_iterations=173 residual=1.031472513450191e-1 target=1.501194134780440e-3 failure=ResidualCheckFailed { iterations: 173, recursive_norm: 0.001044713939624864, true_norm: 0.10314725134501913, target: 0.00150119413478044 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=14 pcg_iterations=76 residual=7.728860967583072e-3 target=1.543479459527550e-3 failure=ResidualCheckFailed { iterations: 76, recursive_norm: 0.001312922052227743, true_norm: 0.0077288609675830715, target: 0.0015434794595275496 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=15 pcg_iterations=32 residual=3.712745750302771e-3 target=1.925905037137261e-3 failure=ResidualCheckFailed { iterations: 32, recursive_norm: 0.001745285813219318, true_norm: 0.003712745750302771, target: 0.0019259050371372615 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=16 pcg_iterations=20 residual=3.511705759773503e-4 target=2.334287731529428e-3 failure=none max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=17 pcg_iterations=37 residual=4.229258545182997e-4 target=5.072650850162920e-5 failure=ResidualCheckFailed { iterations: 37, recursive_norm: 3.877415458963732e-5, true_norm: 0.0004229258545182997, target: 5.07265085016292e-5 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=18 pcg_iterations=20 residual=4.173163838559329e-5 target=5.362289663263277e-5 failure=none max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=19 pcg_iterations=34 residual=4.360039251364158e-5 target=4.158790590164419e-5 failure=ResidualCheckFailed { iterations: 34, recursive_norm: 2.2217701853429952e-5, true_norm: 4.360039251364158e-5, target: 4.158790590164419e-5 } max_pcg_iterations=512"
+    ],
+    "direct-v2-1": [
+      "lm_trace solver=direct iteration=0 cost_before=1.265103987573094e5 cost_after=1.180487562191261e5 pose_step=4.539863504482840e-2 landmark_step=9.543853282311060e2 lambda=1.000000000000000e-3 accepted=false",
+      "lm_trace solver=direct iteration=1 cost_before=1.265103987573094e5 cost_after=1.180398342196572e5 pose_step=4.525615867988825e-2 landmark_step=1.921394697101112e2 lambda=1.000000000000000e-2 accepted=false",
+      "lm_trace solver=direct iteration=2 cost_before=1.265103987573094e5 cost_after=1.256582579826467e5 pose_step=4.422410463690069e-2 landmark_step=2.616518820743931e1 lambda=1.000000000000000e-1 accepted=false",
+      "lm_trace solver=direct iteration=3 cost_before=1.265103987573094e5 cost_after=1.205806612989509e5 pose_step=4.213959723166222e-2 landmark_step=1.429394158145234e1 lambda=1.000000000000000e0 accepted=false",
+      "lm_trace solver=direct iteration=4 cost_before=1.265103987573094e5 cost_after=1.159073791020013e5 pose_step=3.680777736735848e-2 landmark_step=2.581527574433523e0 lambda=1.000000000000000e1 accepted=false",
+      "lm_trace solver=direct iteration=5 cost_before=1.265103987573094e5 cost_after=1.146413621556863e5 pose_step=2.483729149732559e-2 landmark_step=1.294432568328994e0 lambda=1.000000000000000e2 accepted=false",
+      "lm_trace solver=direct iteration=6 cost_before=1.265103987573094e5 cost_after=1.149267972713589e5 pose_step=1.648982300583549e-2 landmark_step=3.756511262902025e-1 lambda=1.000000000000000e3 accepted=false",
+      "lm_trace solver=direct iteration=7 cost_before=1.265103987573094e5 cost_after=1.162868502582037e5 pose_step=1.170108298126295e-2 landmark_step=2.131042068973718e-1 lambda=1.000000000000000e4 accepted=false",
+      "lm_trace solver=direct iteration=8 cost_before=1.265103987573094e5 cost_after=1.167856301155864e5 pose_step=7.011114571557374e-3 landmark_step=9.516736448089731e-2 lambda=1.000000000000000e5 accepted=false",
+      "lm_trace solver=direct iteration=9 cost_before=1.265103987573094e5 cost_after=1.180844047208355e5 pose_step=4.224871200904737e-3 landmark_step=2.631544396998766e-2 lambda=1.000000000000000e5 accepted=true",
+      "lm_trace solver=direct iteration=10 cost_before=1.180844047208355e5 cost_after=1.166783656404518e5 pose_step=4.935727643026278e-3 landmark_step=8.753038594263313e-2 lambda=1.000000000000000e5 accepted=false",
+      "lm_trace solver=direct iteration=11 cost_before=1.180844047208355e5 cost_after=1.175911937289642e5 pose_step=1.370245093610298e-3 landmark_step=1.493247846520461e-2 lambda=1.000000000000000e5 accepted=true",
+      "lm_trace solver=direct iteration=12 cost_before=1.175911937289642e5 cost_after=1.166084491111593e5 pose_step=4.000120376280353e-3 landmark_step=8.078352147541841e-2 lambda=1.000000000000000e5 accepted=false",
+      "lm_trace solver=direct iteration=13 cost_before=1.175911937289642e5 cost_after=1.173456715827083e5 pose_step=9.695098810938158e-4 landmark_step=1.357564066994452e-2 lambda=1.000000000000000e6 accepted=false",
+      "lm_trace solver=direct iteration=14 cost_before=1.175911937289642e5 cost_after=1.175564729990976e5 pose_step=1.278517036264812e-4 landmark_step=1.462150029192773e-3 lambda=1.000000000000000e6 accepted=true",
+      "lm_trace solver=direct iteration=15 cost_before=1.175564729990976e5 cost_after=1.173246173211333e5 pose_step=9.355473714641711e-4 landmark_step=1.344603569926753e-2 lambda=1.000000000000000e6 accepted=false",
+      "lm_trace solver=direct iteration=16 cost_before=1.175564729990976e5 cost_after=1.175251522203322e5 pose_step=1.206931845915765e-4 landmark_step=1.447323667142439e-3 lambda=1.000000000000000e6 accepted=true",
+      "lm_trace solver=direct iteration=17 cost_before=1.175251522203322e5 cost_after=1.173044403491726e5 pose_step=9.056791024117453e-4 landmark_step=1.331867453835742e-2 lambda=1.000000000000000e6 accepted=false",
+      "lm_trace solver=direct iteration=18 cost_before=1.175251522203322e5 cost_after=1.174960330739301e5 pose_step=1.149602830621804e-4 landmark_step=1.432876110685110e-3 lambda=1.000000000000000e6 accepted=true",
+      "lm_trace solver=direct iteration=19 cost_before=1.174960330739301e5 cost_after=1.172850424966106e5 pose_step=8.788071185599755e-4 landmark_step=1.319342534520128e-2 lambda=1.000000000000000e6 accepted=false",
+      "pcg_trace solver=direct status=not-applicable"
+    ],
+    "matrix-free-512-strict-v2-1": [
+      "lm_trace solver=matrix-free iteration=0 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e-3 accepted=false",
+      "lm_trace solver=matrix-free iteration=1 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e-2 accepted=false",
+      "lm_trace solver=matrix-free iteration=2 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e-1 accepted=false",
+      "lm_trace solver=matrix-free iteration=3 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e0 accepted=false",
+      "lm_trace solver=matrix-free iteration=4 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e1 accepted=false",
+      "lm_trace solver=matrix-free iteration=5 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e2 accepted=false",
+      "lm_trace solver=matrix-free iteration=6 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e3 accepted=false",
+      "lm_trace solver=matrix-free iteration=7 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e4 accepted=false",
+      "lm_trace solver=matrix-free iteration=8 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e5 accepted=false",
+      "lm_trace solver=matrix-free iteration=9 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e6 accepted=false",
+      "lm_trace solver=matrix-free iteration=10 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e7 accepted=false",
+      "lm_trace solver=matrix-free iteration=11 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e8 accepted=false",
+      "lm_trace solver=matrix-free iteration=12 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e9 accepted=false",
+      "lm_trace solver=matrix-free iteration=13 cost_before=1.265103987573094e5 cost_after=1.265103987573094e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "lm_trace solver=matrix-free iteration=14 cost_before=1.265103987573094e5 cost_after=1.264774281344812e5 pose_step=8.681684126820639e-6 landmark_step=1.595127480032178e-5 lambda=1.000000000000000e10 accepted=true",
+      "lm_trace solver=matrix-free iteration=15 cost_before=1.264774281344812e5 cost_after=1.264774281344812e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "lm_trace solver=matrix-free iteration=16 cost_before=1.264774281344812e5 cost_after=1.264477773308437e5 pose_step=8.096669795783534e-6 landmark_step=1.579383665620511e-5 lambda=1.000000000000000e10 accepted=true",
+      "lm_trace solver=matrix-free iteration=17 cost_before=1.264477773308437e5 cost_after=1.264477773308437e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "lm_trace solver=matrix-free iteration=18 cost_before=1.264477773308437e5 cost_after=1.264190824771856e5 pose_step=7.563038766157636e-6 landmark_step=1.563800812369709e-5 lambda=1.000000000000000e10 accepted=true",
+      "lm_trace solver=matrix-free iteration=19 cost_before=1.264190824771856e5 cost_after=1.264190824771856e5 pose_step=0.000000000000000e0 landmark_step=0.000000000000000e0 lambda=1.000000000000000e10 accepted=false",
+      "pcg_trace solver=matrix-free iteration=0 pcg_iterations=512 residual=3.183459481943091e2 target=7.354716589947665e-7 failure=MaxIterations { iterations: 512, recursive_norm: 318.34634181495545, residual_norm: 318.3459481943091, target: 7.354716589947665e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=1 pcg_iterations=512 residual=2.844788866066306e2 target=7.354098809332719e-7 failure=MaxIterations { iterations: 512, recursive_norm: 284.47890916139613, residual_norm: 284.4788866066306, target: 7.354098809332719e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=2 pcg_iterations=512 residual=2.169265982217514e2 target=7.354410841836482e-7 failure=MaxIterations { iterations: 512, recursive_norm: 216.92485350372925, residual_norm: 216.92659822175145, target: 7.354410841836482e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=3 pcg_iterations=512 residual=1.705613019339233e1 target=7.354387668322975e-7 failure=MaxIterations { iterations: 512, recursive_norm: 17.056026567242803, residual_norm: 17.056130193392327, target: 7.354387668322975e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=4 pcg_iterations=512 residual=5.991331616682434e0 target=7.355181943007929e-7 failure=MaxIterations { iterations: 512, recursive_norm: 5.990926086468494, residual_norm: 5.991331616682434, target: 7.355181943007929e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=5 pcg_iterations=512 residual=6.229435210169789e2 target=7.360127322637582e-7 failure=MaxIterations { iterations: 512, recursive_norm: 622.943795690782, residual_norm: 622.9435210169789, target: 7.360127322637582e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=6 pcg_iterations=512 residual=3.555112520606723e1 target=7.365750907511965e-7 failure=MaxIterations { iterations: 512, recursive_norm: 35.551112473132186, residual_norm: 35.55112520606723, target: 7.365750907511965e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=7 pcg_iterations=512 residual=3.237583323469034e-1 target=7.370199471449997e-7 failure=MaxIterations { iterations: 512, recursive_norm: 0.3237785392035484, residual_norm: 0.32375833234690343, target: 7.370199471449997e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=8 pcg_iterations=512 residual=1.882516574781104e-3 target=7.370397691026571e-7 failure=MaxIterations { iterations: 512, recursive_norm: 0.0005685723201100786, residual_norm: 0.0018825165747811039, target: 7.370397691026571e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=9 pcg_iterations=512 residual=9.078640699610080e-4 target=7.363379620295508e-7 failure=MaxIterations { iterations: 512, recursive_norm: 4.633822922386621e-6, residual_norm: 0.000907864069961008, target: 7.363379620295508e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=10 pcg_iterations=375 residual=1.347520099264624e-3 target=7.356678741550637e-7 failure=ResidualCheckFailed { iterations: 375, recursive_norm: 6.94099001274054e-7, true_norm: 0.001347520099264624, target: 7.356678741550637e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=11 pcg_iterations=179 residual=2.946754161815764e-4 target=7.366138428285797e-7 failure=ResidualCheckFailed { iterations: 179, recursive_norm: 6.027435734645563e-7, true_norm: 0.0002946754161815764, target: 7.366138428285797e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=12 pcg_iterations=99 residual=8.662572316726888e-5 target=7.375210125720625e-7 failure=ResidualCheckFailed { iterations: 99, recursive_norm: 4.935331585454053e-7, true_norm: 8.662572316726888e-5, target: 7.375210125720625e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=13 pcg_iterations=43 residual=1.297911489722349e-5 target=7.377609206732811e-7 failure=ResidualCheckFailed { iterations: 43, recursive_norm: 4.977964122022111e-7, true_norm: 1.2979114897223494e-5, target: 7.377609206732811e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=14 pcg_iterations=22 residual=5.639331821966476e-7 target=7.377914999757461e-7 failure=none max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=15 pcg_iterations=44 residual=1.237003450702291e-5 target=3.128890921393035e-7 failure=ResidualCheckFailed { iterations: 44, recursive_norm: 1.709251592964516e-7, true_norm: 1.2370034507022906e-5, target: 3.1288909213930355e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=16 pcg_iterations=22 residual=2.373982700608563e-7 target=3.129915475197834e-7 failure=none max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=17 pcg_iterations=45 residual=1.432440121007402e-5 target=3.058033388754850e-7 failure=ResidualCheckFailed { iterations: 45, recursive_norm: 5.029446703792583e-8, true_norm: 1.4324401210074021e-5, target: 3.05803338875485e-7 } max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=18 pcg_iterations=22 residual=1.465141450675378e-7 target=3.058711641361349e-7 failure=none max_pcg_iterations=512",
+      "pcg_trace solver=matrix-free iteration=19 pcg_iterations=44 residual=6.755746401541811e-6 target=2.996034286711816e-7 failure=ResidualCheckFailed { iterations: 44, recursive_norm: 8.962558343168729e-8, true_norm: 6.755746401541811e-6, target: 2.9960342867118155e-7 } max_pcg_iterations=512"
+    ]
+  },
+  "repeat_checks": [
+    {
+      "first": "matrix-free-512-rel1e8-v2-1",
+      "repeat": "matrix-free-512-rel1e8-v2-2",
+      "all_three_model_hashes_exact": true,
+      "all_numerical_trace_lines_exact": true
+    },
+    {
+      "first": "direct-v2-1",
+      "repeat": "direct-v2-2",
+      "all_three_model_hashes_exact": true,
+      "all_numerical_trace_lines_exact": true
+    },
+    {
+      "first": "matrix-free-512-strict-v2-1",
+      "repeat": "matrix-free-512-strict-v2-2",
+      "all_three_model_hashes_exact": true,
+      "all_numerical_trace_lines_exact": true
+    }
+  ],
+  "legacy_checks": {
+    "direct_model_and_all_lm_lines_exact_with_pr79_direct_serial_1": true,
+    "strict_model_and_all_lm_pcg_lines_exact_with_pr79_matrix_free_512_serial_1": true,
+    "default_summary_layout_unchanged": true,
+    "final_input_four_source_hashes_rechecked": true
+  },
+  "audit_provenance": {
+    "geometry_script": "scripts/audit_colmap_pinhole_model.py",
+    "geometry_sha256": "79370647e9acd9a1fc9334502ea900c161c550d06d4e523efaf8abb250f1dc54",
+    "strict_identity_method": "Independent read-only Python row-by-row zip_longest comparison: camera bytes; image ID/camera/name/order and all POINTS2D tokens; point ID/RGB/track tail tokens/order; counts and finite ERROR. Camera centres/rotation matrices and XYZ are compared numerically; frame membership is resolved by image name through the rig manifest.",
+    "scorer": "scripts/score_openloris_model.py",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "repeats": "Audit each unique model; repeat models have all three hashes equal."
+  },
+  "independent_audits": {
+    "matrix-free-512-rel1e8-v2-1": {
+      "geometry": {
+        "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-rel1e8-v2-1/model",
+        "image_poses": 1000,
+        "supported_images": 1000,
+        "unsupported_image_ids": [],
+        "landmarks": 4716,
+        "observations": 130900,
+        "mean_reprojection_px": 0.691588658326868,
+        "observation_weighted_mean_reprojection_px": 0.691588658326868,
+        "point_weighted_mean_reprojection_px": 0.7506696077477801,
+        "max_track_mean_reprojection_px": 3.443407941715984,
+        "max_reprojection_px": 4.84008923981911,
+        "max_stored_mean_difference_px": 5.90660026228082e-9,
+        "nonpositive_depth_observations": 0,
+        "tracks_with_multiple_keypoints_in_one_image": 0,
+        "excess_same_image_track_observations": 0,
+        "bidirectional_references_valid": true,
+        "rig": {
+          "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+          "rig_frames": 500,
+          "supported_rig_frames": 500,
+          "unsupported_rig_frame_ids": [],
+          "max_inferred_rig_center_disagreement_m": 3.694445030094784e-15,
+          "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+          "fixed_sensor_extrinsics_valid": true,
+          "track_connected_components": 1,
+          "track_connected_component_sizes": [
+            500
+          ],
+          "track_connected_component_frame_ranges": [
+            [
+              0,
+              499
+            ]
+          ]
+        }
+      },
+      "identity": {
+        "before": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+        "after": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-rel1e8-v2-1/model",
+        "cameras_byte_exact": true,
+        "image_identity_and_order_exact": true,
+        "full_points2d_tokens_exact": true,
+        "point_ids_rgb_track_tokens_and_order_exact": true,
+        "images": 1000,
+        "keypoints": 361170,
+        "landmarks": 4716,
+        "observations": 130900,
+        "numerically_changed_image_poses": 998,
+        "max_camera_center_delta_m": 0.0029604113979699075,
+        "max_camera_rotation_matrix_delta_frobenius": 0.0027812854564264475,
+        "max_landmark_delta_m": 0.02631599674450293,
+        "fixed_frame_camera_center_delta_m": 7.713637039264346e-13,
+        "fixed_frame_camera_rotation_matrix_delta_frobenius": 1.9406908357248486e-12,
+        "output_sha256": {
+          "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+          "images.txt": "dfc2dba4c21f4d5f31ffd8ac40f405c17476e4251ec630cd9806668e81252425",
+          "points3D.txt": "86242e11eb98dd920eda04af59f17c6fab4d79f257cbd7679421281e03a43e10"
+        }
+      },
+      "trajectory": {
+        "rmse_m": 0.026608055174816774,
+        "p95_m": 0.04109998478546261,
+        "max_m": 0.08094213975864564,
+        "registered": 1000,
+        "gt_scored": 308,
+        "sim3_scale": 1.117173288626517,
+        "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+        "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+        "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+        "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+        "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69",
+        "max_gap_seconds": 0.1,
+        "alignment": "one Sim3 for the sole component; GT post-only"
+      }
+    },
+    "direct-v2-1": {
+      "geometry": {
+        "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/direct-v2-1/model",
+        "image_poses": 1000,
+        "supported_images": 1000,
+        "unsupported_image_ids": [],
+        "landmarks": 4716,
+        "observations": 130900,
+        "mean_reprojection_px": 0.6892603543319799,
+        "observation_weighted_mean_reprojection_px": 0.6892603543319799,
+        "point_weighted_mean_reprojection_px": 0.7498344863813009,
+        "max_track_mean_reprojection_px": 3.40576377483283,
+        "max_reprojection_px": 4.937791375261053,
+        "max_stored_mean_difference_px": 1.357510621708552e-9,
+        "nonpositive_depth_observations": 0,
+        "tracks_with_multiple_keypoints_in_one_image": 0,
+        "excess_same_image_track_observations": 0,
+        "bidirectional_references_valid": true,
+        "rig": {
+          "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+          "rig_frames": 500,
+          "supported_rig_frames": 500,
+          "unsupported_rig_frame_ids": [],
+          "max_inferred_rig_center_disagreement_m": 3.8735455602220786e-15,
+          "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+          "fixed_sensor_extrinsics_valid": true,
+          "track_connected_components": 1,
+          "track_connected_component_sizes": [
+            500
+          ],
+          "track_connected_component_frame_ranges": [
+            [
+              0,
+              499
+            ]
+          ]
+        }
+      },
+      "identity": {
+        "before": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+        "after": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/direct-v2-1/model",
+        "cameras_byte_exact": true,
+        "image_identity_and_order_exact": true,
+        "full_points2d_tokens_exact": true,
+        "point_ids_rgb_track_tokens_and_order_exact": true,
+        "images": 1000,
+        "keypoints": 361170,
+        "landmarks": 4716,
+        "observations": 130900,
+        "numerically_changed_image_poses": 998,
+        "max_camera_center_delta_m": 0.0034355700862467083,
+        "max_camera_rotation_matrix_delta_frobenius": 0.0034958471069869465,
+        "max_landmark_delta_m": 0.04260913017134739,
+        "fixed_frame_camera_center_delta_m": 7.713637039264346e-13,
+        "fixed_frame_camera_rotation_matrix_delta_frobenius": 1.9406908357248486e-12,
+        "output_sha256": {
+          "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+          "images.txt": "7b5445164e61442b6e1c60128ac4a72b5d192dc550b09b4fb5f076c623659e06",
+          "points3D.txt": "ee82a3ad583b96179a8310f6e75224125ef83eda60ceab481304c59a7e43b8f5"
+        }
+      },
+      "trajectory": {
+        "rmse_m": 0.026518520743846325,
+        "p95_m": 0.04098909824472861,
+        "max_m": 0.0810254275753117,
+        "registered": 1000,
+        "gt_scored": 308,
+        "sim3_scale": 1.1168833040035575,
+        "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+        "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+        "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+        "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+        "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69",
+        "max_gap_seconds": 0.1,
+        "alignment": "one Sim3 for the sole component; GT post-only"
+      }
+    },
+    "matrix-free-512-strict-v2-1": {
+      "geometry": {
+        "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-strict-v2-1/model",
+        "image_poses": 1000,
+        "supported_images": 1000,
+        "unsupported_image_ids": [],
+        "landmarks": 4716,
+        "observations": 130900,
+        "mean_reprojection_px": 0.7203140719241329,
+        "observation_weighted_mean_reprojection_px": 0.7203140719241329,
+        "point_weighted_mean_reprojection_px": 0.764180124125914,
+        "max_track_mean_reprojection_px": 3.5601354391089965,
+        "max_reprojection_px": 3.997840133744877,
+        "max_stored_mean_difference_px": 5.22418471329833e-11,
+        "nonpositive_depth_observations": 0,
+        "tracks_with_multiple_keypoints_in_one_image": 0,
+        "excess_same_image_track_observations": 0,
+        "bidirectional_references_valid": true,
+        "rig": {
+          "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+          "rig_frames": 500,
+          "supported_rig_frames": 500,
+          "unsupported_rig_frame_ids": [],
+          "max_inferred_rig_center_disagreement_m": 4.110189335222113e-15,
+          "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+          "fixed_sensor_extrinsics_valid": true,
+          "track_connected_components": 1,
+          "track_connected_component_sizes": [
+            500
+          ],
+          "track_connected_component_frame_ranges": [
+            [
+              0,
+              499
+            ]
+          ]
+        }
+      },
+      "identity": {
+        "before": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+        "after": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-strict-v2-1/model",
+        "cameras_byte_exact": true,
+        "image_identity_and_order_exact": true,
+        "full_points2d_tokens_exact": true,
+        "point_ids_rgb_track_tokens_and_order_exact": true,
+        "images": 1000,
+        "keypoints": 361170,
+        "landmarks": 4716,
+        "observations": 130900,
+        "numerically_changed_image_poses": 998,
+        "max_camera_center_delta_m": 0.000024330631313432282,
+        "max_camera_rotation_matrix_delta_frobenius": 0.000015827411447039907,
+        "max_landmark_delta_m": 0.00004738311618585106,
+        "fixed_frame_camera_center_delta_m": 7.713637039264346e-13,
+        "fixed_frame_camera_rotation_matrix_delta_frobenius": 1.9406908357248486e-12,
+        "output_sha256": {
+          "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+          "images.txt": "95fb935b9e9eb4ad61bfea1d7ab94ca4ecf08521b455619944c31cd4beafe284",
+          "points3D.txt": "f69b84ef240e2a1eb5167e8df71941b9f3f154d20ef21870f610303e2ef9f8fc"
+        }
+      },
+      "trajectory": {
+        "rmse_m": 0.026702677828534166,
+        "p95_m": 0.04134738254716512,
+        "max_m": 0.0804587860151056,
+        "registered": 1000,
+        "gt_scored": 308,
+        "sim3_scale": 1.1176073748449953,
+        "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+        "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+        "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+        "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+        "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69",
+        "max_gap_seconds": 0.1,
+        "alignment": "one Sim3 for the sole component; GT post-only"
+      }
+    }
+  },
+  "direct_vs_relative_delta": {
+    "before": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/direct-v2-1/model",
+    "after": "/home/sasaki/datasets/openloris/corridor1-1-m8-relative-pcg-tolerance-v1/matrix-free-512-rel1e8-v2-1/model",
+    "cameras_byte_exact": true,
+    "image_identity_and_order_exact": true,
+    "full_points2d_tokens_exact": true,
+    "point_ids_rgb_track_tokens_and_order_exact": true,
+    "images": 1000,
+    "keypoints": 361170,
+    "landmarks": 4716,
+    "observations": 130900,
+    "numerically_changed_image_poses": 998,
+    "max_camera_center_delta_m": 0.001097629707302096,
+    "max_camera_rotation_matrix_delta_frobenius": 0.0007575211981974536,
+    "max_landmark_delta_m": 0.01927448120429396,
+    "fixed_frame_camera_center_delta_m": 0,
+    "fixed_frame_camera_rotation_matrix_delta_frobenius": 0,
+    "output_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "dfc2dba4c21f4d5f31ffd8ac40f405c17476e4251ec630cd9806668e81252425",
+      "points3D.txt": "86242e11eb98dd920eda04af59f17c6fab4d79f257cbd7679421281e03a43e10"
+    }
+  },
+  "exploratory_pre_summary_fix": {
+    "arm": "matrix-free-512-rel1e8-1",
+    "implementation_commit": "5c933d6f55580b0299519eba29310c64d0f33fc6",
+    "binary_sha256": "f7f81dd86d2ec4ee6a4bb2730d534508acbd3e177cc3fc4fa165707b28920be9",
+    "wall_seconds": 24.27,
+    "peak_rss_kib": 84248,
+    "numerical_trace_and_three_model_bytes_exact_with_v2": true,
+    "note": "Initial configuration correctly recorded relative1e-8/absolute1e-12, but final legacy pcg_tolerance field misleadingly said1e-12. Fixed explicit summary and reran all six comparison processes with the new binary; this exploratory timing excluded from v2 comparison.",
+    "artifact_hashes": {
+      "matrix-free-512-rel1e8-1.log": "3103c450317b6f5672a2aa084ade1d697d1330a5e29f0951fae7fd0294b7be43",
+      "matrix-free-512-rel1e8-1.time": "9ba7e4fa0fa1e14504971735570fa8e5e506dc756005bd7269467687cb45edec"
+    }
+  },
+  "interpretation": [
+    "Relative1e-8 first accepts LM9 at solve lambda1e5 instead of strict LM14 at1e10. Both candidates still accept only3/20 LM steps; direct accepts5/20, all converged=false.",
+    "Relative arm improves cost, observation-mean reprojection and GT RMSE/p95 over strict, but remains worse than direct on those measures. Maximum observation error4.84009px exceeds frozen input3.99957px and strict3.99784px; it is not a universal reprojection non-regression.",
+    "All1000 images/500 frames,4716 points,130900 observations,361170 keypoints, fixed rig calibration and one connected frame component preserved; no nonpositive depths. Stored point ERROR independently agrees with recomputed means within5.91e-9px.",
+    "Same-host v2 relative wall20.19/20.29s, direct45.49/45.37s; peakRSS84564/84564 versus161692/161932KiB. Different final quality: no equivalent-quality speedup or COLMAP end-to-end claim.",
+    "The relative arm has10 MaxIterations and7 ResidualCheckFailed attempts. Tolerance change alone does not solve the finite-precision/convergence problem; strict gate remains failed and unchanged.",
+    "All three arms are below frozen COLMAP1k RMSE0.027968541677842282 and p950.042266006958647205, but this local1k post-map comparison neither establishes10k quality nor includes comparable mapper/E2E cost."
+  ],
+  "next_candidate": {
+    "status": "planned_not_implemented",
+    "name": "bounded event-triggered classical PCG residual restart",
+    "trigger": "Only recursive convergence with failing recomputed true residual; never accept without passing true residual.",
+    "mechanism": "Replace r by b-Ax and restart p=M^-1 r with recomputed rho; at most one restart within the original total512 iteration budget, no reset or extension. Keep failed steps discarded and all finite/curvature checks.",
+    "scope": "Separate default-off arm; preserve old API struct shapes and default behavior. First test same frozen systems, then full nonlinear A/B, not a10k shortcut.",
+    "memory": "Reuse existing O(N) Krylov vectors; no pose-pair matrix or history bank. Audit real allocation/RSS rather than assume scalar-only overhead.",
+    "limits": "Restart discards accumulated conjugacy and can stagnate or slow convergence. It does not directly repair MaxIterations or guarantee an attainable true-residual target.",
+    "references": [
+      "https://epubs.siam.org/doi/10.1137/S0895479895284944",
+      "https://epubs.siam.org/doi/10.1137/S1064827599353865",
+      "https://petsc.org/release/manual/ksp/"
+    ],
+    "reference_scope": "Papers support residual-gap diagnosis and controlled replacement; one event-triggered restart is an engineering hypothesis, not a reproduction of the error-bound-guided published scheme."
+  },
+  "validation": {
+    "example_tests_passed": 14,
+    "real_oracle_tests_passed": 10,
+    "real_oracle_tests_ignored": 1,
+    "python_tests_passed": 46,
+    "targeted_example_and_lib_tests_clippy_clean": true,
+    "fmt_clean": true,
+    "registry_files_validated": 189,
+    "generated_readme_claims_unchanged": true
+  }
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -110,6 +110,9 @@
 > implicit512は9.079e-4。dense参照解も同基準未達で、前処理だけが原因とは断定できません。
 > 次は物理座標・dampingを変えず、3x3 landmarkブロックのCholesky構成を別armで比較。
 > 現1e-12は診断baselineで、ユーザーの最終目的は精度・速度・省メモリです。
+> PR #81は最終CI8項目（run 34125303050）通過後、`06ca2e1`へmergeし旧branch整理済み。
+> 現在は `feat/m8-cholesky-landmark-elimination`。同じ物理damping・観測集合で
+> landmark eliminationの構成だけを変えるA/Bを実装中です。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -112,7 +112,12 @@
 > 現1e-12は診断baselineで、ユーザーの最終目的は精度・速度・省メモリです。
 > PR #81は最終CI8項目（run 34125303050）通過後、`06ca2e1`へmergeし旧branch整理済み。
 > 現在は `feat/m8-cholesky-landmark-elimination`。同じ物理damping・観測集合で
-> landmark eliminationの構成だけを変えるA/Bを実装中です。
+> landmark eliminationの構成だけを変えるA/Bは `05500bf` に実装し2回の数値一致を確認。
+> [証跡](../benchmarks/electro/m8-openloris-cholesky-landmark-elimination-v1.json)。
+> general inverseの実測非対称性は0。Choleskyもλ1e5で真残差1.215e-5 > 7.363e-7で失敗し、
+> test-onlyのまま非昇格です。次はexampleで停止条件を明示し、production general inverseの
+> PCG512 relative1e-8 / absolute1e-12を、既存strict設定・directと1k全最適化で比較します。
+> これは別設定armであり旧strict gateの合格扱いにはしません。10k・README昇格は未実施。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -118,6 +118,12 @@
 > test-onlyのまま非昇格です。次はexampleで停止条件を明示し、production general inverseの
 > PCG512 relative1e-8 / absolute1e-12を、既存strict設定・directと1k全最適化で比較します。
 > これは別設定armであり旧strict gateの合格扱いにはしません。10k・README昇格は未実施。
+> relative設定は `7b6056a` で実装・表示修正し、同一binaryで3 arm各2回の計測完了。
+> [結果](../benchmarks/electro/m8-openloris-relative-pcg-tolerance-v1.json): 新設定cost118070.554、
+> RMSE/p95 0.026608/0.041100 m、20.19/20.29 s、84,564 KiB。directより精度は未達。
+> 全支持・identity・depth・calibration保持、各repeat完全一致、旧direct/strictもPR #79一致。
+> 次候補はtrue residual再確認失敗時だけ最大1回restartする別arm（総512反復内）。
+> まだ未実装。デフォルト変更・N²状態・反復上限のリセットは行いません。
 
 **更新:** 2026-09-01
 **Repo:** `/home/sasaki/workspace/visloc-rs`

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -1043,3 +1043,50 @@ an assumed asymmetric-inverse defect. Record `Hll * inverse - I` residuals,
 original and inverse off-diagonal differences, and scale metrics before
 interpreting a change in PCG convergence. Cholesky can change rounding even
 when both inverse representations are symmetric.
+
+### Cholesky landmark elimination result (2026-09-07)
+
+[Frozen evidence](../benchmarks/electro/m8-openloris-cholesky-landmark-elimination-v1.json)
+records two release runs of implementation `05500bf`. All seventeen numerical
+report lines repeat exactly; the eleven existing lines also match PR #81.
+Original damped blocks and general inverses have zero measured asymmetry at
+all three damping values. The proposed asymmetric-inverse explanation is thus
+unsupported on this input. Cholesky changes rounding, but is not uniformly
+better: at `1e-4`, the maximum block inverse-identity residual increases from
+`2.000e-8` to `2.634e-8`.
+
+| Damping | Cap | General true residual | Cholesky true residual | Result |
+|---|---:|---:|---:|---|
+| `1e-4` | 512 | 318.346 | 5.38483 | both hit cap |
+| `1e5` | 512 | `9.079e-4` | `1.215e-5` | general hits cap; Cholesky recheck fails at 322 |
+| `1e10` | 128 / 512 | `5.639e-7` | `1.539e-8` | both pass, 22 / 23 iterations |
+
+At useful damping `1e5`, Cholesky recursive residual is `5.936e-7`, but true
+residual exceeds its `7.363e-7` target. Its dense reference's own-action
+residual improves from `0.002572` to `1.076e-5`, and original pose-normal
+equation residual from `0.001232` to `8.359e-6`. The latter is a different
+equation norm, not subject automatically to the Schur stopping threshold.
+No failed PCG iterate is applied or assigned hypothetical geometry metrics.
+At `1e10`, all 130,900 observations remain valid with identical trial cost
+126,477.42813448103; cross-method pose/landmark delta differences are only
+`2.54e-17` / `1.54e-17`. This does not establish nonlinear quality improvement.
+
+The test-only operator borrows existing cross blocks and uses the same
+Cholesky factors consistently in RHS, action, preconditioner and back-substitution.
+It audits symmetry before mirroring the lower triangle and never substitutes a
+diagonal or falls back. General setup failures still abort this diagnostic
+runner; Cholesky setup and PCG failures are reported. The frozen fixture has
+no setup failures. Two combined diagnostic processes take 80.44 / 90.64 s and
+349,472 / 349,540 KiB peak RSS on a shared host. These include all reference
+arms and are not production performance measurements. Cholesky remains
+test-only and no README claim is promoted.
+
+The next experiment exposes an example-only, explicitly logged
+`--pcg-relative-tolerance` option. Compare production general-inverse PCG512
+with relative `1e-8`, absolute `1e-12`, against the unchanged strict `1e-12`
+baseline and direct solver on the same full nonlinear 1k input. This is a
+separate stopping-policy arm, not Ceres' quadratic-progress `eta`, and not a
+retroactive pass of the strict oracle. Keep LM settings, observations and
+physical calibration fixed; audit full support, depth, identity, recomputed
+reprojection and post-only GT trajectory, plus repeated wall/RSS, before any
+10k promotion. Local BA timing alone cannot support a COLMAP end-to-end claim.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -1090,3 +1090,80 @@ retroactive pass of the strict oracle. Keep LM settings, observations and
 physical calibration fixed; audit full support, depth, identity, recomputed
 reprojection and post-only GT trajectory, plus repeated wall/RSS, before any
 10k promotion. Local BA timing alone cannot support a COLMAP end-to-end claim.
+
+### Explicit relative-tolerance nonlinear 1k result (2026-09-07)
+
+[Evidence](../benchmarks/electro/m8-openloris-relative-pcg-tolerance-v1.json)
+records implementation `7b6056a`, the same release binary for six serial
+processes, and independent audits of the three unique models. The example
+accepts `--pcg-relative-tolerance 1e-8` only for matrix-free optimization and
+logs actual relative/absolute values both before solving and in its summary.
+The initial exploratory summary mislabeled its tolerance; its artifacts are
+retained separately, and all comparisons were rerun after the logging fix.
+Default summary and numerical behavior remain unchanged. Cholesky is not
+used by any of these nonlinear runs.
+
+| Fixed-input 1k BA arm | Final squared cost | Mean reprojection px | GT RMSE / p95 m | Wall s (two runs) | Peak KiB (two runs) |
+|---|---:|---:|---:|---|---|
+| Direct, serial | 117,496.033 | 0.689260 | 0.026519 / 0.040989 | 45.49 / 45.37 | 161,692 / 161,932 |
+| MF512, relative `1e-12` | 126,419.082 | 0.720314 | 0.026703 / 0.041347 | 17.81 / 18.30 | 84,568 / 84,400 |
+| MF512, relative `1e-8` | 118,070.554 | 0.691589 | 0.026608 / 0.041100 | 20.19 / 20.29 | 84,564 / 84,564 |
+
+Both PCG arms retain absolute `1e-12` and total cap 512; all arms retain the
+same 20 LM iterations and initial cost 126,510.3987573094. Relative `1e-8`
+first accepts LM9 at solve damping `1e5`, versus strict LM14 at `1e10`, but
+still accepts only three steps (direct five). None reports nonlinear
+convergence. Relative `1e-8` improves the listed quality measures over strict,
+but does not match direct. Its maximum observation error 4.840089 px also
+exceeds input 3.999569 px and strict 3.997840 px (direct 4.937791 px). Do not
+describe this as universal reprojection non-regression.
+
+All models retain 1,000 supported images, 500 supported rig frames, 4,716
+landmarks, 130,900 observations and 361,170 full keypoints. Camera bytes,
+image identity/order/POINTS2D and point IDs/RGB/track order remain exact;
+fixed calibration, one connected frame component and positive depths pass.
+GT uses the same 308 associated images, only after optimization. The new
+model's stored ERROR differs from recomputed track means by at most
+`5.91e-9` px. Its maximum centre/landmark differences from direct remain
+0.001098 / 0.019274 m, not numerical equivalence.
+
+Each repeated arm has identical model hashes and numerical traces. New
+direct and strict controls also match PR #79 model bytes and traces; input
+hashes are unchanged. These warm-cache shared-host times include loading,
+validation, solve and publication, not frontend/mapping/atlas construction.
+The local time and memory advantage is measured at different final quality;
+it is not an equivalent-quality speedup or a COLMAP end-to-end result. The
+frozen COLMAP 1k RMSE/p95 is 0.027969 / 0.042266 m, but being below that local
+reference does not establish the outstanding 10k gate. README is unchanged.
+
+#### Next bounded candidate: true-residual restart
+
+The new arm still has ten `MaxIterations` and seven `ResidualCheckFailed`
+attempts. For example, LM12 has recursive residual `0.001371` but true
+residual `0.116403`; LM13 has `0.001045` versus `0.103147`. The existing
+classical PCG immediately rejects after such a failed final check. A
+separately disabled-by-default candidate can reuse that true residual,
+restart with `r=b-Ax`, `z=M^-1 r`, `rho=r^T z`, `p=z`, and continue only
+within the original total 512-iteration budget. Start with at most one
+restart; never reset the iteration count, accept an unchecked iterate,
+change physical damping, add dense fallback, or retain an iteration history.
+Reuse O(N) vectors and measure actual allocations/RSS. Preserve existing
+public struct shapes and default behavior.
+
+[Greenbaum's analysis](https://epubs.siam.org/doi/10.1137/S0895479895284944)
+supports the finite-precision residual-gap diagnosis.
+[Van der Vorst and Ye](https://epubs.siam.org/doi/10.1137/S1064827599353865)
+study error-bound-guided replacement that limits perturbation of Krylov
+recurrences. The proposed single event-triggered restart is an engineering
+hypothesis, not a reproduction or guarantee of their scheme. Restart drops
+accumulated conjugacy and may slow or stagnate; it does not directly address
+the ten iteration-limit failures. [PETSc's manual](https://petsc.org/release/manual/ksp/)
+also distinguishes estimated residual monitoring from explicit `b-Ax`
+monitoring and warns that the latter adds work.
+
+First test disabled-path exactness, fixed total iteration/restart bounds,
+finite/curvature failures, zero RHS and a controlled residual-gap fixture.
+Then compare frozen real systems and full nonlinear 1k quality/resources
+with explicit restart counters. A reduction in recheck failures alone is
+not sufficient for promotion; retain direct/strict controls and all geometry,
+identity and GT gates. No restart implementation is included in this result.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -1023,3 +1023,14 @@ the fixed `1e-12` rule is a diagnostic baseline, not the user's ultimate goal.
 Any changed policy must retain honest true-residual reporting and demonstrate
 the requested trajectory/reprojection/resource quality, not merely report more
 linear solves as successful.
+
+PR #81 passed all eight final-head CI checks (run `34125303050`, head
+`7b4b6cb`) and merged as `06ca2e1`; its local/remote topic branches were removed.
+The Cholesky A/B must audit original `Hll` symmetry and inverse residuals before
+attributing any improvement to symmetry. Use each arm's block construction
+consistently for RHS, implicit action, explicit reference, preconditioner and
+landmark back-substitution. A failed Cholesky factorization is a reported
+failure, not permission to fall back silently. The new test helper's general
+inverse control must match the existing production operator on small fixtures;
+preserve the real-data baseline reports as well. Do not retain a full second
+normal system/model or scale physical rig calibration.

--- a/docs/openloris_atlas_bounded_ba.md
+++ b/docs/openloris_atlas_bounded_ba.md
@@ -1034,3 +1034,12 @@ failure, not permission to fall back silently. The new test helper's general
 inverse control must match the existing production operator on small fixtures;
 preserve the real-data baseline reports as well. Do not retain a full second
 normal system/model or scale physical rig calibration.
+
+The locked `nalgebra 0.33.3` implementation (`src/linalg/inverse.rs`, 3x3
+branch, inspected locally) uses explicit cofactors and a determinant for
+`try_inverse`. Its formula does not imply asymmetric output for a symmetric
+input. Therefore the A/B concerns inverse accuracy as well as symmetry, not
+an assumed asymmetric-inverse defect. Record `Hll * inverse - I` residuals,
+original and inverse off-diagonal differences, and scale metrics before
+interpreting a change in PCG convergence. Cholesky can change rounding even
+when both inverse representations are symmetric.

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -119,6 +119,13 @@ Next compare an explicitly configured production general-inverse PCG512 arm
 nonlinear controls. This separately labeled policy must earn trajectory,
 reprojection and resource quality, not retroactively pass the strict oracle.
 No new 10k or README claim is authorized by the diagnostic result alone.
+The explicit-tolerance nonlinear comparison is now measured (`7b6056a`):
+[six serial runs and audits](../benchmarks/electro/m8-openloris-relative-pcg-tolerance-v1.json).
+Relative `1e-8` improves cost and GT error over strict but remains worse than
+direct; repeats are exact and all identities/support/calibration/depth remain
+valid. No equivalent-quality speedup or 10k promotion. Next test one bounded,
+event-triggered true-residual restart within the original PCG iteration cap,
+as a separate default-off arm; see the [detailed contract](openloris_atlas_bounded_ba.md).
 
 ## Historical M7 baseline
 

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -110,6 +110,15 @@ for the user's actual quality, speed and memory requirements.
 PR #81 passed all eight final-head checks (run `34125303050`, head `7b4b6cb`),
 merged as `06ca2e1`, and its topic branches were removed. The next controlled
 arm is on `feat/m8-cholesky-landmark-elimination`.
+Its test-only implementation `05500bf` has now been measured twice with all
+seventeen numerical lines identical; [evidence](../benchmarks/electro/m8-openloris-cholesky-landmark-elimination-v1.json).
+General inverse asymmetry is zero. Cholesky improves several residuals but
+still fails the useful `1e5` damping true-residual check; it is not promoted.
+Next compare an explicitly configured production general-inverse PCG512 arm
+(relative `1e-8`, absolute `1e-12`) against unchanged strict and direct 1k
+nonlinear controls. This separately labeled policy must earn trajectory,
+reprojection and resource quality, not retroactively pass the strict oracle.
+No new 10k or README claim is authorized by the diagnostic result alone.
 
 ## Historical M7 baseline
 

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -107,6 +107,9 @@ Cholesky-based damped landmark elimination with the current small general
 inverse, before any nonlinear/10k promotion. Scaling and a separately defined
 inexact policy remain available: the diagnostic tolerance is not a substitute
 for the user's actual quality, speed and memory requirements.
+PR #81 passed all eight final-head checks (run `34125303050`, head `7b4b6cb`),
+merged as `06ca2e1`, and its topic branches were removed. The next controlled
+arm is on `feat/m8-cholesky-landmark-elimination`.
 
 ## Historical M7 baseline
 

--- a/examples/compare_rig_bundle_adjustment.rs
+++ b/examples/compare_rig_bundle_adjustment.rs
@@ -438,23 +438,44 @@ fn run(args: &Args) -> Result<(), String> {
         solver_seconds,
         total_seconds,
     };
-    println!(
-        "solver={} initial_cost={:.15e} final_cost={:.15e} lm_iterations={} converged={} source_images={} source_frames={} source_landmarks={} source_observations={} fixed_pose=0 fixed_landmarks=0 pcg_max_iterations={} pcg_tolerance={:.1e} solver_seconds={:.6} total_seconds={:.6} out={}",
-        summary.solver.as_str(),
-        summary.initial_cost,
-        summary.final_cost,
-        summary.iterations,
-        summary.converged,
-        source.images.len(),
-        manifest.assignments.values().map(|assignment| assignment.frame_id).collect::<BTreeSet<_>>().len(),
-        source.points.len(),
-        source.points.iter().map(|point| point.observations.len()).sum::<usize>(),
-        args.pcg_max_iterations,
-        PCG_TOLERANCE,
-        summary.solver_seconds,
-        summary.total_seconds,
-        out_dir.display(),
-    );
+    if args.pcg_relative_tolerance_explicit {
+        println!(
+            "solver={} initial_cost={:.15e} final_cost={:.15e} lm_iterations={} converged={} source_images={} source_frames={} source_landmarks={} source_observations={} fixed_pose=0 fixed_landmarks=0 pcg_max_iterations={} pcg_relative_tolerance={:.17e} pcg_absolute_tolerance={:.17e} solver_seconds={:.6} total_seconds={:.6} out={}",
+            summary.solver.as_str(),
+            summary.initial_cost,
+            summary.final_cost,
+            summary.iterations,
+            summary.converged,
+            source.images.len(),
+            manifest.assignments.values().map(|assignment| assignment.frame_id).collect::<BTreeSet<_>>().len(),
+            source.points.len(),
+            source.points.iter().map(|point| point.observations.len()).sum::<usize>(),
+            args.pcg_max_iterations,
+            args.pcg_relative_tolerance,
+            PCG_TOLERANCE,
+            summary.solver_seconds,
+            summary.total_seconds,
+            out_dir.display(),
+        );
+    } else {
+        println!(
+            "solver={} initial_cost={:.15e} final_cost={:.15e} lm_iterations={} converged={} source_images={} source_frames={} source_landmarks={} source_observations={} fixed_pose=0 fixed_landmarks=0 pcg_max_iterations={} pcg_tolerance={:.1e} solver_seconds={:.6} total_seconds={:.6} out={}",
+            summary.solver.as_str(),
+            summary.initial_cost,
+            summary.final_cost,
+            summary.iterations,
+            summary.converged,
+            source.images.len(),
+            manifest.assignments.values().map(|assignment| assignment.frame_id).collect::<BTreeSet<_>>().len(),
+            source.points.len(),
+            source.points.iter().map(|point| point.observations.len()).sum::<usize>(),
+            args.pcg_max_iterations,
+            PCG_TOLERANCE,
+            summary.solver_seconds,
+            summary.total_seconds,
+            out_dir.display(),
+        );
+    }
     Ok(())
 }
 

--- a/examples/compare_rig_bundle_adjustment.rs
+++ b/examples/compare_rig_bundle_adjustment.rs
@@ -22,7 +22,7 @@ use visloc_rs::slam::{
 use visloc_rs::{Camera, CameraModel, Pose, SE3};
 
 const USAGE: &str = "usage: compare_rig_bundle_adjustment --model PATH --rig-manifest PATH \\
-    --solver direct|matrix-free --out-dir PATH [--pcg-max-iterations N]\n\
+    --solver direct|matrix-free --out-dir PATH [--pcg-max-iterations N] [--pcg-relative-tolerance X]\n\
     or: compare_rig_bundle_adjustment --model PATH --rig-manifest PATH \\
     --export-oracle-fixture PATH";
 const CENTER_TOLERANCE_M: f64 = 1.0e-4;
@@ -69,13 +69,15 @@ impl SolverArm {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 struct Args {
     model: PathBuf,
     rig_manifest: PathBuf,
     solver: Option<SolverArm>,
     out_dir: Option<PathBuf>,
     pcg_max_iterations: usize,
+    pcg_relative_tolerance: f64,
+    pcg_relative_tolerance_explicit: bool,
     oracle_fixture_out: Option<PathBuf>,
 }
 
@@ -194,6 +196,8 @@ where
     let mut oracle_fixture_out = None;
     let mut pcg_max_iterations = MAX_PCG_ITERATIONS;
     let mut pcg_seen = false;
+    let mut pcg_relative_tolerance = PCG_TOLERANCE;
+    let mut pcg_relative_seen = false;
     while let Some(flag) = values.next() {
         if flag == "-h" || flag == "--help" {
             return Err(USAGE.to_owned());
@@ -211,6 +215,32 @@ where
                 .map_err(|error| format!("{flag} requires a positive integer: {error}\n{USAGE}"))?;
             if pcg_max_iterations == 0 {
                 return Err(format!("{flag} must be positive\n{USAGE}"));
+            }
+            continue;
+        }
+        if flag == "--pcg-relative-tolerance" {
+            if pcg_relative_seen {
+                return Err(format!("duplicate argument {flag}\n{USAGE}"));
+            }
+            pcg_relative_seen = true;
+            let value = values
+                .next()
+                .ok_or_else(|| format!("{flag} requires a positive finite value\n{USAGE}"))?;
+            if value.starts_with('-') {
+                return Err(format!(
+                    "{flag} requires a positive finite value, got {value:?}\n{USAGE}"
+                ));
+            }
+            pcg_relative_tolerance = value.parse::<f64>().map_err(|error| {
+                format!("{flag} requires a positive finite value: {error}\n{USAGE}")
+            })?;
+            if !pcg_relative_tolerance.is_finite()
+                || pcg_relative_tolerance <= 0.0
+                || pcg_relative_tolerance >= 1.0
+            {
+                return Err(format!(
+                    "{flag} must be finite, positive, and less than 1\n{USAGE}"
+                ));
             }
             continue;
         }
@@ -250,10 +280,12 @@ where
             }
         }
     }
-    if oracle_fixture_out.is_some() && (solver.is_some() || out_dir.is_some() || pcg_seen) {
+    if oracle_fixture_out.is_some()
+        && (solver.is_some() || out_dir.is_some() || pcg_seen || pcg_relative_seen)
+    {
         return Err(format!(
             "--export-oracle-fixture is a standalone operation; do not combine it with \
-             --solver, --out-dir or --pcg-max-iterations\n{USAGE}"
+             --solver, --out-dir, --pcg-max-iterations or --pcg-relative-tolerance\n{USAGE}"
         ));
     }
     if oracle_fixture_out.is_none() && (solver.is_none() || out_dir.is_none()) {
@@ -267,11 +299,13 @@ where
         solver,
         out_dir,
         pcg_max_iterations,
+        pcg_relative_tolerance,
+        pcg_relative_tolerance_explicit: pcg_relative_seen,
         oracle_fixture_out,
     };
-    if args.solver == Some(SolverArm::Direct) && pcg_seen {
+    if args.solver == Some(SolverArm::Direct) && (pcg_seen || pcg_relative_seen) {
         return Err(format!(
-            "--pcg-max-iterations is only valid for matrix-free\n{USAGE}"
+            "PCG options are only valid for matrix-free\n{USAGE}"
         ));
     }
     Ok(args)
@@ -351,6 +385,13 @@ fn run(args: &Args) -> Result<(), String> {
         ..BaConfig::default()
     };
     let solver_started = Instant::now();
+    if solver == SolverArm::MatrixFree && args.pcg_relative_tolerance_explicit {
+        println!(
+            "pcg_configuration solver=matrix-free relative_tolerance={:.17e} absolute_tolerance={:.17e}",
+            args.pcg_relative_tolerance,
+            PCG_TOLERANCE,
+        );
+    }
     let optimization = match solver {
         SolverArm::Direct => {
             let result = prepared
@@ -362,7 +403,7 @@ fn run(args: &Args) -> Result<(), String> {
         SolverArm::MatrixFree => {
             let options = MatrixFreeBaOptions {
                 max_pcg_iterations: args.pcg_max_iterations,
-                pcg_relative_tolerance: PCG_TOLERANCE,
+                pcg_relative_tolerance: args.pcg_relative_tolerance,
                 pcg_absolute_tolerance: PCG_TOLERANCE,
             };
             let result = prepared
@@ -2085,6 +2126,156 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.contains("only valid for matrix-free"));
+    }
+
+    #[test]
+    fn parses_matrix_free_relative_tolerance_and_preserves_default() {
+        let explicit = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--pcg-relative-tolerance",
+                "1e-8",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(explicit.pcg_relative_tolerance, 1.0e-8);
+        assert!(explicit.pcg_relative_tolerance_explicit);
+
+        let default = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert_eq!(default.pcg_relative_tolerance, PCG_TOLERANCE);
+        assert!(!default.pcg_relative_tolerance_explicit);
+    }
+
+    #[test]
+    fn rejects_invalid_duplicate_and_wrong_arm_relative_tolerance() {
+        for invalid in ["0", "-1", "1", "NaN", "inf", "-inf"] {
+            let error = parse_args(
+                [
+                    "compare",
+                    "--model",
+                    "model",
+                    "--rig-manifest",
+                    "rig.txt",
+                    "--solver",
+                    "matrix-free",
+                    "--out-dir",
+                    "out",
+                    "--pcg-relative-tolerance",
+                    invalid,
+                ]
+                .into_iter()
+                .map(str::to_owned),
+            )
+            .unwrap_err();
+            assert!(
+                error.contains("pcg-relative-tolerance"),
+                "invalid={invalid:?} error={error}"
+            );
+        }
+
+        let duplicate = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--pcg-relative-tolerance",
+                "1e-8",
+                "--pcg-relative-tolerance",
+                "1e-7",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(duplicate.contains("duplicate argument"));
+
+        let missing = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--pcg-relative-tolerance",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(missing.contains("requires a positive finite value"));
+
+        let direct = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "direct",
+                "--out-dir",
+                "out",
+                "--pcg-relative-tolerance",
+                "1e-8",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(direct.contains("only valid for matrix-free"));
+
+        let export = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--export-oracle-fixture",
+                "fixture.txt",
+                "--pcg-relative-tolerance",
+                "1e-8",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(export.contains("standalone operation"));
     }
 
     #[test]

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -7360,6 +7360,64 @@ mod matrix_free_real_oracle_tests {
         prediction: Option<PredictedDecrease>,
     }
 
+    /// Diagnostics collected before choosing the landmark-block factorization.
+    /// The asymmetry and scale are deliberately reported separately: a large
+    /// block scale can make a small absolute difference look alarming, while
+    /// a small-looking difference can still matter after Schur cancellation.
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    struct LandmarkFactorMetrics {
+        h_ll_max_asymmetry: f64,
+        h_ll_max_scale: f64,
+        inverse_max_asymmetry: Option<f64>,
+        inverse_max_scale: Option<f64>,
+        h_ll_inverse_identity_residual: Option<f64>,
+    }
+
+    impl Default for LandmarkFactorMetrics {
+        fn default() -> Self {
+            Self {
+                h_ll_max_asymmetry: 0.0,
+                h_ll_max_scale: 0.0,
+                inverse_max_asymmetry: None,
+                inverse_max_scale: None,
+                h_ll_inverse_identity_residual: None,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct CholeskyPcgArmReport {
+        status: String,
+        iterations: Option<usize>,
+        recursive_residual: Option<f64>,
+        action_true_residual: Option<f64>,
+        target: Option<f64>,
+        lower_true_residual: Option<f64>,
+        dense_reference_lower_true_residual: Option<f64>,
+        dense_reference_action_true_residual: Option<f64>,
+        dense_reference_original_pose_equation_residual: Option<f64>,
+        original_pose_equation_residual: Option<f64>,
+        pose_error_vs_dense: Option<f64>,
+        landmark_error_vs_dense: Option<f64>,
+        feasibility: Option<Feasibility>,
+        prediction: Option<PredictedDecrease>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct CholeskyPcgIsolationReport {
+        lambda: f64,
+        pcg_max_iterations: usize,
+        general_metrics: LandmarkFactorMetrics,
+        cholesky_metrics: LandmarkFactorMetrics,
+        general: CholeskyPcgArmReport,
+        cholesky: CholeskyPcgArmReport,
+        general_vs_cholesky_pose_error: Option<f64>,
+        general_vs_cholesky_landmark_error: Option<f64>,
+        rhs_error: Option<f64>,
+        probe_action_error: Option<f64>,
+        probe_preconditioner_error: Option<f64>,
+    }
+
     fn parse_f64(token: &str, context: &str) -> Result<f64, String> {
         let value = token
             .parse::<f64>()
@@ -7945,6 +8003,535 @@ mod matrix_free_real_oracle_tests {
         Ok((schur, rhs, singular_landmarks))
     }
 
+    type LandmarkCholesky = nalgebra::Cholesky<f64, nalgebra::Const<3>>;
+
+    const CHOLESKY_HLL_SYMMETRY_RELATIVE_TOLERANCE: f64 = 1.0e-12;
+
+    fn damped_landmark_hessian(
+        landmark: &LandmarkBlock,
+        lambda: f64,
+    ) -> Result<Matrix3<f64>, String> {
+        if !lambda.is_finite() || lambda < 0.0 {
+            return Err(format!("invalid landmark damping {lambda}"));
+        }
+        let mut h_ll = landmark.h_ll;
+        for component in 0..3 {
+            h_ll[(component, component)] += lambda;
+        }
+        if !h_ll.iter().all(|value| value.is_finite()) {
+            return Err("damped landmark Hessian is non-finite".to_owned());
+        }
+        Ok(h_ll)
+    }
+
+    fn matrix3_max_abs(matrix: &Matrix3<f64>) -> f64 {
+        matrix
+            .iter()
+            .map(|value| value.abs())
+            .fold(0.0_f64, f64::max)
+    }
+
+    fn matrix3_max_asymmetry(matrix: &Matrix3<f64>) -> f64 {
+        let mut max_difference = 0.0_f64;
+        for row in 0..3 {
+            for column in (row + 1)..3 {
+                max_difference =
+                    max_difference.max((matrix[(row, column)] - matrix[(column, row)]).abs());
+            }
+        }
+        max_difference
+    }
+
+    fn update_landmark_factor_metrics(
+        metrics: &mut LandmarkFactorMetrics,
+        h_ll: &Matrix3<f64>,
+        inverse: Option<&Matrix3<f64>>,
+    ) -> Result<(), String> {
+        let h_ll_asymmetry = matrix3_max_asymmetry(h_ll);
+        let h_ll_scale = matrix3_max_abs(h_ll);
+        if !h_ll_asymmetry.is_finite() || !h_ll_scale.is_finite() {
+            return Err("landmark Hessian metrics are non-finite".to_owned());
+        }
+        metrics.h_ll_max_asymmetry = metrics.h_ll_max_asymmetry.max(h_ll_asymmetry);
+        metrics.h_ll_max_scale = metrics.h_ll_max_scale.max(h_ll_scale);
+        let Some(inverse) = inverse else {
+            return Ok(());
+        };
+        let inverse_asymmetry = matrix3_max_asymmetry(inverse);
+        let inverse_scale = matrix3_max_abs(inverse);
+        let identity_residual = (h_ll * inverse - Matrix3::identity()).norm();
+        if !inverse_asymmetry.is_finite()
+            || !inverse_scale.is_finite()
+            || !identity_residual.is_finite()
+        {
+            return Err("landmark inverse metrics are non-finite".to_owned());
+        }
+        metrics.inverse_max_asymmetry = Some(
+            metrics
+                .inverse_max_asymmetry
+                .unwrap_or(0.0)
+                .max(inverse_asymmetry),
+        );
+        metrics.inverse_max_scale =
+            Some(metrics.inverse_max_scale.unwrap_or(0.0).max(inverse_scale));
+        metrics.h_ll_inverse_identity_residual = Some(
+            metrics
+                .h_ll_inverse_identity_residual
+                .unwrap_or(0.0)
+                .max(identity_residual),
+        );
+        Ok(())
+    }
+
+    fn general_landmark_factor_metrics(
+        system: &NormalEquationsBa,
+        lambda: f64,
+    ) -> Result<LandmarkFactorMetrics, String> {
+        let mut metrics = LandmarkFactorMetrics::default();
+        for landmark in &system.landmarks {
+            let h_ll = damped_landmark_hessian(landmark, lambda)?;
+            let inverse = h_ll.try_inverse();
+            if let Some(inverse) = inverse {
+                if !inverse.iter().all(|value| value.is_finite()) {
+                    return Err("general landmark inverse is non-finite".to_owned());
+                }
+                update_landmark_factor_metrics(&mut metrics, &h_ll, Some(&inverse))?;
+            } else {
+                update_landmark_factor_metrics(&mut metrics, &h_ll, None)?;
+            }
+        }
+        Ok(metrics)
+    }
+
+    /// Cholesky consumes the lower triangle, but only after this numerical
+    /// symmetry audit.  The upper triangle is then replaced from the lower
+    /// triangle so every Cholesky operation (RHS, Schur action, preconditioner
+    /// and back-substitution) sees the same explicitly audited matrix.
+    fn lower_symmetric_landmark_hessian(h_ll: &Matrix3<f64>) -> Result<Matrix3<f64>, String> {
+        let asymmetry = matrix3_max_asymmetry(h_ll);
+        let scale = matrix3_max_abs(h_ll).max(1.0);
+        if asymmetry > CHOLESKY_HLL_SYMMETRY_RELATIVE_TOLERANCE * scale {
+            return Err(format!(
+                "landmark Hessian is not symmetric: asymmetry={asymmetry:.17e} scale={scale:.17e}"
+            ));
+        }
+        let mut symmetric = *h_ll;
+        for row in 0..3 {
+            for column in (row + 1)..3 {
+                symmetric[(row, column)] = symmetric[(column, row)];
+            }
+        }
+        Ok(symmetric)
+    }
+
+    #[derive(Debug, Clone)]
+    struct CholeskyBuildFailure {
+        metrics: LandmarkFactorMetrics,
+        reason: String,
+    }
+
+    /// Test-only Schur operator whose landmark elimination uses a validated
+    /// lower-triangle Cholesky factor and triangular solves.  The production
+    /// `ImplicitSchurOperator` remains untouched; this operator exists only to
+    /// compare the complete elimination path under the same PCG recurrence.
+    struct CholeskySchurOperator<'a> {
+        diagonal: Vec<Matrix6<f64>>,
+        landmarks: &'a [LandmarkBlock],
+        factors: Vec<LandmarkCholesky>,
+        preconditioner_inverse: Vec<Matrix6<f64>>,
+        rhs: DVector<f64>,
+    }
+
+    impl<'a> CholeskySchurOperator<'a> {
+        fn new(
+            system: &'a NormalEquationsBa,
+            lambda: f64,
+        ) -> Result<(Self, LandmarkFactorMetrics), CholeskyBuildFailure> {
+            let mut metrics = LandmarkFactorMetrics::default();
+            let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: "oracle requires pose-diagonal system".to_owned(),
+                });
+            };
+            if diagonal.is_empty() {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: "oracle has no variable pose blocks".to_owned(),
+                });
+            }
+            let dimension = diagonal.len() * 6;
+            if system.b_p.len() != dimension {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: format!(
+                        "pose RHS dimension mismatch: expected {dimension}, actual {}",
+                        system.b_p.len()
+                    ),
+                });
+            }
+            if !system.b_p.iter().all(|value| value.is_finite()) {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: "pose RHS is non-finite".to_owned(),
+                });
+            }
+
+            let mut damped_diagonal = diagonal.clone();
+            for block in &mut damped_diagonal {
+                for component in 0..6 {
+                    block[(component, component)] += lambda;
+                }
+            }
+            if !damped_diagonal
+                .iter()
+                .flat_map(|block| block.iter())
+                .all(|value| value.is_finite())
+            {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: "damped pose Hessian is non-finite".to_owned(),
+                });
+            }
+
+            let mut factors = Vec::with_capacity(system.landmarks.len());
+            for (landmark_index, landmark) in system.landmarks.iter().enumerate() {
+                let h_ll = match damped_landmark_hessian(landmark, lambda) {
+                    Ok(h_ll) => h_ll,
+                    Err(reason) => {
+                        return Err(CholeskyBuildFailure { metrics, reason });
+                    }
+                };
+                for (pose, cross) in &landmark.cross {
+                    if *pose >= diagonal.len() {
+                        return Err(CholeskyBuildFailure {
+                            metrics,
+                            reason: format!(
+                                "landmark {landmark_index} references pose {pose} outside {} blocks",
+                                diagonal.len()
+                            ),
+                        });
+                    }
+                    if !cross.iter().all(|value| value.is_finite()) {
+                        return Err(CholeskyBuildFailure {
+                            metrics,
+                            reason: format!("landmark {landmark_index} cross is non-finite"),
+                        });
+                    }
+                }
+                if !landmark.b_l.iter().all(|value| value.is_finite()) {
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: format!("landmark {landmark_index} RHS is non-finite"),
+                    });
+                }
+                let symmetric_h_ll = match lower_symmetric_landmark_hessian(&h_ll) {
+                    Ok(h_ll) => h_ll,
+                    Err(reason) => {
+                        if let Err(metric_reason) =
+                            update_landmark_factor_metrics(&mut metrics, &h_ll, None)
+                        {
+                            return Err(CholeskyBuildFailure {
+                                metrics,
+                                reason: metric_reason,
+                            });
+                        }
+                        return Err(CholeskyBuildFailure { metrics, reason });
+                    }
+                };
+                let Some(cholesky) = symmetric_h_ll.cholesky() else {
+                    if let Err(metric_reason) =
+                        update_landmark_factor_metrics(&mut metrics, &h_ll, None)
+                    {
+                        return Err(CholeskyBuildFailure {
+                            metrics,
+                            reason: metric_reason,
+                        });
+                    }
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: format!("landmark {landmark_index} damped Hessian is not SPD"),
+                    });
+                };
+                let inverse = cholesky.inverse();
+                if !inverse.iter().all(|value| value.is_finite()) {
+                    if let Err(metric_reason) =
+                        update_landmark_factor_metrics(&mut metrics, &h_ll, None)
+                    {
+                        return Err(CholeskyBuildFailure {
+                            metrics,
+                            reason: metric_reason,
+                        });
+                    }
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: format!("landmark {landmark_index} Cholesky inverse is non-finite"),
+                    });
+                }
+                if let Err(metric_reason) =
+                    update_landmark_factor_metrics(&mut metrics, &h_ll, Some(&inverse))
+                {
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: metric_reason,
+                    });
+                }
+                factors.push(cholesky);
+            }
+
+            let mut rhs = -&system.b_p;
+            for (landmark, factor) in system.landmarks.iter().zip(&factors) {
+                let solved = factor.solve(&landmark.b_l);
+                if !solved.iter().all(|value| value.is_finite()) {
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: "Cholesky RHS solve is non-finite".to_owned(),
+                    });
+                }
+                for (pose, cross) in &landmark.cross {
+                    let update: Vector6<f64> = cross * solved;
+                    for component in 0..6 {
+                        rhs[pose * 6 + component] += update[component];
+                    }
+                }
+            }
+            if !rhs.iter().all(|value| value.is_finite()) {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: "Cholesky reduced RHS is non-finite".to_owned(),
+                });
+            }
+
+            let mut preconditioner = damped_diagonal.clone();
+            for (landmark, factor) in system.landmarks.iter().zip(&factors) {
+                let mut grouped: BTreeMap<usize, Matrix6x3<f64>> = BTreeMap::new();
+                for (pose, cross) in &landmark.cross {
+                    *grouped.entry(*pose).or_insert_with(Matrix6x3::zeros) += cross;
+                }
+                for (pose, cross) in grouped {
+                    let cross_transpose = cross.transpose();
+                    let solved = factor.solve(&cross_transpose);
+                    if !solved.iter().all(|value| value.is_finite()) {
+                        return Err(CholeskyBuildFailure {
+                            metrics,
+                            reason: "Cholesky preconditioner solve is non-finite".to_owned(),
+                        });
+                    }
+                    preconditioner[pose] -= cross * solved;
+                }
+            }
+            if !preconditioner
+                .iter()
+                .flat_map(|block| block.iter())
+                .all(|value| value.is_finite())
+            {
+                return Err(CholeskyBuildFailure {
+                    metrics,
+                    reason: "Cholesky Schur preconditioner is non-finite".to_owned(),
+                });
+            }
+            let mut preconditioner_inverse = Vec::with_capacity(preconditioner.len());
+            for (pose, block) in preconditioner.iter().enumerate() {
+                let Some(cholesky) = block.cholesky() else {
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: format!("Cholesky Schur preconditioner block {pose} is not SPD"),
+                    });
+                };
+                let inverse = cholesky.inverse();
+                if !inverse.iter().all(|value| value.is_finite()) {
+                    return Err(CholeskyBuildFailure {
+                        metrics,
+                        reason: format!(
+                            "Cholesky Schur preconditioner inverse {pose} is non-finite"
+                        ),
+                    });
+                }
+                preconditioner_inverse.push(inverse);
+            }
+
+            Ok((
+                Self {
+                    diagonal: damped_diagonal,
+                    landmarks: &system.landmarks,
+                    factors,
+                    preconditioner_inverse,
+                    rhs,
+                },
+                metrics,
+            ))
+        }
+
+        fn dimension(&self) -> usize {
+            self.diagonal.len() * 6
+        }
+
+        fn rhs(&self) -> &DVector<f64> {
+            &self.rhs
+        }
+
+        fn apply(
+            &self,
+            x: &DVector<f64>,
+        ) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError> {
+            if x.len() != self.dimension() {
+                return Err(implicit_schur::ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: x.len(),
+                });
+            }
+            if !x.iter().all(|value| value.is_finite()) {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                    "Cholesky operator input",
+                ));
+            }
+            let mut out = DVector::zeros(self.dimension());
+            for (pose, block) in self.diagonal.iter().enumerate() {
+                let x_pose: Vector6<f64> = x.fixed_rows::<6>(pose * 6).into_owned();
+                let value = block * x_pose;
+                for component in 0..6 {
+                    out[pose * 6 + component] = value[component];
+                }
+            }
+            for (landmark, factor) in self.landmarks.iter().zip(&self.factors) {
+                let mut projected = Vector3::zeros();
+                for (pose, cross) in &landmark.cross {
+                    let x_pose: Vector6<f64> = x.fixed_rows::<6>(pose * 6).into_owned();
+                    projected += cross.transpose() * x_pose;
+                }
+                let reduced = factor.solve(&projected);
+                if !reduced.iter().all(|value| value.is_finite()) {
+                    return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                        "Cholesky operator landmark solve",
+                    ));
+                }
+                for (pose, cross) in &landmark.cross {
+                    let value: Vector6<f64> = cross * reduced;
+                    for component in 0..6 {
+                        out[pose * 6 + component] -= value[component];
+                    }
+                }
+            }
+            if !out.iter().all(|value| value.is_finite()) {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                    "Cholesky operator output",
+                ));
+            }
+            Ok(out)
+        }
+
+        fn apply_preconditioner(
+            &self,
+            residual: &DVector<f64>,
+        ) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError> {
+            if residual.len() != self.dimension() {
+                return Err(implicit_schur::ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: residual.len(),
+                });
+            }
+            if !residual.iter().all(|value| value.is_finite()) {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                    "Cholesky preconditioner input",
+                ));
+            }
+            let mut out = DVector::zeros(self.dimension());
+            for (pose, inverse) in self.preconditioner_inverse.iter().enumerate() {
+                let residual_pose: Vector6<f64> = residual.fixed_rows::<6>(pose * 6).into_owned();
+                let value = inverse * residual_pose;
+                for component in 0..6 {
+                    out[pose * 6 + component] = value[component];
+                }
+            }
+            if !out.iter().all(|value| value.is_finite()) {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                    "Cholesky preconditioner output",
+                ));
+            }
+            Ok(out)
+        }
+
+        fn complete_delta(
+            &self,
+            delta_pose: &DVector<f64>,
+        ) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError> {
+            if delta_pose.len() != self.dimension() {
+                return Err(implicit_schur::ImplicitSchurError::DimensionMismatch {
+                    expected: self.dimension(),
+                    actual: delta_pose.len(),
+                });
+            }
+            if !delta_pose.iter().all(|value| value.is_finite()) {
+                return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                    "Cholesky pose delta",
+                ));
+            }
+            let mut delta_landmarks = DVector::zeros(self.landmarks.len() * 3);
+            for (index, (landmark, factor)) in self.landmarks.iter().zip(&self.factors).enumerate()
+            {
+                let mut accumulated = -landmark.b_l;
+                for (pose, cross) in &landmark.cross {
+                    let delta: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+                    accumulated -= cross.transpose() * delta;
+                }
+                let value = factor.solve(&accumulated);
+                if !value.iter().all(|entry| entry.is_finite()) {
+                    return Err(implicit_schur::ImplicitSchurError::NonFinite(
+                        "Cholesky landmark delta",
+                    ));
+                }
+                for component in 0..3 {
+                    delta_landmarks[index * 3 + component] = value[component];
+                }
+            }
+            Ok(delta_landmarks)
+        }
+    }
+
+    fn explicit_cholesky_schur_rhs(
+        system: &NormalEquationsBa,
+        operator: &CholeskySchurOperator<'_>,
+    ) -> Result<(DMatrix<f64>, DVector<f64>), String> {
+        let dimension = operator.dimension();
+        let mut schur = DMatrix::zeros(dimension, dimension);
+        for (pose, block) in operator.diagonal.iter().enumerate() {
+            schur
+                .fixed_view_mut::<6, 6>(pose * 6, pose * 6)
+                .copy_from(block);
+        }
+        let rhs = operator.rhs.clone();
+        for (landmark, factor) in system.landmarks.iter().zip(&operator.factors) {
+            // Solve each 3x6 cross block once per landmark.  The nested
+            // pose-pair accumulation below is O(B^2), but repeated triangular
+            // solves would add an unnecessary O(B^2) factorization cost.
+            let mut solved_crosses = Vec::with_capacity(landmark.cross.len());
+            for (other_pose, other_cross) in &landmark.cross {
+                let solved = factor.solve(&other_cross.transpose());
+                if !solved.iter().all(|value| value.is_finite()) {
+                    return Err("Cholesky explicit Schur block is non-finite".to_owned());
+                }
+                solved_crosses.push((*other_pose, solved));
+            }
+            for (pose, cross) in &landmark.cross {
+                for (other_pose, solved) in &solved_crosses {
+                    let block: Matrix6<f64> = cross * solved;
+                    for row in 0..6 {
+                        for column in 0..6 {
+                            schur[(pose * 6 + row, other_pose * 6 + column)] -=
+                                block[(row, column)];
+                        }
+                    }
+                }
+            }
+        }
+        if !schur.iter().all(|value| value.is_finite())
+            || !rhs.iter().all(|value| value.is_finite())
+        {
+            return Err("Cholesky explicit Schur or RHS is non-finite".to_owned());
+        }
+        Ok((schur, rhs))
+    }
+
     fn explicit_lower_action(
         schur: &DMatrix<f64>,
         x: &DVector<f64>,
@@ -8142,6 +8729,183 @@ mod matrix_free_real_oracle_tests {
             rho = next_rho;
         }
         unreachable!("the max-iteration branch returns above");
+    }
+
+    struct CholeskyPcgArmOutcome {
+        report: CholeskyPcgArmReport,
+        solution: Option<DVector<f64>>,
+        landmark_delta: Option<DVector<f64>>,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_cholesky_pcg_arm<Apply, Preconditioner, Complete>(
+        rhs: &DVector<f64>,
+        dimension: usize,
+        options: implicit_schur::PcgOptions,
+        lower_schur: &DMatrix<f64>,
+        dense_solution: Option<&DVector<f64>>,
+        dense_landmark_delta: Option<&DVector<f64>>,
+        dense_reference_action_true_residual: Option<f64>,
+        dense_reference_original_pose_equation_residual: Option<f64>,
+        apply: Apply,
+        apply_preconditioner: Preconditioner,
+        mut complete_delta: Complete,
+        success_label: &str,
+    ) -> CholeskyPcgArmOutcome
+    where
+        Apply: FnMut(&DVector<f64>) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError>,
+        Preconditioner:
+            FnMut(&DVector<f64>) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError>,
+        Complete: FnMut(&DVector<f64>) -> Result<DVector<f64>, implicit_schur::ImplicitSchurError>,
+    {
+        match solve_test_pcg(rhs, dimension, options, apply, apply_preconditioner) {
+            Ok(result) => {
+                let lower_true_residual = explicit_lower_action(lower_schur, &result.solution)
+                    .ok()
+                    .map(|applied| (rhs - applied).norm());
+                let landmark_delta = complete_delta(&result.solution).ok();
+                let dense_reference_lower_true_residual = dense_solution.and_then(|solution| {
+                    explicit_lower_action(lower_schur, solution)
+                        .ok()
+                        .map(|applied| (rhs - applied).norm())
+                });
+                let pose_error_vs_dense =
+                    dense_solution.map(|solution| (&result.solution - solution).norm());
+                let landmark_error_vs_dense = match (landmark_delta.as_ref(), dense_landmark_delta)
+                {
+                    (Some(actual), Some(expected)) => Some((actual - expected).norm()),
+                    _ => None,
+                };
+                CholeskyPcgArmOutcome {
+                    report: CholeskyPcgArmReport {
+                        status: success_label.to_owned(),
+                        iterations: Some(result.iterations),
+                        recursive_residual: None,
+                        action_true_residual: Some(result.residual_norm),
+                        target: Some(result.target),
+                        lower_true_residual,
+                        dense_reference_lower_true_residual,
+                        dense_reference_action_true_residual,
+                        dense_reference_original_pose_equation_residual,
+                        original_pose_equation_residual: None,
+                        pose_error_vs_dense,
+                        landmark_error_vs_dense,
+                        feasibility: None,
+                        prediction: None,
+                    },
+                    solution: Some(result.solution),
+                    landmark_delta,
+                }
+            }
+            Err(error) => {
+                let (iterations, recursive_residual, action_true_residual, target) =
+                    pcg_error_details(&error);
+                CholeskyPcgArmOutcome {
+                    report: CholeskyPcgArmReport {
+                        status: format!("failure:{error:?}"),
+                        iterations,
+                        recursive_residual,
+                        action_true_residual,
+                        target,
+                        lower_true_residual: None,
+                        dense_reference_lower_true_residual: dense_solution.and_then(|solution| {
+                            explicit_lower_action(lower_schur, solution)
+                                .ok()
+                                .map(|applied| (rhs - applied).norm())
+                        }),
+                        dense_reference_action_true_residual,
+                        dense_reference_original_pose_equation_residual,
+                        original_pose_equation_residual: None,
+                        pose_error_vs_dense: None,
+                        landmark_error_vs_dense: None,
+                        feasibility: None,
+                        prediction: None,
+                    },
+                    solution: None,
+                    landmark_delta: None,
+                }
+            }
+        }
+    }
+
+    fn failed_cholesky_pcg_arm(
+        status: String,
+        rhs: &DVector<f64>,
+        lower_schur: Option<&DMatrix<f64>>,
+        dense_solution: Option<&DVector<f64>>,
+        dense_reference_action_true_residual: Option<f64>,
+        dense_reference_original_pose_equation_residual: Option<f64>,
+    ) -> CholeskyPcgArmOutcome {
+        let dense_reference_lower_true_residual = dense_solution.and_then(|solution| {
+            lower_schur.and_then(|lower| {
+                explicit_lower_action(lower, solution)
+                    .ok()
+                    .map(|applied| (rhs - applied).norm())
+            })
+        });
+        CholeskyPcgArmOutcome {
+            report: CholeskyPcgArmReport {
+                status,
+                iterations: None,
+                recursive_residual: None,
+                action_true_residual: None,
+                target: None,
+                lower_true_residual: None,
+                dense_reference_lower_true_residual,
+                dense_reference_action_true_residual,
+                dense_reference_original_pose_equation_residual,
+                original_pose_equation_residual: None,
+                pose_error_vs_dense: None,
+                landmark_error_vs_dense: None,
+                feasibility: None,
+                prediction: None,
+            },
+            solution: None,
+            landmark_delta: None,
+        }
+    }
+
+    fn populate_cholesky_arm_diagnostics(
+        outcome: &mut CholeskyPcgArmOutcome,
+        ba: &BundleAdjustment,
+        system: &NormalEquationsBa,
+        lambda: f64,
+        lower_schur: &DMatrix<f64>,
+        rhs: &DVector<f64>,
+        factors: Option<&[LandmarkCholesky]>,
+    ) {
+        let (Some(solution), Some(landmark_delta)) =
+            (outcome.solution.as_ref(), outcome.landmark_delta.as_ref())
+        else {
+            return;
+        };
+        outcome.report.original_pose_equation_residual =
+            original_pose_equation_residual(system, lambda, solution, landmark_delta);
+        outcome.report.prediction =
+            predicted_decrease(system, lambda, solution, landmark_delta).ok();
+        outcome.report.feasibility = Some(match factors {
+            Some(factors) => feasibility_with_cholesky(
+                ba,
+                system,
+                lambda,
+                lower_schur,
+                rhs,
+                solution,
+                landmark_delta,
+                outcome.report.action_true_residual,
+                factors,
+            ),
+            None => feasibility(
+                ba,
+                system,
+                lambda,
+                lower_schur,
+                rhs,
+                solution,
+                landmark_delta,
+                outcome.report.action_true_residual,
+            ),
+        });
     }
 
     fn pcg_error_details(
@@ -8409,6 +9173,286 @@ mod matrix_free_real_oracle_tests {
         Ok(reports)
     }
 
+    fn run_cholesky_pcg_isolation(
+        ba: &BundleAdjustment,
+    ) -> Result<Vec<CholeskyPcgIsolationReport>, String> {
+        let (system, pose_blocks, _landmark_count, _observation_count) = build_oracle_system(ba)?;
+        let CameraHessian::PoseDiagonal(_diagonal) = &system.h_pp else {
+            return Err("Cholesky PCG oracle requires pose blocks".to_owned());
+        };
+        let dimension = pose_blocks * 6;
+        let mut reports = Vec::with_capacity(6);
+
+        for lambda in [1.0e-4, 1.0e5, 1.0e10] {
+            let general_metrics = general_landmark_factor_metrics(&system, lambda)?;
+            let (general_raw_schur, general_rhs, _singular_landmarks) =
+                explicit_schur_rhs(&system, lambda)?;
+            let mut general_lower_schur = general_raw_schur;
+            mirror_lower_triangle(&mut general_lower_schur);
+            let general_operator = implicit_schur::ImplicitSchurOperator::new(&system, lambda)
+                .map_err(|error| format!("general operator: {error:?}"))?;
+            let general_dense_solution =
+                solve_normal_equations(&general_lower_schur, &general_rhs).ok();
+            let general_dense_landmark_delta = general_dense_solution
+                .as_ref()
+                .and_then(|solution| general_operator.complete_delta(solution).ok());
+            let general_dense_action_true_residual =
+                general_dense_solution.as_ref().and_then(|solution| {
+                    general_operator
+                        .apply(solution)
+                        .ok()
+                        .map(|applied| (general_operator.rhs() - applied).norm())
+                });
+            let general_dense_original_pose_equation_residual =
+                match (&general_dense_solution, &general_dense_landmark_delta) {
+                    (Some(solution), Some(landmarks)) => {
+                        original_pose_equation_residual(&system, lambda, solution, landmarks)
+                    }
+                    _ => None,
+                };
+
+            let cholesky_build = CholeskySchurOperator::new(&system, lambda);
+            let (cholesky_operator, cholesky_metrics) = match cholesky_build {
+                Ok(value) => value,
+                Err(failure) => {
+                    for pcg_max_iterations in [128_usize, 512_usize] {
+                        let options = implicit_schur::PcgOptions {
+                            max_iterations: pcg_max_iterations,
+                            relative_tolerance: ORACLE_PC_TOLERANCE,
+                            absolute_tolerance: ORACLE_PC_TOLERANCE,
+                        };
+                        let mut general = run_cholesky_pcg_arm(
+                            &general_rhs,
+                            dimension,
+                            options,
+                            &general_lower_schur,
+                            general_dense_solution.as_ref(),
+                            general_dense_landmark_delta.as_ref(),
+                            general_dense_action_true_residual,
+                            general_dense_original_pose_equation_residual,
+                            |x| general_operator.apply(x),
+                            |residual| general_operator.apply_preconditioner(residual),
+                            |pose| general_operator.complete_delta(pose),
+                            "general_pcg",
+                        );
+                        populate_cholesky_arm_diagnostics(
+                            &mut general,
+                            ba,
+                            &system,
+                            lambda,
+                            &general_lower_schur,
+                            &general_rhs,
+                            None,
+                        );
+                        let cholesky = failed_cholesky_pcg_arm(
+                            format!("failure:cholesky_build:{}", failure.reason),
+                            &general_rhs,
+                            None,
+                            None,
+                            None,
+                            None,
+                        );
+                        reports.push(CholeskyPcgIsolationReport {
+                            lambda,
+                            pcg_max_iterations,
+                            general_metrics,
+                            cholesky_metrics: failure.metrics,
+                            general: general.report,
+                            cholesky: cholesky.report,
+                            general_vs_cholesky_pose_error: None,
+                            general_vs_cholesky_landmark_error: None,
+                            rhs_error: None,
+                            probe_action_error: None,
+                            probe_preconditioner_error: None,
+                        });
+                    }
+                    continue;
+                }
+            };
+
+            let (cholesky_raw_schur, cholesky_rhs) =
+                match explicit_cholesky_schur_rhs(&system, &cholesky_operator) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        for pcg_max_iterations in [128_usize, 512_usize] {
+                            let options = implicit_schur::PcgOptions {
+                                max_iterations: pcg_max_iterations,
+                                relative_tolerance: ORACLE_PC_TOLERANCE,
+                                absolute_tolerance: ORACLE_PC_TOLERANCE,
+                            };
+                            let mut general = run_cholesky_pcg_arm(
+                                &general_rhs,
+                                dimension,
+                                options,
+                                &general_lower_schur,
+                                general_dense_solution.as_ref(),
+                                general_dense_landmark_delta.as_ref(),
+                                general_dense_action_true_residual,
+                                general_dense_original_pose_equation_residual,
+                                |x| general_operator.apply(x),
+                                |residual| general_operator.apply_preconditioner(residual),
+                                |pose| general_operator.complete_delta(pose),
+                                "general_pcg",
+                            );
+                            populate_cholesky_arm_diagnostics(
+                                &mut general,
+                                ba,
+                                &system,
+                                lambda,
+                                &general_lower_schur,
+                                &general_rhs,
+                                None,
+                            );
+                            let cholesky = failed_cholesky_pcg_arm(
+                                format!("failure:cholesky_explicit_schur:{error}"),
+                                &general_rhs,
+                                None,
+                                None,
+                                None,
+                                None,
+                            );
+                            reports.push(CholeskyPcgIsolationReport {
+                                lambda,
+                                pcg_max_iterations,
+                                general_metrics,
+                                cholesky_metrics,
+                                general: general.report,
+                                cholesky: cholesky.report,
+                                general_vs_cholesky_pose_error: None,
+                                general_vs_cholesky_landmark_error: None,
+                                rhs_error: None,
+                                probe_action_error: None,
+                                probe_preconditioner_error: None,
+                            });
+                        }
+                        continue;
+                    }
+                };
+            let mut cholesky_lower_schur = cholesky_raw_schur;
+            mirror_lower_triangle(&mut cholesky_lower_schur);
+            let cholesky_dense_solution =
+                solve_normal_equations(&cholesky_lower_schur, &cholesky_rhs).ok();
+            let cholesky_dense_landmark_delta = cholesky_dense_solution
+                .as_ref()
+                .and_then(|solution| cholesky_operator.complete_delta(solution).ok());
+            let cholesky_dense_action_true_residual =
+                cholesky_dense_solution.as_ref().and_then(|solution| {
+                    cholesky_operator
+                        .apply(solution)
+                        .ok()
+                        .map(|applied| (cholesky_operator.rhs() - applied).norm())
+                });
+            let cholesky_dense_original_pose_equation_residual =
+                match (&cholesky_dense_solution, &cholesky_dense_landmark_delta) {
+                    (Some(solution), Some(landmarks)) => {
+                        original_pose_equation_residual(&system, lambda, solution, landmarks)
+                    }
+                    _ => None,
+                };
+
+            let probe = DVector::from_iterator(
+                dimension,
+                (0..dimension)
+                    .map(|index| 0.001 * ((index % 17) as f64 - 8.0) + 0.00001 * index as f64),
+            );
+            let rhs_error = (&general_rhs - cholesky_operator.rhs()).norm();
+            let probe_action_error = match (
+                general_operator.apply(&probe),
+                cholesky_operator.apply(&probe),
+            ) {
+                (Ok(general), Ok(cholesky)) => Some((general - cholesky).norm()),
+                _ => None,
+            };
+            let probe_preconditioner_error = match (
+                general_operator.apply_preconditioner(&probe),
+                cholesky_operator.apply_preconditioner(&probe),
+            ) {
+                (Ok(general), Ok(cholesky)) => Some((general - cholesky).norm()),
+                _ => None,
+            };
+
+            for pcg_max_iterations in [128_usize, 512_usize] {
+                let options = implicit_schur::PcgOptions {
+                    max_iterations: pcg_max_iterations,
+                    relative_tolerance: ORACLE_PC_TOLERANCE,
+                    absolute_tolerance: ORACLE_PC_TOLERANCE,
+                };
+                let mut general = run_cholesky_pcg_arm(
+                    &general_rhs,
+                    dimension,
+                    options,
+                    &general_lower_schur,
+                    general_dense_solution.as_ref(),
+                    general_dense_landmark_delta.as_ref(),
+                    general_dense_action_true_residual,
+                    general_dense_original_pose_equation_residual,
+                    |x| general_operator.apply(x),
+                    |residual| general_operator.apply_preconditioner(residual),
+                    |pose| general_operator.complete_delta(pose),
+                    "general_pcg",
+                );
+                populate_cholesky_arm_diagnostics(
+                    &mut general,
+                    ba,
+                    &system,
+                    lambda,
+                    &general_lower_schur,
+                    &general_rhs,
+                    None,
+                );
+                let mut cholesky = run_cholesky_pcg_arm(
+                    cholesky_operator.rhs(),
+                    dimension,
+                    options,
+                    &cholesky_lower_schur,
+                    cholesky_dense_solution.as_ref(),
+                    cholesky_dense_landmark_delta.as_ref(),
+                    cholesky_dense_action_true_residual,
+                    cholesky_dense_original_pose_equation_residual,
+                    |x| cholesky_operator.apply(x),
+                    |residual| cholesky_operator.apply_preconditioner(residual),
+                    |pose| cholesky_operator.complete_delta(pose),
+                    "cholesky_pcg",
+                );
+                populate_cholesky_arm_diagnostics(
+                    &mut cholesky,
+                    ba,
+                    &system,
+                    lambda,
+                    &cholesky_lower_schur,
+                    cholesky_operator.rhs(),
+                    Some(&cholesky_operator.factors),
+                );
+                let general_vs_cholesky_pose_error =
+                    match (general.solution.as_ref(), cholesky.solution.as_ref()) {
+                        (Some(general), Some(cholesky)) => Some((general - cholesky).norm()),
+                        _ => None,
+                    };
+                let general_vs_cholesky_landmark_error = match (
+                    general.landmark_delta.as_ref(),
+                    cholesky.landmark_delta.as_ref(),
+                ) {
+                    (Some(general), Some(cholesky)) => Some((general - cholesky).norm()),
+                    _ => None,
+                };
+                reports.push(CholeskyPcgIsolationReport {
+                    lambda,
+                    pcg_max_iterations,
+                    general_metrics,
+                    cholesky_metrics,
+                    general: general.report,
+                    cholesky: cholesky.report,
+                    general_vs_cholesky_pose_error,
+                    general_vs_cholesky_landmark_error,
+                    rhs_error: Some(rhs_error),
+                    probe_action_error,
+                    probe_preconditioner_error,
+                });
+            }
+        }
+        Ok(reports)
+    }
+
     fn schur_asymmetry(matrix: &DMatrix<f64>) -> f64 {
         let mut max_difference: f64 = 0.0;
         for row in 0..matrix.nrows() {
@@ -8601,6 +9645,106 @@ mod matrix_free_real_oracle_tests {
                 && max_landmark.is_finite()
                 && geometry_feasible,
         }
+    }
+
+    fn cholesky_backsub_residual(
+        system: &NormalEquationsBa,
+        lambda: f64,
+        _factors: &[LandmarkCholesky],
+        delta_pose: &DVector<f64>,
+        delta_landmarks: &DVector<f64>,
+    ) -> f64 {
+        let mut max_residual = 0.0_f64;
+        for (index, landmark) in system.landmarks.iter().enumerate() {
+            let delta_l: Vector3<f64> = delta_landmarks.fixed_rows::<3>(index * 3).into_owned();
+            let mut h_ll = landmark.h_ll;
+            for component in 0..3 {
+                h_ll[(component, component)] += lambda;
+            }
+            let mut residual = h_ll * delta_l + landmark.b_l;
+            for (pose, cross) in &landmark.cross {
+                let delta_p: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+                residual += cross.transpose() * delta_p;
+            }
+            let norm = residual.norm();
+            if !norm.is_finite() {
+                return f64::NAN;
+            }
+            max_residual = max_residual.max(norm);
+        }
+        max_residual
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn feasibility_with_cholesky(
+        ba: &BundleAdjustment,
+        system: &NormalEquationsBa,
+        lambda: f64,
+        schur: &DMatrix<f64>,
+        rhs: &DVector<f64>,
+        delta_pose: &DVector<f64>,
+        delta_landmarks: &DVector<f64>,
+        implicit_pose_true_residual: Option<f64>,
+        factors: &[LandmarkCholesky],
+    ) -> Feasibility {
+        let mut result = feasibility(
+            ba,
+            system,
+            lambda,
+            schur,
+            rhs,
+            delta_pose,
+            delta_landmarks,
+            implicit_pose_true_residual,
+        );
+        result.max_landmark_backsub_residual =
+            cholesky_backsub_residual(system, lambda, factors, delta_pose, delta_landmarks);
+        result.feasible = result.finite
+            && result.pose_true_residual.is_finite()
+            && result.max_landmark_backsub_residual.is_finite()
+            && result.geometry_feasible;
+        result
+    }
+
+    fn original_pose_equation_residual(
+        system: &NormalEquationsBa,
+        lambda: f64,
+        delta_pose: &DVector<f64>,
+        delta_landmarks: &DVector<f64>,
+    ) -> Option<f64> {
+        let CameraHessian::PoseDiagonal(diagonal) = &system.h_pp else {
+            return None;
+        };
+        if delta_pose.len() != diagonal.len() * 6
+            || delta_landmarks.len() != system.landmarks.len() * 3
+        {
+            return None;
+        }
+        let mut residual = system.b_p.clone();
+        for (pose, block) in diagonal.iter().enumerate() {
+            let mut damped = *block;
+            for component in 0..6 {
+                damped[(component, component)] += lambda;
+            }
+            let delta: Vector6<f64> = delta_pose.fixed_rows::<6>(pose * 6).into_owned();
+            let value = damped * delta;
+            for component in 0..6 {
+                residual[pose * 6 + component] += value[component];
+            }
+        }
+        for (landmark_index, landmark) in system.landmarks.iter().enumerate() {
+            let delta: Vector3<f64> = delta_landmarks
+                .fixed_rows::<3>(landmark_index * 3)
+                .into_owned();
+            for (pose, cross) in &landmark.cross {
+                let value: Vector6<f64> = cross * delta;
+                for component in 0..6 {
+                    residual[pose * 6 + component] += value[component];
+                }
+            }
+        }
+        let norm = residual.norm();
+        norm.is_finite().then_some(norm)
     }
 
     fn schur_action_scales(
@@ -9084,6 +10228,90 @@ mod matrix_free_real_oracle_tests {
         ba
     }
 
+    fn non_diagonal_landmark_system() -> NormalEquationsBa {
+        let h_pp = Matrix6::identity() * 20.0;
+        let cross = Matrix6x3::from_row_slice(&[
+            0.8, -0.2, 0.1, 0.0, 0.4, -0.3, 0.2, 0.1, 0.5, -0.1, 0.3, 0.2, 0.6, -0.4, 0.2, 0.1,
+            0.2, 0.7,
+        ]);
+        NormalEquationsBa {
+            h_pp: CameraHessian::PoseDiagonal(vec![h_pp]),
+            b_p: DVector::from_iterator(6, (0..6).map(|index| 0.2 + index as f64 * 0.03)),
+            landmarks: vec![LandmarkBlock {
+                h_ll: Matrix3::new(8.0, 1.0, 0.5, 1.0, 6.0, -0.3, 0.5, -0.3, 7.0),
+                b_l: Vector3::new(0.4, -0.7, 0.2),
+                cross: vec![(0, cross)],
+            }],
+        }
+    }
+
+    #[test]
+    fn cholesky_landmark_arm_matches_general_inverse_for_nondiagonal_block() {
+        let system = non_diagonal_landmark_system();
+        for lambda in [0.0, 0.5, 1.0e5] {
+            let general = implicit_schur::ImplicitSchurOperator::new(&system, lambda).unwrap();
+            let (cholesky, metrics) = CholeskySchurOperator::new(&system, lambda).unwrap();
+            assert!(metrics.h_ll_max_asymmetry < 1.0e-12);
+            assert!(metrics.inverse_max_asymmetry.unwrap() < 1.0e-12);
+            assert!(metrics.h_ll_inverse_identity_residual.unwrap().is_finite());
+            assert!((general.rhs() - cholesky.rhs()).norm() < 1.0e-10);
+            let probe = DVector::from_iterator(6, (0..6).map(|index| 0.1 + index as f64 * 0.07));
+            assert!(
+                (general.apply(&probe).unwrap() - cholesky.apply(&probe).unwrap()).norm() < 1.0e-10
+            );
+            assert!(
+                (general.apply_preconditioner(&probe).unwrap()
+                    - cholesky.apply_preconditioner(&probe).unwrap())
+                .norm()
+                    < 1.0e-10
+            );
+            assert!(
+                (general.complete_delta(&probe).unwrap()
+                    - cholesky.complete_delta(&probe).unwrap())
+                .norm()
+                    < 1.0e-10
+            );
+
+            let (general_raw, general_rhs, _) = explicit_schur_rhs(&system, lambda).unwrap();
+            let (cholesky_raw, cholesky_rhs) =
+                explicit_cholesky_schur_rhs(&system, &cholesky).unwrap();
+            let mut general_lower = general_raw;
+            let mut cholesky_lower = cholesky_raw;
+            mirror_lower_triangle(&mut general_lower);
+            mirror_lower_triangle(&mut cholesky_lower);
+            assert!((general_rhs - cholesky_rhs).norm() < 1.0e-10);
+            assert!((general_lower - cholesky_lower).norm() < 1.0e-10);
+        }
+    }
+
+    #[test]
+    fn cholesky_landmark_arm_rejects_asymmetric_input_without_fallback() {
+        let mut system = non_diagonal_landmark_system();
+        if let Some(landmark) = system.landmarks.first_mut() {
+            landmark.h_ll[(0, 1)] += 1.0e-6;
+        }
+        let error = match CholeskySchurOperator::new(&system, 0.5) {
+            Ok(_) => panic!("asymmetric landmark block must not use a Cholesky fallback"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("not symmetric"));
+    }
+
+    #[test]
+    fn cholesky_landmark_arm_rejects_symmetric_non_spd_input_without_general_fallback() {
+        let mut system = non_diagonal_landmark_system();
+        if let Some(landmark) = system.landmarks.first_mut() {
+            landmark.h_ll = Matrix3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0);
+            landmark.cross = vec![(0, Matrix6x3::zeros())];
+        }
+        assert!(implicit_schur::ImplicitSchurOperator::new(&system, 0.1).is_ok());
+        let error = match CholeskySchurOperator::new(&system, 0.1) {
+            Ok(_) => panic!("symmetric non-SPD block must not use a general fallback"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("not SPD"));
+    }
+
     #[test]
     fn synthetic_oracle_compares_both_damping_values_and_coefficients() {
         let reports = run_oracle(&synthetic_rig_problem()).unwrap();
@@ -9224,6 +10452,83 @@ mod matrix_free_real_oracle_tests {
             }
         }
         assert!(successful_explicit_arms > 0);
+
+        let cholesky_reports = run_cholesky_pcg_isolation(&synthetic_rig_problem()).unwrap();
+        assert_eq!(cholesky_reports.len(), 6);
+        for report in cholesky_reports {
+            assert!(report.general_metrics.h_ll_max_scale.is_finite());
+            assert!(report.cholesky_metrics.h_ll_max_scale.is_finite());
+            assert!(report.cholesky_metrics.h_ll_max_asymmetry < 1.0e-12);
+            assert!(report.rhs_error.is_some_and(|error| error < 1.0e-8));
+            assert!(report
+                .probe_action_error
+                .is_some_and(|error| error < 1.0e-8));
+            assert!(report
+                .probe_preconditioner_error
+                .is_some_and(|error| error < 1.0e-8));
+            if report.lambda == 1.0e10 {
+                assert_eq!(report.general.status, "general_pcg");
+                assert_eq!(report.cholesky.status, "cholesky_pcg");
+                assert!(report
+                    .general
+                    .pose_error_vs_dense
+                    .is_some_and(|error| error < 1.0e-7));
+                assert!(report
+                    .cholesky
+                    .pose_error_vs_dense
+                    .is_some_and(|error| error < 1.0e-7));
+                assert!(report
+                    .general
+                    .landmark_error_vs_dense
+                    .is_some_and(|error| error < 1.0e-7));
+                assert!(report
+                    .cholesky
+                    .landmark_error_vs_dense
+                    .is_some_and(|error| error < 1.0e-7));
+                assert!(report
+                    .general_vs_cholesky_pose_error
+                    .is_some_and(|error| error < 1.0e-7));
+                assert!(report
+                    .general_vs_cholesky_landmark_error
+                    .is_some_and(|error| error < 1.0e-7));
+                assert!(report
+                    .general
+                    .original_pose_equation_residual
+                    .is_some_and(f64::is_finite));
+                assert!(report
+                    .cholesky
+                    .original_pose_equation_residual
+                    .is_some_and(f64::is_finite));
+                assert!(report
+                    .general
+                    .dense_reference_action_true_residual
+                    .is_some_and(f64::is_finite));
+                assert!(report
+                    .cholesky
+                    .dense_reference_action_true_residual
+                    .is_some_and(f64::is_finite));
+                assert!(report
+                    .general
+                    .dense_reference_original_pose_equation_residual
+                    .is_some_and(f64::is_finite));
+                assert!(report
+                    .cholesky
+                    .dense_reference_original_pose_equation_residual
+                    .is_some_and(f64::is_finite));
+                assert!(report
+                    .general
+                    .feasibility
+                    .as_ref()
+                    .is_some_and(|value| value.feasible));
+                assert!(report
+                    .cholesky
+                    .feasibility
+                    .as_ref()
+                    .is_some_and(|value| value.feasible));
+                assert!(report.general.prediction.is_some());
+                assert!(report.cholesky.prediction.is_some());
+            }
+        }
     }
 
     #[test]
@@ -9422,6 +10727,11 @@ mod matrix_free_real_oracle_tests {
         assert_eq!(isolation_reports.len(), 6);
         for report in isolation_reports {
             println!("explicit_pcg_isolation {report:?}");
+        }
+        let cholesky_reports = run_cholesky_pcg_isolation(&fixture.ba).unwrap();
+        assert_eq!(cholesky_reports.len(), 6);
+        for report in cholesky_reports {
+            println!("cholesky_pcg_isolation {report:?}");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add a bounded, test-only Cholesky landmark-elimination oracle, consistently using triangular solves for RHS, Schur action, preconditioner and back-substitution.
- Preserve all production solver defaults and APIs. Add an example-only explicit PCG relative-tolerance option with validation and accurate configuration/summary logs.
- Record two repeated Cholesky diagnostics and six same-binary nonlinear 1k runs, identity/geometry/GT audits, hashes and limits.

## Results and scope

Cholesky improves several residuals but still fails the useful lambda=1e5 true-residual target; the original general inverse is measured symmetric. It remains test-only.

PCG512 relative1e-8 / absolute1e-12 improves over strict: cost118070.554 and RMSE0.026608m, versus strict126419.082 /0.026703m. Direct remains better at117496.033 /0.026519m. New arm wall20.19/20.29s, RSS84564KiB; direct45.49/45.37s, RSS161692/161932KiB. This is different-quality post-map BA, not equivalent-quality speedup, mapper/E2E timing or a10k promotion.

All1000 images,500 frames,4716 points,130900 observations and361170 keypoints retained; identity, fixed calibration, component support and positive depths pass. Repeats have exact model hashes and numerical traces; direct/strict controls match PR79. Maximum observation error is not universally improved. README claims unchanged.

## Validation

- 14 example tests
- 10 bounded oracle tests passed; 1 real-fixture test ignored normally and executed twice explicitly
- targeted example and lib/tests clippy, formatting
- 46 Python tests, documentation links, 189 registry JSON files, generated-claim check
- Independent artifact hash and geometry/identity/trajectory checks

Evidence:
- benchmarks/electro/m8-openloris-cholesky-landmark-elimination-v1.json
- benchmarks/electro/m8-openloris-relative-pcg-tolerance-v1.json

Next candidate is a separately controlled one-time true-residual restart within the existing total iteration budget, grounded in residual-gap/replacement literature. It is documented, not implemented here. Full M8–M10 goal remains open.

## Closure

All eight final-head checks passed (CI run34130693082, headcd226ddf1944ff185858b4f51b7e1bc469df1e02). Squash merged as 35df35fd7b00d21cb339c5d6ded8caf19ac1f48a at 2026-09-07T14:07:26Z. Local and remote topic branches removed; main clean. Independent final review found no material evidence/claim corrections.