### PR TITLE
test(sfm): add and evaluate frozen Huber BA intervention

### DIFF
--- a/benchmarks/electro/m8-openloris-frozen-huber-ba-preflight-v1.json
+++ b/benchmarks/electro/m8-openloris-frozen-huber-ba-preflight-v1.json
@@ -1,0 +1,122 @@
+{
+  "schema": "visloc_m8_frozen_huber_ba_preflight_v1",
+  "status": "candidate_fixed_before_measurement",
+  "contract_commit": "9de6fe8",
+  "base_merge_commit": "e1695275c6a14e74f9776058a64c0a7d0ab56c2d",
+  "candidate": {
+    "kernel": "Huber",
+    "delta_px": 3,
+    "scale_basis": "existing IncrementalSfmConfig engineering default, not GT selected",
+    "matrix_free": true,
+    "column_scaling": true,
+    "adaptive_damping": true,
+    "iterations": 20,
+    "initial_lambda": 0.0001,
+    "pcg_max_iterations": 512,
+    "pcg_relative_tolerance": 1e-8,
+    "pcg_absolute_tolerance": 1e-12,
+    "pcg_max_restarts": 0,
+    "threads": 1,
+    "all_landmarks_variable": true,
+    "fixed_frame_id": 0
+  },
+  "gates": {
+    "ate_rmse_max_m": 0.026608055174816774,
+    "ate_p95_max_m": 0.04109998478546261,
+    "raw_mean_reprojection_max_px": 0.691588658326868,
+    "identity_and_order_exact": true,
+    "all_observations_positive_depth": true,
+    "one_supported_component": true,
+    "calibration_and_anchor_preserved": true,
+    "accepted_update_required": true,
+    "repeat_model_bytes_and_numerical_traces_exact": true
+  },
+  "initial": {
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+    "images": 1000,
+    "landmarks": 4716,
+    "observations": 130900,
+    "keypoints": 361170,
+    "raw_squared_cost": 126510.39875805238,
+    "huber_3px_cost": 125938.89325088603,
+    "raw_mean_px": 0.720678689714061,
+    "raw_rmse_px": 0.9830900239021312,
+    "raw_p95_px": 2.148156034094761,
+    "raw_max_px": 3.9995690559394936,
+    "downweighted_observations": 1984,
+    "weight_min": 0.7500808107175696,
+    "weight_sum": 130653.34773138781,
+    "all_positive_depth": true,
+    "min_depth_m": 0.00011093307669790553,
+    "max_depth_m": 5207.122999967967,
+    "nonprojectable_observations": 0,
+    "quantile_method": "numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve",
+    "input_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "90773af9546ea351f9610721eab2ccac7b6d55f9c0638fd7ce596942012610d6",
+      "points3D.txt": "8850f161ac44f76ef6d512f8c1739493970849a380f6a232c82e3006a33f346a"
+    }
+  },
+  "prior_controls": {
+    "legacy": {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-weak-angle-fixed-landmarks-v1/legacy/model",
+      "images": 1000,
+      "landmarks": 4716,
+      "observations": 130900,
+      "keypoints": 361170,
+      "raw_squared_cost": 118070.55436891594,
+      "huber_3px_cost": 117471.29096772365,
+      "raw_mean_px": 0.691588658326868,
+      "raw_rmse_px": 0.9497317958780395,
+      "raw_p95_px": 2.0550448938898276,
+      "raw_max_px": 4.84008923981911,
+      "downweighted_observations": 1700,
+      "weight_min": 0.6198232824550399,
+      "weight_sum": 130673.57532942058,
+      "all_positive_depth": true,
+      "min_depth_m": 0.00001364691730734724,
+      "max_depth_m": 5207.231377381257,
+      "nonprojectable_observations": 0,
+      "quantile_method": "numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve",
+      "input_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "dfc2dba4c21f4d5f31ffd8ac40f405c17476e4251ec630cd9806668e81252425",
+        "points3D.txt": "86242e11eb98dd920eda04af59f17c6fab4d79f257cbd7679421281e03a43e10"
+      }
+    },
+    "adaptive": {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-weak-angle-fixed-landmarks-v1/adaptive/model",
+      "images": 1000,
+      "landmarks": 4716,
+      "observations": 130900,
+      "keypoints": 361170,
+      "raw_squared_cost": 113550.21933901115,
+      "huber_3px_cost": 112906.08606200629,
+      "raw_mean_px": 0.675153253020779,
+      "raw_rmse_px": 0.931374118687611,
+      "raw_p95_px": 2.0091280316378604,
+      "raw_max_px": 5.101115585248235,
+      "downweighted_observations": 1572,
+      "weight_min": 0.5881066503718542,
+      "weight_sum": 130679.82899874753,
+      "all_positive_depth": true,
+      "min_depth_m": 0.00006868780493446414,
+      "max_depth_m": 5212.560478444767,
+      "nonprojectable_observations": 0,
+      "quantile_method": "numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve",
+      "input_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "5f06ca8c42e6aba0a557ad18dc73175467a6b535de04c6e156dfc55ad5af96c3",
+        "points3D.txt": "11d61d0e53e58c6eba2e3465e08ae0d5743ae5ded0cc63b3a4f37c4cffc75be0"
+      }
+    }
+  },
+  "independent_program": "import sys,json,math,hashlib,array\nfrom pathlib import Path\nimport numpy as np\nsys.path.insert(0,'scripts')\nfrom audit_colmap_pinhole_model import rotation\nroot=Path(sys.argv[1])\nnames=('cameras.txt','images.txt','points3D.txt')\nfor name in names:\n    path=root/name\n    assert path.is_file() and not path.is_symlink() and path.stat().st_size<=32*1024*1024\ndef hashes():\n    return {name:hashlib.sha256((root/name).read_bytes()).hexdigest() for name in names}\nbefore=hashes()\ncameras={}\nfor line in (root/'cameras.txt').read_text().splitlines():\n    if line.strip() and not line.lstrip().startswith('#'):\n        row=line.split();assert row[1]=='PINHOLE' and len(row)==8\n        cameras[int(row[0])]=tuple(map(float,row[4:]))\nimages={};keypoints=0\nwith (root/'images.txt').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('#'):continue\n        row=line.split();kp=next(stream).split();assert len(kp)%3==0\n        i=int(row[0]);assert i not in images\n        images[i]=(rotation(row[1:5]),tuple(map(float,row[5:8])),cameras[int(row[8])],kp)\n        keypoints+=len(kp)//3\n        assert len(images)<=1000 and keypoints<=361170\nresiduals=array.array('d');min_depth=math.inf;max_depth=0;points=0\nwith (root/'points3D.txt').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('#'):continue\n        row=line.split();assert (len(row)-8)%2==0\n        point_id=int(row[0]);xyz=tuple(map(float,row[1:4]));points+=1\n        assert points<=4716 and all(map(math.isfinite,xyz))\n        for j in range(8,len(row),2):\n            i,k=map(int,row[j:j+2]);R,t,intr,kp=images[i]\n            assert int(kp[3*k+2])==point_id\n            q=[sum(v*x for v,x in zip(axis,xyz))+shift for axis,shift in zip(R,t)]\n            assert all(map(math.isfinite,q)) and q[2]>0\n            fx,fy,cx,cy=intr\n            dx=fx*q[0]/q[2]+cx-float(kp[3*k]);dy=fy*q[1]/q[2]+cy-float(kp[3*k+1])\n            s=dx*dx+dy*dy;assert math.isfinite(s)\n            residuals.append(math.sqrt(s));assert len(residuals)<=130900\n            min_depth=min(min_depth,q[2]);max_depth=max(max_depth,q[2])\nassert (len(images),points,len(residuals),keypoints)==(1000,4716,130900,361170)\nraw=math.fsum(r*r for r in residuals)\nrobust=math.fsum(r*r if r<=3 else 6*r-9 for r in residuals)\nweight_sum=math.fsum(1 if r<=3 else 3/r for r in residuals)\nresult=dict(model=str(root),images=len(images),landmarks=points,observations=len(residuals),keypoints=keypoints,\n    raw_squared_cost=raw,huber_3px_cost=robust,raw_mean_px=math.fsum(residuals)/len(residuals),\n    raw_rmse_px=math.sqrt(raw/len(residuals)),raw_p95_px=float(np.percentile(np.frombuffer(residuals,dtype=np.float64),95,method='linear')),\n    raw_max_px=max(residuals),downweighted_observations=sum(r>3 for r in residuals),\n    weight_min=min(1,3/max(residuals)),weight_sum=weight_sum,all_positive_depth=True,\n    min_depth_m=min_depth,max_depth_m=max_depth,nonprojectable_observations=0,\n    quantile_method='numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve',\n    input_sha256=before)\nassert hashes()==before\nprint(json.dumps(result,indent=2))\n",
+  "initial_command": "python3 -c 'import sys,json,math,hashlib,array\nfrom pathlib import Path\nimport numpy as np\nsys.path.insert(0,'\\''scripts'\\'')\nfrom audit_colmap_pinhole_model import rotation\nroot=Path(sys.argv[1])\nnames=('\\''cameras.txt'\\'','\\''images.txt'\\'','\\''points3D.txt'\\'')\nfor name in names:\n    path=root/name\n    assert path.is_file() and not path.is_symlink() and path.stat().st_size<=32*1024*1024\ndef hashes():\n    return {name:hashlib.sha256((root/name).read_bytes()).hexdigest() for name in names}\nbefore=hashes()\ncameras={}\nfor line in (root/'\\''cameras.txt'\\'').read_text().splitlines():\n    if line.strip() and not line.lstrip().startswith('\\''#'\\''):\n        row=line.split();assert row[1]=='\\''PINHOLE'\\'' and len(row)==8\n        cameras[int(row[0])]=tuple(map(float,row[4:]))\nimages={};keypoints=0\nwith (root/'\\''images.txt'\\'').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('\\''#'\\''):continue\n        row=line.split();kp=next(stream).split();assert len(kp)%3==0\n        i=int(row[0]);assert i not in images\n        images[i]=(rotation(row[1:5]),tuple(map(float,row[5:8])),cameras[int(row[8])],kp)\n        keypoints+=len(kp)//3\n        assert len(images)<=1000 and keypoints<=361170\nresiduals=array.array('\\''d'\\'');min_depth=math.inf;max_depth=0;points=0\nwith (root/'\\''points3D.txt'\\'').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('\\''#'\\''):continue\n        row=line.split();assert (len(row)-8)%2==0\n        point_id=int(row[0]);xyz=tuple(map(float,row[1:4]));points+=1\n        assert points<=4716 and all(map(math.isfinite,xyz))\n        for j in range(8,len(row),2):\n            i,k=map(int,row[j:j+2]);R,t,intr,kp=images[i]\n            assert int(kp[3*k+2])==point_id\n            q=[sum(v*x for v,x in zip(axis,xyz))+shift for axis,shift in zip(R,t)]\n            assert all(map(math.isfinite,q)) and q[2]>0\n            fx,fy,cx,cy=intr\n            dx=fx*q[0]/q[2]+cx-float(kp[3*k]);dy=fy*q[1]/q[2]+cy-float(kp[3*k+1])\n            s=dx*dx+dy*dy;assert math.isfinite(s)\n            residuals.append(math.sqrt(s));assert len(residuals)<=130900\n            min_depth=min(min_depth,q[2]);max_depth=max(max_depth,q[2])\nassert (len(images),points,len(residuals),keypoints)==(1000,4716,130900,361170)\nraw=math.fsum(r*r for r in residuals)\nrobust=math.fsum(r*r if r<=3 else 6*r-9 for r in residuals)\nweight_sum=math.fsum(1 if r<=3 else 3/r for r in residuals)\nresult=dict(model=str(root),images=len(images),landmarks=points,observations=len(residuals),keypoints=keypoints,\n    raw_squared_cost=raw,huber_3px_cost=robust,raw_mean_px=math.fsum(residuals)/len(residuals),\n    raw_rmse_px=math.sqrt(raw/len(residuals)),raw_p95_px=float(np.percentile(np.frombuffer(residuals,dtype=np.float64),95,method='\\''linear'\\'')),\n    raw_max_px=max(residuals),downweighted_observations=sum(r>3 for r in residuals),\n    weight_min=min(1,3/max(residuals)),weight_sum=weight_sum,all_positive_depth=True,\n    min_depth_m=min_depth,max_depth_m=max_depth,nonprojectable_observations=0,\n    quantile_method='\\''numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve'\\'',\n    input_sha256=before)\nassert hashes()==before\nprint(json.dumps(result,indent=2))\n' '/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model'",
+  "limitations": [
+    "Read-only existing output audits are outside timed solve. No new candidate solve or GT scoring has run.",
+    "Initial model serialized-sensor projection differs at sub-micro cost level from BA body-pose recomposition; certify source hashes, use 1e-5 absolute external cost tolerance, and record actual differences.",
+    "Only 1.52% initial residuals exceed 3 px; no guarantee of causal leverage or accuracy improvement.",
+    "Exact raw p95 uses bounded O(130900) scalar buffer outside timed solve, not constant-memory streaming quantiles."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-frozen-huber-ba-v1.json
+++ b/benchmarks/electro/m8-openloris-frozen-huber-ba-v1.json
@@ -1,0 +1,698 @@
+{
+  "schema": "visloc_m8_frozen_huber_ba_v1",
+  "status": "measured_failed_quality_gate",
+  "scope": "One frozen 1k post-input rig BA problem, not native mapper or native E2E",
+  "preflight": "m8-openloris-frozen-huber-ba-preflight-v1.json",
+  "certificate": {
+    "implementation_commit": "c026f404d92ff466c691ac86e240ab2df5629504",
+    "driver_sha256": "5e656249c85bb5465879722bc92acf1b12f64bae03c436918f326489c91deeb3",
+    "bundle_sha256": "8f84b49c8b4704ce8a4a918cbc18dcbb39d1191c326f00c233ce1c22e3275e4b",
+    "lib_sha256": "33909a1d725fee977d3af4aa45e8f69eaa240008526d94e28eb880fb9bae4de3",
+    "binary_sha256": "cdbdf63466e9cca7940014d20605ec9485c566f184a86ac7c11dd5476fea23f3",
+    "build": {
+      "command": "cargo build --release --example compare_rig_bundle_adjustment",
+      "exit_code": 0,
+      "reported_seconds": 3.68
+    },
+    "root_tests": {
+      "driver": "28 passed",
+      "example_clippy": "passed -D warnings",
+      "huber_weight_derivative": "1 passed",
+      "matrix_free_rig_regression": "1 passed"
+    },
+    "toolchain": {
+      "rustc": "1.94.0 (4a4ef493e 2026-03-02)",
+      "cargo": "1.94.0 (85eff7c80 2026-01-15)"
+    },
+    "input_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "90773af9546ea351f9610721eab2ccac7b6d55f9c0638fd7ce596942012610d6",
+      "points3D.txt": "8850f161ac44f76ef6d512f8c1739493970849a380f6a232c82e3006a33f346a"
+    },
+    "rig_sha256": "6bcd670c475c66a82aaa9b96247331ca1686df2676d569cf7ed01c3158c35900",
+    "source_combined_sha256": "ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829",
+    "commands": {
+      "legacy": "test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy && test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy.time && env -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy/model > /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy.log 2>&1",
+      "adaptive": "test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive && test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive.time && env -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --matrix-free-column-scaling --matrix-free-adaptive-damping --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive/model > /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive.log 2>&1",
+      "huber3": "test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3 && test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3.time && env -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --matrix-free-column-scaling --matrix-free-adaptive-damping --huber-loss-3px --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model > /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3.log 2>&1",
+      "huber3-repeat": "test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat && test ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat.time && env -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --matrix-free-column-scaling --matrix-free-adaptive-damping --huber-loss-3px --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat/model > /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat.log 2>&1"
+    },
+    "run_order": [
+      "legacy",
+      "adaptive",
+      "huber3",
+      "huber3-repeat"
+    ],
+    "before_any_real_run": true
+  },
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1",
+  "runs": {
+    "legacy": {
+      "summary": {
+        "solver": "matrix-free",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.180705543689159e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "pcg_max_iterations": "512",
+        "pcg_relative_tolerance": "1.00000000000000002e-8",
+        "pcg_absolute_tolerance": "9.99999999999999980e-13",
+        "solver_seconds": "19.600873",
+        "total_seconds": "19.831944",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy/model"
+      },
+      "wall_seconds": 19.84,
+      "peak_rss_kib": 84652,
+      "exit_code": 0,
+      "accepted_lm_updates": 3,
+      "successful_pcg": 3,
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "dfc2dba4c21f4d5f31ffd8ac40f405c17476e4251ec630cd9806668e81252425",
+        "points3D.txt": "86242e11eb98dd920eda04af59f17c6fab4d79f257cbd7679421281e03a43e10"
+      },
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/legacy/model\"\n\tUser time (seconds): 19.79\n\tSystem time (seconds): 0.04\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:19.84\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 84652\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 22686\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 128\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 20824\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "artifact_sha256": {
+        "log": "f1505b19db9912351a16b99f58da70cef131aec1d83bcd900bb2717553f8e6ed",
+        "time": "c260e98d7ebaa63f3eae6f34cf53c9bbb5b6367714d97b616c8057e43cf3e588"
+      },
+      "prior_control_model_and_numerical_trace_exact": true,
+      "numerical_trace_rows": 40,
+      "numerical_trace_sha256": "cc7c040e4624c587cde178a4175cab9e2b29e7b02ee86076695861ab4c7e08c0"
+    },
+    "adaptive": {
+      "summary": {
+        "solver": "matrix-free-column-scaled-adaptive",
+        "initial_cost": "1.265103987573094e5",
+        "final_cost": "1.135502193390116e5",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "allow_unsupported_sensor_images": "false",
+        "source_supported_image_count": "1000",
+        "pcg_max_iterations": "512",
+        "pcg_relative_tolerance": "1.00000000000000002e-8",
+        "pcg_absolute_tolerance": "9.99999999999999980e-13",
+        "pcg_max_restarts": "0",
+        "adaptive_damping": "true",
+        "adaptive_iterations": "20",
+        "prediction_coordinates": "scaled",
+        "prediction": "undamped_squared_cost",
+        "acceptance_rho": "actual_same_observation_cost_decrease_over_prediction",
+        "accepted_lambda_factor": "max_1_3_1_minus_centered_rho_cubed",
+        "solver_seconds": "22.018174",
+        "total_seconds": "22.252184",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive/model"
+      },
+      "wall_seconds": 22.26,
+      "peak_rss_kib": 84856,
+      "exit_code": 0,
+      "accepted_lm_updates": 15,
+      "successful_pcg": 20,
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "5f06ca8c42e6aba0a557ad18dc73175467a6b535de04c6e156dfc55ad5af96c3",
+        "points3D.txt": "11d61d0e53e58c6eba2e3465e08ae0d5743ae5ded0cc63b3a4f37c4cffc75be0"
+      },
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --matrix-free-column-scaling --matrix-free-adaptive-damping --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/adaptive/model\"\n\tUser time (seconds): 22.20\n\tSystem time (seconds): 0.05\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:22.26\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 84856\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 22761\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 187\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 20856\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "artifact_sha256": {
+        "log": "2a1bfa15aa4294dd289c65ed5c50b080f5875e2a5baa581ed98565808af1ac47",
+        "time": "e8354c62ca45691cbcdaea62eb15650566bc96ef25f1d21d2eb76bd151471968"
+      },
+      "prior_control_model_and_numerical_trace_exact": true,
+      "numerical_trace_rows": 82,
+      "numerical_trace_sha256": "abfa7cc45b04bbcf6fd901fc9355c51346d06a4f0b440b1bcd32b20c384314e7"
+    },
+    "huber3": {
+      "summary": {
+        "solver": "matrix-free-column-scaled-adaptive",
+        "cost_objective": "robust_huber_3px",
+        "raw_objective": "sum_squared",
+        "lm_trace_cost": "robust_huber",
+        "delta_px": "3.00000000000000000e0",
+        "initial_cost": "1.259388932501286e5",
+        "final_cost": "1.128921430795691e5",
+        "initial_raw_cost": "1.265103987573094e5",
+        "final_raw_cost": "1.138169989304408e5",
+        "initial_robust_cost": "1.259388932501286e5",
+        "final_robust_cost": "1.128921430795691e5",
+        "initial_raw_mean_px": "7.206786897055600e-1",
+        "final_raw_mean_px": "6.732622404250271e-1",
+        "initial_raw_rmse_px": "9.830900238992444e-1",
+        "final_raw_rmse_px": "9.324675812855462e-1",
+        "initial_max_residual_px": "3.999569055666249e0",
+        "final_max_residual_px": "5.524139736727758e0",
+        "initial_valid_observations": "130900",
+        "final_valid_observations": "130900",
+        "initial_nonprojectable_observations": "0",
+        "final_nonprojectable_observations": "0",
+        "initial_robustified_observations": "1984",
+        "final_robustified_observations": "1617",
+        "initial_minimum_weight": "7.50080810768814055e-1",
+        "final_minimum_weight": "5.43070983533276763e-1",
+        "initial_weight_sum": "1.306533477313892e5",
+        "final_weight_sum": "1.306467099960589e5",
+        "accepted_lm_steps": "13",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_sha256": "ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "allow_unsupported_sensor_images": "false",
+        "source_supported_image_count": "1000",
+        "pcg_max_iterations": "512",
+        "pcg_relative_tolerance": "1.00000000000000002e-8",
+        "pcg_absolute_tolerance": "9.99999999999999980e-13",
+        "pcg_max_restarts": "0",
+        "adaptive_damping": "true",
+        "solver_seconds": "21.689549",
+        "total_seconds": "21.988537",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model"
+      },
+      "wall_seconds": 22,
+      "peak_rss_kib": 85156,
+      "exit_code": 0,
+      "accepted_lm_updates": 13,
+      "successful_pcg": 20,
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "0c53e48afff57efe61a5172dbe290c884c3ef45d51736b9dbca36be3cae6c4cb",
+        "points3D.txt": "5943ba3fbf010e122c5d083b7b29da70a3e30bce6af53150d6be19c4a6e22af8"
+      },
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --matrix-free-column-scaling --matrix-free-adaptive-damping --huber-loss-3px --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model\"\n\tUser time (seconds): 21.90\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:22.00\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 85156\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 22778\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 103\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 20856\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "artifact_sha256": {
+        "log": "a575407f24ee07dcdcf0efefc5b67cc0007afdf702c22dc0b84f318c033f87c7",
+        "time": "1bb83ea9165304d2fa7b5644fd82f999d48bce2f441e890429e2a85ce20a228d"
+      },
+      "numerical_trace_rows": 85,
+      "numerical_trace_sha256": "a0bde889d7a9795ad9a4574bf22ce997b685aa3de9ff0048379eddea347b74af",
+      "solver_initial_matches_huber_and_all_accepted_steps_reduce_robust_cost": true
+    },
+    "huber3-repeat": {
+      "summary": {
+        "solver": "matrix-free-column-scaled-adaptive",
+        "cost_objective": "robust_huber_3px",
+        "raw_objective": "sum_squared",
+        "lm_trace_cost": "robust_huber",
+        "delta_px": "3.00000000000000000e0",
+        "initial_cost": "1.259388932501286e5",
+        "final_cost": "1.128921430795691e5",
+        "initial_raw_cost": "1.265103987573094e5",
+        "final_raw_cost": "1.138169989304408e5",
+        "initial_robust_cost": "1.259388932501286e5",
+        "final_robust_cost": "1.128921430795691e5",
+        "initial_raw_mean_px": "7.206786897055600e-1",
+        "final_raw_mean_px": "6.732622404250271e-1",
+        "initial_raw_rmse_px": "9.830900238992444e-1",
+        "final_raw_rmse_px": "9.324675812855462e-1",
+        "initial_max_residual_px": "3.999569055666249e0",
+        "final_max_residual_px": "5.524139736727758e0",
+        "initial_valid_observations": "130900",
+        "final_valid_observations": "130900",
+        "initial_nonprojectable_observations": "0",
+        "final_nonprojectable_observations": "0",
+        "initial_robustified_observations": "1984",
+        "final_robustified_observations": "1617",
+        "initial_minimum_weight": "7.50080810768814055e-1",
+        "final_minimum_weight": "5.43070983533276763e-1",
+        "initial_weight_sum": "1.306533477313892e5",
+        "final_weight_sum": "1.306467099960589e5",
+        "accepted_lm_steps": "13",
+        "lm_iterations": "20",
+        "converged": "false",
+        "source_sha256": "ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829",
+        "source_images": "1000",
+        "source_frames": "500",
+        "source_landmarks": "4716",
+        "source_observations": "130900",
+        "fixed_pose": "0",
+        "fixed_landmarks": "0",
+        "allow_unsupported_sensor_images": "false",
+        "source_supported_image_count": "1000",
+        "pcg_max_iterations": "512",
+        "pcg_relative_tolerance": "1.00000000000000002e-8",
+        "pcg_absolute_tolerance": "9.99999999999999980e-13",
+        "pcg_max_restarts": "0",
+        "adaptive_damping": "true",
+        "solver_seconds": "22.107005",
+        "total_seconds": "22.424100",
+        "out": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat/model"
+      },
+      "wall_seconds": 22.43,
+      "peak_rss_kib": 85108,
+      "exit_code": 0,
+      "accepted_lm_updates": 13,
+      "successful_pcg": 20,
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "0c53e48afff57efe61a5172dbe290c884c3ef45d51736b9dbca36be3cae6c4cb",
+        "points3D.txt": "5943ba3fbf010e122c5d083b7b29da70a3e30bce6af53150d6be19c4a6e22af8"
+      },
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/compare-c026f40 --model /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --solver matrix-free --pcg-max-iterations 512 --pcg-relative-tolerance 1e-8 --matrix-free-column-scaling --matrix-free-adaptive-damping --huber-loss-3px --out-dir /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3-repeat/model\"\n\tUser time (seconds): 22.37\n\tSystem time (seconds): 0.05\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:22.43\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 85108\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 22777\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 147\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 20856\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "artifact_sha256": {
+        "log": "83f01753121c261f7ec6193f4fe6ed247be5ef821a7839fea223e43e1d89fa4d",
+        "time": "aa49895d897a4449f556335593d2a5aa101e41e478b8f31660730d5b46047edb"
+      },
+      "numerical_trace_rows": 85,
+      "numerical_trace_sha256": "a0bde889d7a9795ad9a4574bf22ce997b685aa3de9ff0048379eddea347b74af",
+      "solver_initial_matches_huber_and_all_accepted_steps_reduce_robust_cost": true
+    }
+  },
+  "repeat_model_bytes_and_numerical_trace_exact": true,
+  "run_audit_program": "import sys,json,hashlib,re,shlex,math\nfrom pathlib import Path\nroot=Path(sys.argv[1])\nold=json.loads(Path('benchmarks/electro/m8-openloris-weak-angle-fixed-landmarks-v1.json').read_text())\nprefix=('lm_trace ','pcg_trace ','column_scaling_trace ','adaptive_damping_trace ','column_scaling_configuration ','adaptive_damping_configuration ','huber_loss_configuration ','huber_reprojection_stats ','huber_trace_objectives ')\nruns={}\nfor arm in ('legacy','adaptive','huber3','huber3-repeat'):\n    log=(root/(arm+'.log')).read_text();time=(root/(arm+'.time')).read_text()\n    lines=log.splitlines()\n    summary=dict(t.split('=',1) for t in shlex.split(next(l for l in lines if l.startswith('solver='))))\n    elapsed=re.search(r'Elapsed \\(wall clock\\) time \\(h:mm:ss or m:ss\\):\\s*(\\S+)',time).group(1)\n    seconds=0\n    for value in elapsed.split(':'): seconds=seconds*60+float(value)\n    exit_code=int(re.search(r'Exit status:\\s*(\\d+)',time).group(1));assert exit_code==0\n    trace=[l for l in lines if l.startswith(prefix)]\n    model_hashes={n:hashlib.sha256((root/arm/'model'/n).read_bytes()).hexdigest() for n in ('cameras.txt','images.txt','points3D.txt')}\n    accepted=sum(l.startswith('lm_trace ') and ' accepted=true' in l for l in lines)\n    assert accepted>0 and int(summary['source_observations'])==130900 and int(summary['fixed_landmarks'])==0\n    result=dict(summary=summary,wall_seconds=seconds,peak_rss_kib=int(re.search(r'Maximum resident set size \\(kbytes\\):\\s*(\\d+)',time).group(1)),\n        exit_code=exit_code,accepted_lm_updates=accepted,\n        successful_pcg=sum(l.startswith('pcg_trace ') and ' failure=none ' in l for l in lines),\n        numerical_trace=trace,model_sha256=model_hashes,time_output=time,\n        artifact_sha256={n:hashlib.sha256((root/(arm+'.'+n)).read_bytes()).hexdigest() for n in ('log','time')})\n    assert float(summary['final_cost'])<=float(summary['initial_cost']) and math.isfinite(float(summary['final_cost']))\n    if arm in ('legacy','adaptive'):\n        assert model_hashes==old['runs'][arm]['model_sha256'],arm\n        assert trace==old['runs'][arm]['numerical_trace'],arm\n        result['prior_control_model_and_numerical_trace_exact']=True\n    runs[arm]=result\nassert runs['huber3']['model_sha256']==runs['huber3-repeat']['model_sha256']\nassert runs['huber3']['numerical_trace']==runs['huber3-repeat']['numerical_trace']\nfor arm,result in runs.items():\n    trace=result.pop('numerical_trace')\n    result['numerical_trace_rows']=len(trace)\n    result['numerical_trace_sha256']=hashlib.sha256(('\\n'.join(trace)+'\\n').encode()).hexdigest()\n    if arm.startswith('huber3'):\n        summary=result['summary']\n        first=next(l for l in trace if l.startswith('lm_trace '))\n        first_fields=dict(t.split('=',1) for t in shlex.split(first) if '=' in t)\n        assert abs(float(first_fields['cost_before'])-float(summary['initial_robust_cost']))<1e-7\n        assert summary['cost_objective']=='robust_huber_3px'\n        assert summary['source_sha256']=='ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829'\n        for line in trace:\n            if line.startswith('lm_trace ') and ' accepted=true ' in line:\n                f=dict(t.split('=',1) for t in shlex.split(line) if '=' in t)\n                assert float(f['cost_after'])<float(f['cost_before'])\n        result['solver_initial_matches_huber_and_all_accepted_steps_reduce_robust_cost']=True\nprint(json.dumps(dict(runs=runs,repeat_model_bytes_and_numerical_trace_exact=True),indent=2))\n",
+  "run_audit_command": "python3 -c 'import sys,json,hashlib,re,shlex,math\nfrom pathlib import Path\nroot=Path(sys.argv[1])\nold=json.loads(Path('\\''benchmarks/electro/m8-openloris-weak-angle-fixed-landmarks-v1.json'\\'').read_text())\nprefix=('\\''lm_trace '\\'','\\''pcg_trace '\\'','\\''column_scaling_trace '\\'','\\''adaptive_damping_trace '\\'','\\''column_scaling_configuration '\\'','\\''adaptive_damping_configuration '\\'','\\''huber_loss_configuration '\\'','\\''huber_reprojection_stats '\\'','\\''huber_trace_objectives '\\'')\nruns={}\nfor arm in ('\\''legacy'\\'','\\''adaptive'\\'','\\''huber3'\\'','\\''huber3-repeat'\\''):\n    log=(root/(arm+'\\''.log'\\'')).read_text();time=(root/(arm+'\\''.time'\\'')).read_text()\n    lines=log.splitlines()\n    summary=dict(t.split('\\''='\\'',1) for t in shlex.split(next(l for l in lines if l.startswith('\\''solver='\\''))))\n    elapsed=re.search(r'\\''Elapsed \\(wall clock\\) time \\(h:mm:ss or m:ss\\):\\s*(\\S+)'\\'',time).group(1)\n    seconds=0\n    for value in elapsed.split('\\'':'\\''): seconds=seconds*60+float(value)\n    exit_code=int(re.search(r'\\''Exit status:\\s*(\\d+)'\\'',time).group(1));assert exit_code==0\n    trace=[l for l in lines if l.startswith(prefix)]\n    model_hashes={n:hashlib.sha256((root/arm/'\\''model'\\''/n).read_bytes()).hexdigest() for n in ('\\''cameras.txt'\\'','\\''images.txt'\\'','\\''points3D.txt'\\'')}\n    accepted=sum(l.startswith('\\''lm_trace '\\'') and '\\'' accepted=true'\\'' in l for l in lines)\n    assert accepted>0 and int(summary['\\''source_observations'\\''])==130900 and int(summary['\\''fixed_landmarks'\\''])==0\n    result=dict(summary=summary,wall_seconds=seconds,peak_rss_kib=int(re.search(r'\\''Maximum resident set size \\(kbytes\\):\\s*(\\d+)'\\'',time).group(1)),\n        exit_code=exit_code,accepted_lm_updates=accepted,\n        successful_pcg=sum(l.startswith('\\''pcg_trace '\\'') and '\\'' failure=none '\\'' in l for l in lines),\n        numerical_trace=trace,model_sha256=model_hashes,time_output=time,\n        artifact_sha256={n:hashlib.sha256((root/(arm+'\\''.'\\''+n)).read_bytes()).hexdigest() for n in ('\\''log'\\'','\\''time'\\'')})\n    assert float(summary['\\''final_cost'\\''])<=float(summary['\\''initial_cost'\\'']) and math.isfinite(float(summary['\\''final_cost'\\'']))\n    if arm in ('\\''legacy'\\'','\\''adaptive'\\''):\n        assert model_hashes==old['\\''runs'\\''][arm]['\\''model_sha256'\\''],arm\n        assert trace==old['\\''runs'\\''][arm]['\\''numerical_trace'\\''],arm\n        result['\\''prior_control_model_and_numerical_trace_exact'\\'']=True\n    runs[arm]=result\nassert runs['\\''huber3'\\'']['\\''model_sha256'\\'']==runs['\\''huber3-repeat'\\'']['\\''model_sha256'\\'']\nassert runs['\\''huber3'\\'']['\\''numerical_trace'\\'']==runs['\\''huber3-repeat'\\'']['\\''numerical_trace'\\'']\nfor arm,result in runs.items():\n    trace=result.pop('\\''numerical_trace'\\'')\n    result['\\''numerical_trace_rows'\\'']=len(trace)\n    result['\\''numerical_trace_sha256'\\'']=hashlib.sha256(('\\''\\n'\\''.join(trace)+'\\''\\n'\\'').encode()).hexdigest()\n    if arm.startswith('\\''huber3'\\''):\n        summary=result['\\''summary'\\'']\n        first=next(l for l in trace if l.startswith('\\''lm_trace '\\''))\n        first_fields=dict(t.split('\\''='\\'',1) for t in shlex.split(first) if '\\''='\\'' in t)\n        assert abs(float(first_fields['\\''cost_before'\\''])-float(summary['\\''initial_robust_cost'\\'']))<1e-7\n        assert summary['\\''cost_objective'\\'']=='\\''robust_huber_3px'\\''\n        assert summary['\\''source_sha256'\\'']=='\\''ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829'\\''\n        for line in trace:\n            if line.startswith('\\''lm_trace '\\'') and '\\'' accepted=true '\\'' in line:\n                f=dict(t.split('\\''='\\'',1) for t in shlex.split(line) if '\\''='\\'' in t)\n                assert float(f['\\''cost_after'\\''])<float(f['\\''cost_before'\\''])\n        result['\\''solver_initial_matches_huber_and_all_accepted_steps_reduce_robust_cost'\\'']=True\nprint(json.dumps(dict(runs=runs,repeat_model_bytes_and_numerical_trace_exact=True),indent=2))\n' '/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1'",
+  "geometry": {
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model",
+    "image_poses": 1000,
+    "supported_images": 1000,
+    "unsupported_image_ids": [],
+    "landmarks": 4716,
+    "observations": 130900,
+    "mean_reprojection_px": 0.6732622404250175,
+    "observation_weighted_mean_reprojection_px": 0.6732622404250175,
+    "point_weighted_mean_reprojection_px": 0.7359902791613149,
+    "max_track_mean_reprojection_px": 3.147876460360457,
+    "max_reprojection_px": 5.524139736727244,
+    "max_stored_mean_difference_px": 4.0443141067006416e-10,
+    "nonpositive_depth_observations": 0,
+    "tracks_with_multiple_keypoints_in_one_image": 0,
+    "excess_same_image_track_observations": 0,
+    "bidirectional_references_valid": true,
+    "rig": {
+      "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+      "rig_frames": 500,
+      "supported_rig_frames": 500,
+      "unsupported_rig_frame_ids": [],
+      "max_inferred_rig_center_disagreement_m": 4.8973382127780135e-15,
+      "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+      "fixed_sensor_extrinsics_valid": true,
+      "track_connected_components": 1,
+      "track_connected_component_sizes": [
+        500
+      ],
+      "track_connected_component_frame_ranges": [
+        [
+          0,
+          499
+        ]
+      ]
+    }
+  },
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py '/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model' --rig-manifest '/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt'",
+  "identity": {
+    "before": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+    "after": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model",
+    "fixed_frame_id": 0,
+    "fixed_images_checked": 2,
+    "cameras_byte_exact": true,
+    "image_identity_and_order_exact": true,
+    "full_points2d_tokens_exact": true,
+    "point_ids_rgb_track_tokens_and_order_exact": true,
+    "images": 1000,
+    "keypoints": 361170,
+    "landmarks": 4716,
+    "observations": 130900,
+    "numerically_changed_image_poses": 998,
+    "max_camera_center_delta_m": 0.02403506882298494,
+    "max_camera_rotation_matrix_delta_frobenius": 0.006223647871732108,
+    "max_landmark_delta_m": 221.1201690266865,
+    "fixed_frame_camera_center_delta_m": 7.713637039264346e-13,
+    "fixed_frame_camera_rotation_matrix_delta_frobenius": 1.9406908357248486e-12,
+    "output_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "0c53e48afff57efe61a5172dbe290c884c3ef45d51736b9dbca36be3cae6c4cb",
+      "points3D.txt": "5943ba3fbf010e122c5d083b7b29da70a3e30bce6af53150d6be19c4a6e22af8"
+    }
+  },
+  "identity_program": "import sys,json,itertools,hashlib\nfrom pathlib import Path\nimport numpy as np\nsys.path.insert(0, \"scripts\")\nfrom audit_colmap_pinhole_model import rotation\nbefore,after,rig=map(Path,sys.argv[1:4])\nfixed_frame_id=int(sys.argv[4])\nassignments={}\nfor line in rig.read_text().splitlines():\n    tokens=line.split()\n    if tokens and tokens[0]==\"F\":\n        assignments[tokens[2]]=(int(tokens[1]),int(tokens[3]))\ndef image_rows(path):\n    with path.open() as f:\n        for line in f:\n            if not line.strip() or line.lstrip().startswith(\"#\"): continue\n            header=line.split()\n            points=next(f).split()\n            yield header,points\ndef point_rows(path):\n    with path.open() as f:\n        for line in f:\n            if line.strip() and not line.lstrip().startswith(\"#\"): yield line.split()\nassert (before/\"cameras.txt\").read_bytes()==(after/\"cameras.txt\").read_bytes()\nimages=points=observations=keypoints=0\nfixed_center=fixed_rotation=0.0\nfixed_images_checked=0\nmax_center=max_rotation=max_xyz=0.0\nchanged_poses=0\nfor old,new in itertools.zip_longest(image_rows(before/\"images.txt\"),image_rows(after/\"images.txt\")):\n    assert old is not None and new is not None\n    a,ka=old;b,kb=new\n    assert (a[0],a[8],a[9])==(b[0],b[8],b[9])\n    assert ka==kb\n    ra=np.array(rotation(a[1:5]))\n    rb=np.array(rotation(b[1:5]))\n    ta=np.array(list(map(float,a[5:8])));tb=np.array(list(map(float,b[5:8])))\n    center=float(np.linalg.norm(-ra.T@ta+rb.T@tb))\n    rotation_frob=float(np.linalg.norm(ra-rb))\n    max_center=max(max_center,center);max_rotation=max(max_rotation,rotation_frob)\n    changed_poses+=center>1e-10 or rotation_frob>1e-10\n    if assignments[a[9]][0]==fixed_frame_id:\n        fixed_images_checked+=1\n        fixed_center=max(fixed_center,center);fixed_rotation=max(fixed_rotation,rotation_frob)\n    images+=1;keypoints+=len(ka)//3\nfor a,b in itertools.zip_longest(point_rows(before/\"points3D.txt\"),point_rows(after/\"points3D.txt\")):\n    assert a is not None and b is not None\n    assert a[0]==b[0] and a[4:7]==b[4:7] and a[8:]==b[8:]\n    assert float(b[7])>=0 and np.isfinite(float(b[7]))\n    max_xyz=max(max_xyz,float(np.linalg.norm(np.array(list(map(float,a[1:4])))-np.array(list(map(float,b[1:4]))))))\n    points+=1;observations+=(len(a)-8)//2\nassert fixed_images_checked>0\nassert fixed_center<1e-10 and fixed_rotation<1e-10\nprint(json.dumps(dict(before=str(before),after=str(after),fixed_frame_id=fixed_frame_id,fixed_images_checked=fixed_images_checked,cameras_byte_exact=True,image_identity_and_order_exact=True,full_points2d_tokens_exact=True,point_ids_rgb_track_tokens_and_order_exact=True,images=images,keypoints=keypoints,landmarks=points,observations=observations,numerically_changed_image_poses=changed_poses,max_camera_center_delta_m=max_center,max_camera_rotation_matrix_delta_frobenius=max_rotation,max_landmark_delta_m=max_xyz,fixed_frame_camera_center_delta_m=fixed_center,fixed_frame_camera_rotation_matrix_delta_frobenius=fixed_rotation,output_sha256={name:hashlib.sha256((after/name).read_bytes()).hexdigest() for name in (\"cameras.txt\",\"images.txt\",\"points3D.txt\")}),indent=2))\n",
+  "identity_command": "python3 -c 'import sys,json,itertools,hashlib\nfrom pathlib import Path\nimport numpy as np\nsys.path.insert(0, \"scripts\")\nfrom audit_colmap_pinhole_model import rotation\nbefore,after,rig=map(Path,sys.argv[1:4])\nfixed_frame_id=int(sys.argv[4])\nassignments={}\nfor line in rig.read_text().splitlines():\n    tokens=line.split()\n    if tokens and tokens[0]==\"F\":\n        assignments[tokens[2]]=(int(tokens[1]),int(tokens[3]))\ndef image_rows(path):\n    with path.open() as f:\n        for line in f:\n            if not line.strip() or line.lstrip().startswith(\"#\"): continue\n            header=line.split()\n            points=next(f).split()\n            yield header,points\ndef point_rows(path):\n    with path.open() as f:\n        for line in f:\n            if line.strip() and not line.lstrip().startswith(\"#\"): yield line.split()\nassert (before/\"cameras.txt\").read_bytes()==(after/\"cameras.txt\").read_bytes()\nimages=points=observations=keypoints=0\nfixed_center=fixed_rotation=0.0\nfixed_images_checked=0\nmax_center=max_rotation=max_xyz=0.0\nchanged_poses=0\nfor old,new in itertools.zip_longest(image_rows(before/\"images.txt\"),image_rows(after/\"images.txt\")):\n    assert old is not None and new is not None\n    a,ka=old;b,kb=new\n    assert (a[0],a[8],a[9])==(b[0],b[8],b[9])\n    assert ka==kb\n    ra=np.array(rotation(a[1:5]))\n    rb=np.array(rotation(b[1:5]))\n    ta=np.array(list(map(float,a[5:8])));tb=np.array(list(map(float,b[5:8])))\n    center=float(np.linalg.norm(-ra.T@ta+rb.T@tb))\n    rotation_frob=float(np.linalg.norm(ra-rb))\n    max_center=max(max_center,center);max_rotation=max(max_rotation,rotation_frob)\n    changed_poses+=center>1e-10 or rotation_frob>1e-10\n    if assignments[a[9]][0]==fixed_frame_id:\n        fixed_images_checked+=1\n        fixed_center=max(fixed_center,center);fixed_rotation=max(fixed_rotation,rotation_frob)\n    images+=1;keypoints+=len(ka)//3\nfor a,b in itertools.zip_longest(point_rows(before/\"points3D.txt\"),point_rows(after/\"points3D.txt\")):\n    assert a is not None and b is not None\n    assert a[0]==b[0] and a[4:7]==b[4:7] and a[8:]==b[8:]\n    assert float(b[7])>=0 and np.isfinite(float(b[7]))\n    max_xyz=max(max_xyz,float(np.linalg.norm(np.array(list(map(float,a[1:4])))-np.array(list(map(float,b[1:4]))))))\n    points+=1;observations+=(len(a)-8)//2\nassert fixed_images_checked>0\nassert fixed_center<1e-10 and fixed_rotation<1e-10\nprint(json.dumps(dict(before=str(before),after=str(after),fixed_frame_id=fixed_frame_id,fixed_images_checked=fixed_images_checked,cameras_byte_exact=True,image_identity_and_order_exact=True,full_points2d_tokens_exact=True,point_ids_rgb_track_tokens_and_order_exact=True,images=images,keypoints=keypoints,landmarks=points,observations=observations,numerically_changed_image_poses=changed_poses,max_camera_center_delta_m=max_center,max_camera_rotation_matrix_delta_frobenius=max_rotation,max_landmark_delta_m=max_xyz,fixed_frame_camera_center_delta_m=fixed_center,fixed_frame_camera_rotation_matrix_delta_frobenius=fixed_rotation,output_sha256={name:hashlib.sha256((after/name).read_bytes()).hexdigest() for name in (\"cameras.txt\",\"images.txt\",\"points3D.txt\")}),indent=2))\n' '/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model' '/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model' '/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt' 0",
+  "independent_cost": {
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model",
+    "images": 1000,
+    "landmarks": 4716,
+    "observations": 130900,
+    "keypoints": 361170,
+    "raw_squared_cost": 113816.99893044145,
+    "huber_3px_cost": 112892.14307956967,
+    "raw_mean_px": 0.6732622404250176,
+    "raw_rmse_px": 0.9324675812855487,
+    "raw_p95_px": 1.9913689120464875,
+    "raw_max_px": 5.524139736727244,
+    "downweighted_observations": 1617,
+    "weight_min": 0.5430709835333273,
+    "weight_sum": 130646.70999605878,
+    "all_positive_depth": true,
+    "min_depth_m": 0.0000691902689924917,
+    "max_depth_m": 5211.3193711766535,
+    "nonprojectable_observations": 0,
+    "quantile_method": "numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve",
+    "input_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "0c53e48afff57efe61a5172dbe290c884c3ef45d51736b9dbca36be3cae6c4cb",
+      "points3D.txt": "5943ba3fbf010e122c5d083b7b29da70a3e30bce6af53150d6be19c4a6e22af8"
+    }
+  },
+  "independent_cost_program": "import sys,json,math,hashlib,array\nfrom pathlib import Path\nimport numpy as np\nsys.path.insert(0,'scripts')\nfrom audit_colmap_pinhole_model import rotation\nroot=Path(sys.argv[1])\nnames=('cameras.txt','images.txt','points3D.txt')\nfor name in names:\n    path=root/name\n    assert path.is_file() and not path.is_symlink() and path.stat().st_size<=32*1024*1024\ndef hashes():\n    return {name:hashlib.sha256((root/name).read_bytes()).hexdigest() for name in names}\nbefore=hashes()\ncameras={}\nfor line in (root/'cameras.txt').read_text().splitlines():\n    if line.strip() and not line.lstrip().startswith('#'):\n        row=line.split();assert row[1]=='PINHOLE' and len(row)==8\n        cameras[int(row[0])]=tuple(map(float,row[4:]))\nimages={};keypoints=0\nwith (root/'images.txt').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('#'):continue\n        row=line.split();kp=next(stream).split();assert len(kp)%3==0\n        i=int(row[0]);assert i not in images\n        images[i]=(rotation(row[1:5]),tuple(map(float,row[5:8])),cameras[int(row[8])],kp)\n        keypoints+=len(kp)//3\n        assert len(images)<=1000 and keypoints<=361170\nresiduals=array.array('d');min_depth=math.inf;max_depth=0;points=0\nwith (root/'points3D.txt').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('#'):continue\n        row=line.split();assert (len(row)-8)%2==0\n        point_id=int(row[0]);xyz=tuple(map(float,row[1:4]));points+=1\n        assert points<=4716 and all(map(math.isfinite,xyz))\n        for j in range(8,len(row),2):\n            i,k=map(int,row[j:j+2]);R,t,intr,kp=images[i]\n            assert int(kp[3*k+2])==point_id\n            q=[sum(v*x for v,x in zip(axis,xyz))+shift for axis,shift in zip(R,t)]\n            assert all(map(math.isfinite,q)) and q[2]>0\n            fx,fy,cx,cy=intr\n            dx=fx*q[0]/q[2]+cx-float(kp[3*k]);dy=fy*q[1]/q[2]+cy-float(kp[3*k+1])\n            s=dx*dx+dy*dy;assert math.isfinite(s)\n            residuals.append(math.sqrt(s));assert len(residuals)<=130900\n            min_depth=min(min_depth,q[2]);max_depth=max(max_depth,q[2])\nassert (len(images),points,len(residuals),keypoints)==(1000,4716,130900,361170)\nraw=math.fsum(r*r for r in residuals)\nrobust=math.fsum(r*r if r<=3 else 6*r-9 for r in residuals)\nweight_sum=math.fsum(1 if r<=3 else 3/r for r in residuals)\nresult=dict(model=str(root),images=len(images),landmarks=points,observations=len(residuals),keypoints=keypoints,\n    raw_squared_cost=raw,huber_3px_cost=robust,raw_mean_px=math.fsum(residuals)/len(residuals),\n    raw_rmse_px=math.sqrt(raw/len(residuals)),raw_p95_px=float(np.percentile(np.frombuffer(residuals,dtype=np.float64),95,method='linear')),\n    raw_max_px=max(residuals),downweighted_observations=sum(r>3 for r in residuals),\n    weight_min=min(1,3/max(residuals)),weight_sum=weight_sum,all_positive_depth=True,\n    min_depth_m=min_depth,max_depth_m=max_depth,nonprojectable_observations=0,\n    quantile_method='numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve',\n    input_sha256=before)\nassert hashes()==before\nprint(json.dumps(result,indent=2))\n",
+  "independent_cost_command": "python3 -c 'import sys,json,math,hashlib,array\nfrom pathlib import Path\nimport numpy as np\nsys.path.insert(0,'\\''scripts'\\'')\nfrom audit_colmap_pinhole_model import rotation\nroot=Path(sys.argv[1])\nnames=('\\''cameras.txt'\\'','\\''images.txt'\\'','\\''points3D.txt'\\'')\nfor name in names:\n    path=root/name\n    assert path.is_file() and not path.is_symlink() and path.stat().st_size<=32*1024*1024\ndef hashes():\n    return {name:hashlib.sha256((root/name).read_bytes()).hexdigest() for name in names}\nbefore=hashes()\ncameras={}\nfor line in (root/'\\''cameras.txt'\\'').read_text().splitlines():\n    if line.strip() and not line.lstrip().startswith('\\''#'\\''):\n        row=line.split();assert row[1]=='\\''PINHOLE'\\'' and len(row)==8\n        cameras[int(row[0])]=tuple(map(float,row[4:]))\nimages={};keypoints=0\nwith (root/'\\''images.txt'\\'').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('\\''#'\\''):continue\n        row=line.split();kp=next(stream).split();assert len(kp)%3==0\n        i=int(row[0]);assert i not in images\n        images[i]=(rotation(row[1:5]),tuple(map(float,row[5:8])),cameras[int(row[8])],kp)\n        keypoints+=len(kp)//3\n        assert len(images)<=1000 and keypoints<=361170\nresiduals=array.array('\\''d'\\'');min_depth=math.inf;max_depth=0;points=0\nwith (root/'\\''points3D.txt'\\'').open() as stream:\n    for line in stream:\n        if not line.strip() or line.lstrip().startswith('\\''#'\\''):continue\n        row=line.split();assert (len(row)-8)%2==0\n        point_id=int(row[0]);xyz=tuple(map(float,row[1:4]));points+=1\n        assert points<=4716 and all(map(math.isfinite,xyz))\n        for j in range(8,len(row),2):\n            i,k=map(int,row[j:j+2]);R,t,intr,kp=images[i]\n            assert int(kp[3*k+2])==point_id\n            q=[sum(v*x for v,x in zip(axis,xyz))+shift for axis,shift in zip(R,t)]\n            assert all(map(math.isfinite,q)) and q[2]>0\n            fx,fy,cx,cy=intr\n            dx=fx*q[0]/q[2]+cx-float(kp[3*k]);dy=fy*q[1]/q[2]+cy-float(kp[3*k+1])\n            s=dx*dx+dy*dy;assert math.isfinite(s)\n            residuals.append(math.sqrt(s));assert len(residuals)<=130900\n            min_depth=min(min_depth,q[2]);max_depth=max(max_depth,q[2])\nassert (len(images),points,len(residuals),keypoints)==(1000,4716,130900,361170)\nraw=math.fsum(r*r for r in residuals)\nrobust=math.fsum(r*r if r<=3 else 6*r-9 for r in residuals)\nweight_sum=math.fsum(1 if r<=3 else 3/r for r in residuals)\nresult=dict(model=str(root),images=len(images),landmarks=points,observations=len(residuals),keypoints=keypoints,\n    raw_squared_cost=raw,huber_3px_cost=robust,raw_mean_px=math.fsum(residuals)/len(residuals),\n    raw_rmse_px=math.sqrt(raw/len(residuals)),raw_p95_px=float(np.percentile(np.frombuffer(residuals,dtype=np.float64),95,method='\\''linear'\\'')),\n    raw_max_px=max(residuals),downweighted_observations=sum(r>3 for r in residuals),\n    weight_min=min(1,3/max(residuals)),weight_sum=weight_sum,all_positive_depth=True,\n    min_depth_m=min_depth,max_depth_m=max_depth,nonprojectable_observations=0,\n    quantile_method='\\''numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve'\\'',\n    input_sha256=before)\nassert hashes()==before\nprint(json.dumps(result,indent=2))\n' '/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model'",
+  "independent_cost_minus_driver": {
+    "raw": 6.548361852765083e-10,
+    "robust": 5.675246939063072e-10,
+    "raw_mean": -9.547918011776346e-15,
+    "weight_sum": -1.1641532182693481e-10
+  },
+  "initial_independent_cost": {
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-1k-control-v1/rig-legacy-cap256/model",
+    "images": 1000,
+    "landmarks": 4716,
+    "observations": 130900,
+    "keypoints": 361170,
+    "raw_squared_cost": 126510.39875805238,
+    "huber_3px_cost": 125938.89325088603,
+    "raw_mean_px": 0.720678689714061,
+    "raw_rmse_px": 0.9830900239021312,
+    "raw_p95_px": 2.148156034094761,
+    "raw_max_px": 3.9995690559394936,
+    "downweighted_observations": 1984,
+    "weight_min": 0.7500808107175696,
+    "weight_sum": 130653.34773138781,
+    "all_positive_depth": true,
+    "min_depth_m": 0.00011093307669790553,
+    "max_depth_m": 5207.122999967967,
+    "nonprojectable_observations": 0,
+    "quantile_method": "numpy percentile linear, bounded O(130900) scalar audit buffer outside timed solve",
+    "input_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "90773af9546ea351f9610721eab2ccac7b6d55f9c0638fd7ce596942012610d6",
+      "points3D.txt": "8850f161ac44f76ef6d512f8c1739493970849a380f6a232c82e3006a33f346a"
+    }
+  },
+  "post_only_score": {
+    "component_weighted_max_m": 0.08542338154933952,
+    "component_weighted_median_m": 0.026132588451571216,
+    "component_weighted_p95_m": 0.04401826073094061,
+    "component_weighted_rmse_m": 0.02882219997580861,
+    "components": [
+      {
+        "gt_scored": 308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model/images.txt",
+        "images_txt_sha256": "0c53e48afff57efe61a5172dbe290c884c3ef45d51736b9dbca36be3cae6c4cb",
+        "max_m": 0.08542338154933952,
+        "median_m": 0.026132588451571216,
+        "p95_m": 0.04401826073094061,
+        "reference_extent_m": 1.9718678959594034,
+        "registered": 1000,
+        "relative_rmse": 0.01461669923977605,
+        "rmse_m": 0.02882219997580861,
+        "sim3_scale": 1.1208370768007534,
+        "trajectory_segments": [
+          {
+            "images": 32,
+            "max_m": 0.034515917110404026,
+            "median_m": 0.03160947744570135,
+            "p95_m": 0.03422166884119984,
+            "rmse_m": 0.03163295750769047,
+            "segment": 0,
+            "timestamp_end": 1560000015.556828,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 30,
+            "max_m": 0.03490153968886164,
+            "median_m": 0.03126972313151611,
+            "p95_m": 0.034842594859048816,
+            "rmse_m": 0.03197772653775804,
+            "segment": 1,
+            "timestamp_end": 1560000016.056906,
+            "timestamp_start": 1560000015.590162
+          },
+          {
+            "images": 32,
+            "max_m": 0.02816603341403852,
+            "median_m": 0.013040573728856569,
+            "p95_m": 0.026092149377009866,
+            "rmse_m": 0.015406179879220312,
+            "segment": 2,
+            "timestamp_end": 1560000016.590147,
+            "timestamp_start": 1560000016.09024
+          },
+          {
+            "images": 30,
+            "max_m": 0.030292293498035812,
+            "median_m": 0.014313326396973206,
+            "p95_m": 0.02896715675543347,
+            "rmse_m": 0.01815623576443979,
+            "segment": 3,
+            "timestamp_end": 1560000017.09023,
+            "timestamp_start": 1560000016.623481
+          },
+          {
+            "images": 30,
+            "max_m": 0.044337028815748025,
+            "median_m": 0.03945510394077078,
+            "p95_m": 0.04311593185174136,
+            "rmse_m": 0.0390324561382482,
+            "segment": 4,
+            "timestamp_end": 1560000017.590167,
+            "timestamp_start": 1560000017.123563
+          },
+          {
+            "images": 32,
+            "max_m": 0.044442430918308753,
+            "median_m": 0.03730750838736844,
+            "p95_m": 0.04235258211401948,
+            "rmse_m": 0.03653902152370379,
+            "segment": 5,
+            "timestamp_end": 1560000018.123552,
+            "timestamp_start": 1560000017.623501
+          },
+          {
+            "images": 30,
+            "max_m": 0.028276689302874136,
+            "median_m": 0.019463823732449342,
+            "p95_m": 0.02592590229324695,
+            "rmse_m": 0.01982364229206501,
+            "segment": 6,
+            "timestamp_end": 1560000018.623534,
+            "timestamp_start": 1560000018.156885
+          },
+          {
+            "images": 30,
+            "max_m": 0.04063883071564336,
+            "median_m": 0.00938915256690357,
+            "p95_m": 0.030392691929727593,
+            "rmse_m": 0.015540054234412314,
+            "segment": 7,
+            "timestamp_end": 1560000019.123582,
+            "timestamp_start": 1560000018.656868
+          },
+          {
+            "images": 32,
+            "max_m": 0.08542338154933952,
+            "median_m": 0.015286193915183603,
+            "p95_m": 0.07277288398729825,
+            "rmse_m": 0.03820008281662521,
+            "segment": 8,
+            "timestamp_end": 1560000019.666914,
+            "timestamp_start": 1560000019.156915
+          },
+          {
+            "images": 30,
+            "max_m": 0.05589166451388615,
+            "median_m": 0.021641094777301983,
+            "p95_m": 0.046089586710601496,
+            "rmse_m": 0.026782963130593775,
+            "segment": 9,
+            "timestamp_end": 1560000020.166894,
+            "timestamp_start": 1560000019.700247
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 308,
+    "gt_scored_images": 308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+    "manifest_images": 1000,
+    "manifest_sha256": "f1ed9292c806103c1d129340f429bc74e5ba4842c6092b836d541cd518256baa",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 1000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 32,
+        "max_m": 0.034515917110404026,
+        "median_m": 0.03160947744570135,
+        "p95_m": 0.03422166884119984,
+        "rmse_m": 0.03163295750769047,
+        "segment": 0,
+        "timestamp_end": 1560000015.556828,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 30,
+        "max_m": 0.03490153968886164,
+        "median_m": 0.03126972313151611,
+        "p95_m": 0.034842594859048816,
+        "rmse_m": 0.03197772653775804,
+        "segment": 1,
+        "timestamp_end": 1560000016.056906,
+        "timestamp_start": 1560000015.590162
+      },
+      {
+        "images": 32,
+        "max_m": 0.02816603341403852,
+        "median_m": 0.013040573728856569,
+        "p95_m": 0.026092149377009866,
+        "rmse_m": 0.015406179879220312,
+        "segment": 2,
+        "timestamp_end": 1560000016.590147,
+        "timestamp_start": 1560000016.09024
+      },
+      {
+        "images": 30,
+        "max_m": 0.030292293498035812,
+        "median_m": 0.014313326396973206,
+        "p95_m": 0.02896715675543347,
+        "rmse_m": 0.01815623576443979,
+        "segment": 3,
+        "timestamp_end": 1560000017.09023,
+        "timestamp_start": 1560000016.623481
+      },
+      {
+        "images": 30,
+        "max_m": 0.044337028815748025,
+        "median_m": 0.03945510394077078,
+        "p95_m": 0.04311593185174136,
+        "rmse_m": 0.0390324561382482,
+        "segment": 4,
+        "timestamp_end": 1560000017.590167,
+        "timestamp_start": 1560000017.123563
+      },
+      {
+        "images": 32,
+        "max_m": 0.044442430918308753,
+        "median_m": 0.03730750838736844,
+        "p95_m": 0.04235258211401948,
+        "rmse_m": 0.03653902152370379,
+        "segment": 5,
+        "timestamp_end": 1560000018.123552,
+        "timestamp_start": 1560000017.623501
+      },
+      {
+        "images": 30,
+        "max_m": 0.028276689302874136,
+        "median_m": 0.019463823732449342,
+        "p95_m": 0.02592590229324695,
+        "rmse_m": 0.01982364229206501,
+        "segment": 6,
+        "timestamp_end": 1560000018.623534,
+        "timestamp_start": 1560000018.156885
+      },
+      {
+        "images": 30,
+        "max_m": 0.04063883071564336,
+        "median_m": 0.00938915256690357,
+        "p95_m": 0.030392691929727593,
+        "rmse_m": 0.015540054234412314,
+        "segment": 7,
+        "timestamp_end": 1560000019.123582,
+        "timestamp_start": 1560000018.656868
+      },
+      {
+        "images": 32,
+        "max_m": 0.08542338154933952,
+        "median_m": 0.015286193915183603,
+        "p95_m": 0.07277288398729825,
+        "rmse_m": 0.03820008281662521,
+        "segment": 8,
+        "timestamp_end": 1560000019.666914,
+        "timestamp_start": 1560000019.156915
+      },
+      {
+        "images": 30,
+        "max_m": 0.05589166451388615,
+        "median_m": 0.021641094777301983,
+        "p95_m": 0.046089586710601496,
+        "rmse_m": 0.026782963130593775,
+        "segment": 9,
+        "timestamp_end": 1560000020.166894,
+        "timestamp_start": 1560000019.700247
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "post_only_score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-frozen-huber-ba-v1/huber3/model/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "same_model_score_repeat_exact": true,
+  "input_and_certified_source_hashes_unchanged_after_all_runs": true,
+  "gates": {
+    "rmse": {
+      "value_m": 0.02882219997580861,
+      "maximum_m": 0.026608055174816774,
+      "pass": false
+    },
+    "trajectory_p95": {
+      "value_m": 0.04401826073094061,
+      "maximum_m": 0.04109998478546261,
+      "pass": false
+    },
+    "mean_reprojection": {
+      "value_px": 0.6732622404250176,
+      "maximum_px": 0.691588658326868,
+      "pass": true
+    },
+    "identity_support_calibration_anchor_and_depth": true,
+    "robust_objective_nonincrease": true,
+    "accepted_step": true,
+    "candidate_approved": false,
+    "atlas_run": false,
+    "default_promotion": false
+  },
+  "interpretation": [
+    "Huber-3 improves trajectory slightly relative to adaptive None, but remains worse than the predeclared legacy threshold on both RMSE and p95.",
+    "Raw mean/p95 reprojection improve relative to adaptive None while raw squared cost/RMSE rise; report raw and robust costs separately.",
+    "All 130900 observations remain active and all 4716 landmarks remain variable. Robustification downweights 1984 initially and 1617 finally; no observation is removed.",
+    "Do not perform a loss-scale sweep or promote this candidate to atlas/default based on this failed gate.",
+    "Next work must address the full native speed/memory objective rather than repeat local solver-parameter diagnoses; concrete native integration feasibility is being audited separately."
+  ],
+  "limitations": [
+    "All four runs stop after 20 LM iterations with converged=false, not certified stationary optima.",
+    "Process wall/RSS includes driver input and publication, excludes frontend/window mapping/atlas construction; this is not a native COLMAP speedup claim.",
+    "Raw candidate-step states are not exposed: existing per-iteration traces carry robust cost and weighted IRLS surrogate predictions; initial/final raw costs are independently audited.",
+    "Synthetic test verifies cost semantics, accepted update, observation count and extrinsics/anchor; exact full identity/order/calibration is separately proved on the real output.",
+    "Exact p95 audit uses bounded O(130900) scalar storage outside timed solve. Driver additional statistics are streaming scalars; existing solver rollback state is not removed.",
+    "First full-log audit itself exited successfully but its tool output was truncated at 24000 tokens and could not be parsed by root. A compact read-only audit was rerun successfully; no solve or input was repeated/modified for this tooling issue.",
+    "Candidate repeat model bytes are exact. The same first model was scored twice with exact score JSON; this is not a claim of separately invoking GT scoring on the repeat pathname."
+  ],
+  "remaining_goal_gates": [
+    "10k COLMAP trajectory parity",
+    "faster native mapper and native E2E than COLMAP",
+    "native 10k peak RSS <=2 GiB and lower than COLMAP without N-squared state",
+    "1k/2.5k/5k/10k final parity",
+    "repeat/restart",
+    "100k I/O stress",
+    "honest final README visual COLMAP comparison"
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,14 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 続行（2026-09-08）: PR #91はhead `b2a012f`のCI9項目
+> （run `34182134711`）通過後、`e169527`へsquash merge。旧branch整理済み。
+> 現在は `feat/m8-frozen-huber-ba`。次の[事前契約](openloris_frozen_huber_ba.md)を
+> `9de6fe8`で固定し、Luna Maxがdriver-only Huber-3 opt-inを実装中。
+> 同一130,900観測・全XYZ可変のrobust BAは、過去の観測集合を変える
+> robust triangulation/Huber-1実験とは区別します。尺度sweep・GT調整なし。
+> rootの初期モデル独立集計で3 px超は1,984観測（約1.52%）、最小重み0.750081。
+> 影響範囲は限定的で改善は未証明。実solveは未実施、全体goalは未完了です。
+
 > 固定39点A/B完了（2026-09-08）: `5a8f135`をroot独立24driverテスト＋既存rig固定点テスト後に
 > release build。legacy/adaptive対照は過去モデル・数値trace一致。fixed39反復も3ファイル/83行一致。
 > 全支持/identity/校正/anchor/正深度と固定39 XYZ bit一致を維持したが、post-only GT308画像は

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,16 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> Frozen Huber BA完了（2026-09-08）: Luna Max `c026f40`をroot独立28テストと
+> clippy後にrelease認証。4本ともexit0、None対照はPR #91のモデル/trace一致、
+> Huber反復も3ファイル/85行一致。全identity/支持/校正/anchor/正深度を保持。
+> Huberは22.00/22.43 s、peak RSS85,156/85,108 KiB。GT308画像はRMSE/p95
+> **0.028822/0.044018 m**でlegacy基準を満たさず不採用（adaptive Noneよりは改善）。
+> 平均再投影0.673262 pxでも軌跡改善ゲートは閉じません。尺度sweep/atlas/既定化なし。
+> [結果](openloris_frozen_huber_ba.md)、
+> [全証跡](../benchmarks/electro/m8-openloris-frozen-huber-ba-v1.json)。次はこのPRのCI/merge。
+> Luna Maxは次のnative統合候補をread-only監査中。局所BAのパラメータ診断は繰り返さず、
+> native速度・メモリ改善へ進める具体的scopeを確認します。全体goalは未完了です。
+
 > 続行（2026-09-08）: PR #91はhead `b2a012f`のCI9項目
 > （run `34182134711`）通過後、`e169527`へsquash merge。旧branch整理済み。
 > 現在は `feat/m8-frozen-huber-ba`。次の[事前契約](openloris_frozen_huber_ba.md)を

--- a/docs/openloris_frozen_huber_ba.md
+++ b/docs/openloris_frozen_huber_ba.md
@@ -1,6 +1,7 @@
 # Frozen-observation Huber BA experiment
 
-Status: predeclared, not measured. One candidate; no loss-scale sweep.
+Status: measured; failed the predeclared quality gate. No atlas/default
+promotion and no loss-scale sweep.
 
 ## Hypothesis and source boundary
 
@@ -86,3 +87,59 @@ the same candidate's bounded atlas assessment, not automatic native rollout.
 Local BA timing excludes frontend, window mapping and atlas construction;
 it cannot establish COLMAP mapper/native-E2E superiority. Full M8–M10 tier,
 restart, 100k I/O and README comparison gates remain open.
+
+## Measured result (2026-09-08)
+
+Implementation `c026f40` changes only the comparison driver. Luna Max's
+28 example tests and example-only clippy passed; root independently repeated
+both, plus the existing library Huber derivative and matrix-free rig tests.
+The certified release binary SHA is
+`cdbdf63466e9cca7940014d20605ec9485c566f184a86ac7c11dd5476fea23f3`.
+All four processes exit zero after 20 iterations (`converged=false`).
+
+| Arm | Wall s | Peak RSS KiB | Accepted LM | Raw squared cost | Huber-3 cost |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Legacy None | 19.84 | 84,652 | 3 | 118070.554369 | 117471.290968 |
+| Adaptive None | 22.26 | 84,856 | 15 | 113550.219339 | 112906.086062 |
+| Adaptive Huber-3 | 22.00 | 85,156 | 13 | 113816.998930 | 112892.143080 |
+| Huber-3 repeat | 22.43 | 85,108 | 13 | same | same |
+
+The two controls reproduce PR #91's three model files and numerical traces
+exactly (40/82 rows). Huber repeat reproduces its three model files and 85
+numerical/policy rows exactly. The control Huber costs above are independent
+evaluations of their byte-identical prior outputs, not their optimized loss.
+No timing difference between these two adaptive arms is claimed significant.
+
+Independent audits retain all 1,000 supported images, 500 supported frames,
+4,716 points, 130,900 observations and 361,170 keypoints in one component.
+Image/point/track/POINTS2D identities and order, cameras and fixed rig/anchor
+are unchanged. All observations have positive depth. Independent final raw
+and robust cost differ from the driver by only 6.55e-10 and 5.68e-10.
+Initial/final downweighted counts are 1,984/1,617 and minimum weights
+0.750081/0.543071. Downweighting never removes a residual.
+
+Post-only GT scoring uses the unchanged 308-image set and agrees on repeat:
+
+| Quality metric | Legacy limit | Huber-3 | Gate |
+| --- | ---: | ---: | --- |
+| Trajectory RMSE m | 0.026608055 | 0.028822200 | fail |
+| Trajectory p95 m | 0.041099985 | 0.044018261 | fail |
+| Raw mean reprojection px | 0.691588658 | 0.673262240 | pass |
+
+The candidate slightly improves trajectory over adaptive None
+(0.029190/0.044521 m), but still fails both legacy trajectory limits.
+Raw reprojection RMSE/p95/max are 0.932468/1.991369/5.524140 px;
+its raw squared cost rises relative to adaptive None even though mean and
+p95 decrease. Lower robust loss is not evidence of lower raw squared loss
+or a passing trajectory. Maximum point motion is 221.120 m, and maximum
+camera-centre motion is 0.024035 m; neither substitutes for GT accuracy.
+
+Reject the candidate without another scale or atlas run. Library/default
+solver and README performance claims remain unchanged. Native mapper/E2E,
+10k COLMAP parity, tier/restart and 100k I/O gates are still open.
+
+[Preflight and independent input accounting](../benchmarks/electro/m8-openloris-frozen-huber-ba-preflight-v1.json)
+and [all four runs, commands, hashes and audits](../benchmarks/electro/m8-openloris-frozen-huber-ba-v1.json)
+record the completed experiment. Full logs remain under the certified local
+artifact root named there; the evidence stores their hashes and a reproducible
+compact trace auditor rather than duplicating every control trace.

--- a/docs/openloris_frozen_huber_ba.md
+++ b/docs/openloris_frozen_huber_ba.md
@@ -1,0 +1,88 @@
+# Frozen-observation Huber BA experiment
+
+Status: predeclared, not measured. One candidate; no loss-scale sweep.
+
+## Hypothesis and source boundary
+
+The same-input adaptive and Ceres solves lowered squared reprojection cost
+but worsened trajectory. Fixing 39 weak-angle XYZ values also worsened it
+([fixed-point evidence](../benchmarks/electro/m8-openloris-weak-angle-fixed-landmarks-v1.json)).
+Test whether reducing large-residual influence, without removing observations
+or fixing landmarks, improves the pose/structure solution.
+
+This is not a repeat of the earlier
+[robust-triangulation experiment](../benchmarks/electro/m8-openloris-robust-triangulation-ab.json):
+that changed tracks and observations (its 1k control has 270,204 observations,
+versus 279,489 in the Huber-3 arm). It also tested Huber-1 BA and landmark-only
+refinement on different populations; those failures remain valid, but do not
+answer this exact frozen 130,900-observation question.
+
+Use **Huber delta 3 px**, the existing engineering default in
+`IncrementalSfmConfig::default`, not a parameter estimated from this GT.
+[Ceres's primary modeling documentation](https://ceres-solver.readthedocs.io/latest/nnls_modeling.html#lossfunction)
+defines robust scale in residual-norm units and describes the Huber loss.
+It supports the loss semantics, not the claim that 3 px is statistically
+optimal for OpenLORIS. This experiment uses the existing Rust IRLS solver,
+not Ceres or COLMAP's potentially different local-BA loss/default settings.
+Improvement is unproven; already-filtered residuals may give limited leverage.
+
+## Frozen contract
+
+- Same original 1k model, rig, frame-zero anchor and source SHA as PR #91:
+  `ecb825c37e2aed47adef6b20e0d362544c56e37238861d5bcf80ed80cb915829`.
+- Preserve all 1,000 images, 500 supported frames, 4,716 variable XYZ points,
+  130,900 observations, 361,170 keypoints, identities/order and calibration.
+  No point freezing, filtering, triangulation, pose prior or GT-based selection.
+- Candidate changes only `RobustKernel::None` to `Huber { delta: 3.0 }` in
+  adaptive column-scaled matrix-free BA. Twenty LM iterations, lambda 1e-4,
+  PCG 512 / relative 1e-8 / absolute 1e-12 / restart zero, one thread.
+  Existing scaling clamps, adaptive rho rule and depth feasibility unchanged.
+- Driver-only opt-in `--huber-loss-3px`, restricted to adaptive column-scaled
+  matrix-free mode; reject fixture export and fixed-landmark combinations.
+  Option absent must preserve previous outputs and numerical traces.
+
+## Cost accounting and memory
+
+Separate full raw squared cost `C_raw = sum(s)` and optimized robust cost
+`C_H = sum(rho(s))`, where `s` is each 2D residual's squared norm and
+`rho(s) = s` for `s <= 9`, otherwise `6*sqrt(s)-9`. Rust reports sums without
+Ceres's one-half factor. The IRLS weight is one below the threshold and
+`3/sqrt(s)` above it. Raw decrease is diagnostic, not the LM acceptance rule.
+
+The candidate's existing LM cost/acceptance/actual-reduction traces must be
+explicitly labeled as robust; its local quadratic prediction is the weighted
+IRLS surrogate. Do not label it as an unweighted raw squared objective.
+Record initial/final raw and robust cost, valid/nonprojectable counts, raw
+mean/RMSE/max and weight count/min/sum through scalar streaming accumulators.
+Cross-check the robust sum against `BundleAdjustment::robust_cost` and solver
+initial/final cost. No second model/normal clone or per-observation weight
+array is needed. Existing per-iteration traces provide robust candidate
+costs, not raw candidate costs; adding a state hook solely for that diagnostic
+is outside this driver-only experiment.
+
+Root independently recomputes final raw/robust costs, residual quantiles and
+weights after timed solves. Exact p95 may use a bounded 130,900-scalar audit
+array outside the timed solver; do not claim constant-memory exact quantiles.
+
+## Runs, gates and next decision
+
+Certify one reviewed/tested release binary and input hashes. Run four serial
+processes with 180-second bounds: legacy None, adaptive None, adaptive Huber-3,
+and exact Huber-3 repeat. Record process wall/RSS, exit status and numerical
+traces. Controls must reproduce PR #91 models/traces; candidate repeat must
+produce byte-identical model files and matching numerical/policy traces.
+
+Before post-only GT scoring, verify complete identity/support, one component,
+fixed calibration/anchor, positive depth for every observation, finite costs,
+robust objective nonincrease and at least one accepted update. No observation
+may disappear through robustification. Score the same 308 images with the
+unchanged scorer/GT/transform files. Predeclared quality limits remain legacy
+RMSE **0.026608055174816774 m**, trajectory p95 **0.04109998478546261 m** and
+raw mean reprojection **0.691588658326868 px**, all no worse. Raw reprojection
+RMSE/p95 are additional diagnostics, not newly invented trajectory gates.
+
+Failure means no atlas/default promotion, no scale sweep. Success permits
+the same candidate's bounded atlas assessment, not automatic native rollout.
+Local BA timing excludes frontend, window mapping and atlas construction;
+it cannot establish COLMAP mapper/native-E2E superiority. Full M8–M10 tier,
+restart, 100k I/O and README comparison gates remain open.

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -114,6 +114,15 @@ identity/support/calibration/anchor/fixed-XYZ and repeat checks pass, but RMSE/p
 did not improve trajectory. Reject this hard-XYZ candidate without threshold
 expansion or atlas execution; keep native E2E and all remaining goal gates open.
 
+PR #91 merged as `e169527` after all nine checks on `b2a012f`
+(run `34182134711`). The next [frozen Huber BA contract](openloris_frozen_huber_ba.md)
+keeps every observation and all XYZ variable, using the existing 3 px loss
+setting rather than selecting a scale from GT. Prior robust-triangulation and
+Huber-1 experiments changed observation populations and do not constitute this
+exact-input test. Record raw and robust objectives separately, preserve the
+same quality gates, and do not promote or sweep if it fails. The opt-in adds
+only streaming scalar diagnostics; quantile auditing stays outside timed BA.
+
 ## Current checkpoint (2026-09-07)
 
 The connected, observation-backed atlas now preserves 9,998 registered images,

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -123,6 +123,16 @@ exact-input test. Record raw and robust objectives separately, preserve the
 same quality gates, and do not promote or sweep if it fails. The opt-in adds
 only streaming scalar diagnostics; quantile auditing stays outside timed BA.
 
+That [four-run Huber experiment](../benchmarks/electro/m8-openloris-frozen-huber-ba-v1.json)
+is complete. All identity/support/calibration/anchor/depth and repeat gates
+pass, but trajectory RMSE/p95 0.028822/0.044018 m fail the legacy limits.
+Mean reprojection 0.673262 px passes. The 22.00/22.43-second, roughly 83-MiB
+local BA runs are not native E2E measurements. Reject without a loss-scale
+sweep or atlas/default promotion. Next, audit the actual native SfM entry for
+one concrete integration that advances speed/memory while preserving the
+accuracy gate; do not substitute another local parameter-diagnostic ladder
+for the remaining native/tier/restart/100k outcome requirements.
+
 ## Current checkpoint (2026-09-07)
 
 The connected, observation-backed atlas now preserves 9,998 registered images,

--- a/examples/compare_rig_bundle_adjustment.rs
+++ b/examples/compare_rig_bundle_adjustment.rs
@@ -23,7 +23,7 @@ use visloc_rs::slam::{
 use visloc_rs::{Camera, CameraModel, Pose, SE3};
 
 const USAGE: &str = "usage: compare_rig_bundle_adjustment --model PATH --rig-manifest PATH \\
-    --solver direct|matrix-free --out-dir PATH [--fixed-frame-id U64] [--allow-unsupported-sensor-images] [--fixed-landmark-ids PATH] [--matrix-free-column-scaling] [--matrix-free-adaptive-damping] [--pcg-max-iterations N] [--pcg-relative-tolerance X] [--pcg-max-restarts 0|1]\n\
+    --solver direct|matrix-free --out-dir PATH [--fixed-frame-id U64] [--allow-unsupported-sensor-images] [--fixed-landmark-ids PATH] [--matrix-free-column-scaling] [--matrix-free-adaptive-damping] [--huber-loss-3px] [--pcg-max-iterations N] [--pcg-relative-tolerance X] [--pcg-max-restarts 0|1]\n\
     or: compare_rig_bundle_adjustment --model PATH --rig-manifest PATH \\
     --export-oracle-fixture PATH";
 const CENTER_TOLERANCE_M: f64 = 1.0e-4;
@@ -39,6 +39,7 @@ const MAX_PCG_ITERATIONS: usize = 128;
 const PCG_TOLERANCE: f64 = 1.0e-12;
 const ADAPTIVE_PCG_MAX_ITERATIONS: usize = 512;
 const ADAPTIVE_PCG_RELATIVE_TOLERANCE: f64 = 1.0e-8;
+const HUBER_LOSS_3PX_DELTA: f64 = 3.0;
 const BA_MAX_ITERATIONS: usize = 20;
 const BA_INITIAL_LAMBDA: f64 = 1.0e-4;
 const ORACLE_MAX_VARIABLE_POSES: usize = 512;
@@ -92,6 +93,7 @@ struct Args {
     fixed_landmark_ids: Option<PathBuf>,
     matrix_free_column_scaling: bool,
     matrix_free_adaptive_damping: bool,
+    huber_loss_3px: bool,
     oracle_fixture_out: Option<PathBuf>,
 }
 
@@ -170,6 +172,19 @@ struct PreparedProblem {
     ba: BundleAdjustment,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct HuberReprojectionStats {
+    raw_cost: f64,
+    robust_cost: f64,
+    residual_norm_sum: f64,
+    max_residual_norm: f64,
+    valid_observations: usize,
+    nonprojectable_observations: usize,
+    robustified_observations: usize,
+    weight_sum: f64,
+    minimum_weight: Option<f64>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 struct RunSummary {
     solver: SolverArm,
@@ -227,6 +242,8 @@ where
     let mut matrix_free_column_scaling_seen = false;
     let mut matrix_free_adaptive_damping = false;
     let mut matrix_free_adaptive_damping_seen = false;
+    let mut huber_loss_3px = false;
+    let mut huber_loss_seen = false;
     while let Some(flag) = values.next() {
         if flag == "-h" || flag == "--help" {
             return Err(USAGE.to_owned());
@@ -301,6 +318,14 @@ where
             }
             matrix_free_adaptive_damping_seen = true;
             matrix_free_adaptive_damping = true;
+            continue;
+        }
+        if flag == "--huber-loss-3px" {
+            if huber_loss_seen {
+                return Err(format!("duplicate argument {flag}\n{USAGE}"));
+            }
+            huber_loss_seen = true;
+            huber_loss_3px = true;
             continue;
         }
         if flag == "--pcg-relative-tolerance" {
@@ -394,12 +419,13 @@ where
             || allow_unsupported_seen
             || fixed_landmark_ids_seen
             || matrix_free_column_scaling_seen
-            || matrix_free_adaptive_damping_seen)
+            || matrix_free_adaptive_damping_seen
+            || huber_loss_seen)
     {
         return Err(format!(
             "--export-oracle-fixture is a standalone operation; do not combine it with \
              --solver, --out-dir, --fixed-frame-id, --allow-unsupported-sensor-images, --fixed-landmark-ids, \
-             --matrix-free-column-scaling, --matrix-free-adaptive-damping, --pcg-max-iterations, --pcg-relative-tolerance or \
+             --matrix-free-column-scaling, --matrix-free-adaptive-damping, --huber-loss-3px, --pcg-max-iterations, --pcg-relative-tolerance or \
              --pcg-max-restarts\n{USAGE}"
         ));
     }
@@ -425,6 +451,7 @@ where
         fixed_landmark_ids,
         matrix_free_column_scaling,
         matrix_free_adaptive_damping,
+        huber_loss_3px,
         oracle_fixture_out,
     };
     if args.solver == Some(SolverArm::Direct) && matrix_free_column_scaling_seen {
@@ -463,11 +490,25 @@ where
             "adaptive damping requires PCG max_iterations=512, relative_tolerance=1e-8, and max_restarts=0\n{USAGE}"
         ));
     }
+    if huber_loss_3px
+        && !(args.solver == Some(SolverArm::MatrixFree)
+            && matrix_free_column_scaling
+            && matrix_free_adaptive_damping)
+    {
+        return Err(format!(
+            "--huber-loss-3px requires matrix-free column-scaled adaptive mode\n{USAGE}"
+        ));
+    }
     if args.fixed_landmark_ids.is_some()
         && !(args.solver == Some(SolverArm::MatrixFree) && matrix_free_adaptive_damping)
     {
         return Err(format!(
             "--fixed-landmark-ids requires --solver matrix-free --matrix-free-column-scaling --matrix-free-adaptive-damping\n{USAGE}"
+        ));
+    }
+    if huber_loss_3px && args.fixed_landmark_ids.is_some() {
+        return Err(format!(
+            "--huber-loss-3px cannot be combined with --fixed-landmark-ids\n{USAGE}"
         ));
     }
     Ok(args)
@@ -556,7 +597,31 @@ fn run(args: &Args) -> Result<(), String> {
         .out_dir
         .as_deref()
         .ok_or_else(|| "--out-dir is required for solver mode".to_owned())?;
-    let initial_cost = prepared.ba.cost();
+    let huber_kernel = args.huber_loss_3px.then_some(RobustKernel::Huber {
+        delta: HUBER_LOSS_3PX_DELTA,
+    });
+    let huber_source_hashes = if args.huber_loss_3px {
+        Some(hash_source_inputs(&args.model, &args.rig_manifest)?)
+    } else {
+        None
+    };
+    let huber_initial_stats = if let Some(kernel) = &huber_kernel {
+        let stats = stream_huber_reprojection_stats(&prepared.ba, kernel)?;
+        ensure_huber_initially_eligible(&stats)?;
+        ensure_huber_cost_matches(
+            "initial",
+            stats.robust_cost,
+            prepared.ba.robust_cost(kernel),
+        )?;
+        ensure_huber_cost_matches("initial raw", stats.raw_cost, prepared.ba.cost())?;
+        print_huber_reprojection_stats("initial", &stats, prepared.ba.rig_observations.len());
+        Some(stats)
+    } else {
+        None
+    };
+    let initial_cost = huber_initial_stats
+        .as_ref()
+        .map_or_else(|| prepared.ba.cost(), |stats| stats.robust_cost);
     if !initial_cost.is_finite() {
         return Err("initial BA cost is non-finite".to_owned());
     }
@@ -564,7 +629,7 @@ fn run(args: &Args) -> Result<(), String> {
         max_iterations: BA_MAX_ITERATIONS,
         initial_lambda: Some(BA_INITIAL_LAMBDA),
         linear_solver: LinearSolver::Sparse,
-        robust_kernel: RobustKernel::None,
+        robust_kernel: huber_kernel.unwrap_or(RobustKernel::None),
         refine_intrinsics: false,
         refine_distortion: false,
         parallel: false,
@@ -603,11 +668,31 @@ fn run(args: &Args) -> Result<(), String> {
         );
     }
     if args.matrix_free_adaptive_damping {
+        if args.huber_loss_3px {
+            println!(
+                "adaptive_damping_configuration solver=matrix-free-column-scaled-adaptive policy=accepted_rho_cubic_min_factor[1/3] prediction_coordinates=scaled prediction=weighted_irls_surrogate same_observation_gate=true lm_acceptance_cost=robust_huber pcg_max_iterations={} pcg_relative_tolerance={:.17e} pcg_absolute_tolerance={:.17e} pcg_max_restarts=0",
+                ADAPTIVE_PCG_MAX_ITERATIONS,
+                ADAPTIVE_PCG_RELATIVE_TOLERANCE,
+                PCG_TOLERANCE,
+            );
+        } else {
+            println!(
+                "adaptive_damping_configuration solver=matrix-free-column-scaled-adaptive policy=accepted_rho_cubic_min_factor[1/3] prediction_coordinates=scaled prediction=undamped_squared_cost same_observation_gate=true pcg_max_iterations={} pcg_relative_tolerance={:.17e} pcg_absolute_tolerance={:.17e} pcg_max_restarts=0",
+                ADAPTIVE_PCG_MAX_ITERATIONS,
+                ADAPTIVE_PCG_RELATIVE_TOLERANCE,
+                PCG_TOLERANCE,
+            );
+        }
+    }
+    if args.huber_loss_3px {
+        let source_hashes = huber_source_hashes
+            .as_ref()
+            .expect("Huber mode computes source hashes before solving");
         println!(
-            "adaptive_damping_configuration solver=matrix-free-column-scaled-adaptive policy=accepted_rho_cubic_min_factor[1/3] prediction_coordinates=scaled prediction=undamped_squared_cost same_observation_gate=true pcg_max_iterations={} pcg_relative_tolerance={:.17e} pcg_absolute_tolerance={:.17e} pcg_max_restarts=0",
-            ADAPTIVE_PCG_MAX_ITERATIONS,
-            ADAPTIVE_PCG_RELATIVE_TOLERANCE,
-            PCG_TOLERANCE,
+            "huber_loss_configuration solver=matrix-free-column-scaled-adaptive delta_px={:.17e} raw_objective=sum_squared robust_objective=sum_huber_rho robustified_weight=huber_derivative lm_acceptance_cost=robust_huber source_sha256={} combined_source_sha256={}",
+            HUBER_LOSS_3PX_DELTA,
+            source_hashes.combined,
+            source_hashes.combined,
         );
     }
     if solver == SolverArm::MatrixFree && args.pcg_max_restarts_explicit {
@@ -719,6 +804,49 @@ fn run(args: &Args) -> Result<(), String> {
     if !final_cost.is_finite() {
         return Err("final BA cost is non-finite".to_owned());
     }
+    let huber_final_stats = if let Some(kernel) = &huber_kernel {
+        let stats = stream_huber_reprojection_stats(&prepared.ba, kernel)?;
+        ensure_huber_cost_matches("final", stats.robust_cost, final_cost)?;
+        ensure_huber_cost_matches(
+            "final streamed",
+            stats.robust_cost,
+            prepared.ba.robust_cost(kernel),
+        )?;
+        ensure_huber_cost_matches("final raw", stats.raw_cost, prepared.ba.cost())?;
+        if stats.nonprojectable_observations != 0 {
+            return Err(format!(
+                "Huber candidate produced nonprojectable observations: {}",
+                stats.nonprojectable_observations
+            ));
+        }
+        let accepted_steps = match &optimization {
+            OptimizationResult::MatrixFreeAdaptive(result) => result
+                .ba
+                .iterations
+                .iter()
+                .filter(|iteration| iteration.step_accepted)
+                .count(),
+            _ => 0,
+        };
+        if accepted_steps == 0 {
+            return Err("Huber candidate accepted no LM steps".to_owned());
+        }
+        let initial = huber_initial_stats
+            .as_ref()
+            .expect("Huber final stats require initial stats");
+        let increase = stats.robust_cost - initial.robust_cost;
+        let tolerance = 1.0e-8 + 1.0e-12 * initial.robust_cost.abs().max(1.0);
+        if !increase.is_finite() || increase > tolerance {
+            return Err(format!(
+                "Huber robust objective increased: initial={:.17e} final={:.17e}",
+                initial.robust_cost, stats.robust_cost
+            ));
+        }
+        print_huber_reprojection_stats("final", &stats, prepared.ba.rig_observations.len());
+        Some(stats)
+    } else {
+        None
+    };
     if let Some(snapshot) = &fixed_landmark_snapshot {
         ensure_fixed_landmarks_unchanged(&prepared.ba, snapshot)?;
     }
@@ -748,7 +876,84 @@ fn run(args: &Args) -> Result<(), String> {
     } else {
         summary.solver.as_str()
     };
-    if args.matrix_free_adaptive_damping {
+    if args.huber_loss_3px {
+        let initial = huber_initial_stats
+            .as_ref()
+            .expect("Huber summary requires initial stats");
+        let final_stats = huber_final_stats
+            .as_ref()
+            .expect("Huber summary requires final stats");
+        let accepted_steps = match &optimization {
+            OptimizationResult::MatrixFreeAdaptive(result) => result
+                .ba
+                .iterations
+                .iter()
+                .filter(|iteration| iteration.step_accepted)
+                .count(),
+            _ => 0,
+        };
+        let source_hashes = huber_source_hashes
+            .as_ref()
+            .expect("Huber summary requires source hashes");
+        println!(
+            "solver={} cost_objective=robust_huber_3px raw_objective=sum_squared lm_trace_cost=robust_huber delta_px={:.17e} initial_cost={:.15e} final_cost={:.15e} initial_raw_cost={:.15e} final_raw_cost={:.15e} initial_robust_cost={:.15e} final_robust_cost={:.15e} initial_raw_mean_px={:.15e} final_raw_mean_px={:.15e} initial_raw_rmse_px={:.15e} final_raw_rmse_px={:.15e} initial_max_residual_px={:.15e} final_max_residual_px={:.15e} initial_valid_observations={} final_valid_observations={} initial_nonprojectable_observations={} final_nonprojectable_observations={} initial_robustified_observations={} final_robustified_observations={} initial_minimum_weight={} final_minimum_weight={} initial_weight_sum={:.15e} final_weight_sum={:.15e} accepted_lm_steps={} lm_iterations={} converged={} source_sha256={} source_images={} source_frames={} source_landmarks={} source_observations={} fixed_pose={} fixed_landmarks={} allow_unsupported_sensor_images={} source_supported_image_count={} pcg_max_iterations={} pcg_relative_tolerance={:.17e} pcg_absolute_tolerance={:.17e} pcg_max_restarts=0 adaptive_damping=true solver_seconds={:.6} total_seconds={:.6} out={}",
+            solver_name,
+            HUBER_LOSS_3PX_DELTA,
+            summary.initial_cost,
+            summary.final_cost,
+            initial.raw_cost,
+            final_stats.raw_cost,
+            initial.robust_cost,
+            final_stats.robust_cost,
+            initial.residual_norm_sum / initial.valid_observations.max(1) as f64,
+            final_stats.residual_norm_sum / final_stats.valid_observations.max(1) as f64,
+            (initial.raw_cost / initial.valid_observations.max(1) as f64).sqrt(),
+            (final_stats.raw_cost / final_stats.valid_observations.max(1) as f64).sqrt(),
+            initial.max_residual_norm,
+            final_stats.max_residual_norm,
+            initial.valid_observations,
+            final_stats.valid_observations,
+            initial.nonprojectable_observations,
+            final_stats.nonprojectable_observations,
+            initial.robustified_observations,
+            final_stats.robustified_observations,
+            initial
+                .minimum_weight
+                .map_or_else(|| "none".to_owned(), |value| format!("{value:.17e}")),
+            final_stats
+                .minimum_weight
+                .map_or_else(|| "none".to_owned(), |value| format!("{value:.17e}")),
+            initial.weight_sum,
+            final_stats.weight_sum,
+            accepted_steps,
+            summary.iterations,
+            summary.converged,
+            source_hashes.combined,
+            source.images.len(),
+            manifest
+                .assignments
+                .values()
+                .map(|assignment| assignment.frame_id)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            source.points.len(),
+            source
+                .points
+                .iter()
+                .map(|point| point.observations.len())
+                .sum::<usize>(),
+            args.fixed_frame_id,
+            fixed_landmark_count,
+            args.allow_unsupported_sensor_images,
+            source_supported_image_count(&source),
+            args.pcg_max_iterations,
+            args.pcg_relative_tolerance,
+            PCG_TOLERANCE,
+            summary.solver_seconds,
+            summary.total_seconds,
+            out_dir.display(),
+        );
+    } else if args.matrix_free_adaptive_damping {
         let adaptive_iterations = match &optimization {
             OptimizationResult::MatrixFreeAdaptive(result) => result.adaptive_iterations.len(),
             _ => 0,
@@ -2805,6 +3010,151 @@ fn write_model_files(
     Ok(())
 }
 
+fn stream_huber_reprojection_stats(
+    ba: &BundleAdjustment,
+    kernel: &RobustKernel,
+) -> Result<HuberReprojectionStats, String> {
+    let mut stats = HuberReprojectionStats {
+        raw_cost: 0.0,
+        robust_cost: 0.0,
+        residual_norm_sum: 0.0,
+        max_residual_norm: 0.0,
+        valid_observations: 0,
+        nonprojectable_observations: 0,
+        robustified_observations: 0,
+        weight_sum: 0.0,
+        minimum_weight: None,
+    };
+    for observation in &ba.rig_observations {
+        let Some(pose) = ba.poses.get(&observation.keyframe_id) else {
+            stats.nonprojectable_observations += 1;
+            continue;
+        };
+        let Some(point) = ba.landmarks.get(&observation.landmark_id) else {
+            stats.nonprojectable_observations += 1;
+            continue;
+        };
+        let Some((fx, fy, cx, cy)) = observation.camera.intrinsics() else {
+            stats.nonprojectable_observations += 1;
+            continue;
+        };
+        let point_rig = pose.transform_world_point(point);
+        let point_sensor = observation.sensor_from_rig.transform_point(&point_rig);
+        let coordinates_finite = point_sensor.coords.iter().all(|value| value.is_finite());
+        if !coordinates_finite || point_sensor.z <= MIN_DEPTH_M {
+            stats.nonprojectable_observations += 1;
+            continue;
+        }
+        let predicted = Point2::new(
+            fx * point_sensor.x / point_sensor.z + cx,
+            fy * point_sensor.y / point_sensor.z + cy,
+        );
+        if !predicted.coords.iter().all(|value| value.is_finite()) {
+            stats.nonprojectable_observations += 1;
+            continue;
+        }
+        let residual = predicted - observation.xy;
+        let squared = residual.norm_squared();
+        let norm = squared.sqrt();
+        if !squared.is_finite() || !norm.is_finite() {
+            return Err(format!(
+                "non-finite Huber reprojection residual for frame {} landmark {}",
+                observation.keyframe_id, observation.landmark_id
+            ));
+        }
+        let robust = kernel.cost(squared);
+        let weight = kernel.weight(squared);
+        if !robust.is_finite() || !weight.is_finite() || weight < 0.0 {
+            return Err(format!(
+                "non-finite Huber cost/weight for frame {} landmark {}",
+                observation.keyframe_id, observation.landmark_id
+            ));
+        }
+        stats.raw_cost += squared;
+        stats.robust_cost += robust;
+        stats.residual_norm_sum += norm;
+        stats.weight_sum += weight;
+        if !stats.raw_cost.is_finite()
+            || !stats.robust_cost.is_finite()
+            || !stats.residual_norm_sum.is_finite()
+            || !stats.weight_sum.is_finite()
+        {
+            return Err("Huber reprojection scalar accumulation overflowed".to_owned());
+        }
+        stats.max_residual_norm = stats.max_residual_norm.max(norm);
+        stats.minimum_weight = Some(
+            stats
+                .minimum_weight
+                .map_or(weight, |minimum| minimum.min(weight)),
+        );
+        if weight < 1.0 {
+            stats.robustified_observations += 1;
+        }
+        stats.valid_observations += 1;
+    }
+    Ok(stats)
+}
+
+fn ensure_huber_cost_matches(label: &str, observed: f64, reported: f64) -> Result<(), String> {
+    if !observed.is_finite() || !reported.is_finite() {
+        return Err(format!("{label} Huber cost is non-finite"));
+    }
+    let difference = (observed - reported).abs();
+    let scale = observed.abs().max(reported.abs()).max(1.0);
+    if !difference.is_finite() || difference > 1.0e-8 + 1.0e-12 * scale {
+        return Err(format!(
+            "{label} Huber cost mismatch: streamed={observed:.17e} solver={reported:.17e}"
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_huber_initially_eligible(stats: &HuberReprojectionStats) -> Result<(), String> {
+    if stats.nonprojectable_observations != 0 {
+        return Err(format!(
+            "Huber candidate requires all observations projectable; nonprojectable_observations={}",
+            stats.nonprojectable_observations
+        ));
+    }
+    if stats.valid_observations == 0 {
+        return Err("Huber candidate has no valid observations".to_owned());
+    }
+    if !stats.raw_cost.is_finite() || !stats.robust_cost.is_finite() {
+        return Err("Huber candidate initial cost is non-finite".to_owned());
+    }
+    Ok(())
+}
+
+fn print_huber_reprojection_stats(
+    phase: &str,
+    stats: &HuberReprojectionStats,
+    total_observations: usize,
+) {
+    let raw_mean = stats.raw_cost / stats.valid_observations.max(1) as f64;
+    let raw_rmse = raw_mean.sqrt();
+    let raw_mean_px = stats.residual_norm_sum / stats.valid_observations.max(1) as f64;
+    println!(
+        "huber_reprojection_stats phase={} objective_raw=sum_squared objective_robust=sum_huber_rho delta_px={:.17e} raw_cost={:.17e} robust_cost={:.17e} raw_mean_squared={:.17e} raw_mean_px={:.17e} raw_rmse_px={:.17e} residual_norm_sum_px={:.17e} max_residual_px={:.17e} valid_observations={} nonprojectable_observations={} total_observations={} robustified_observations={} minimum_weight={} weight_sum={:.17e}",
+        phase,
+        HUBER_LOSS_3PX_DELTA,
+        stats.raw_cost,
+        stats.robust_cost,
+        raw_mean,
+        raw_mean_px,
+        raw_rmse,
+        stats.residual_norm_sum,
+        stats.max_residual_norm,
+        stats.valid_observations,
+        stats.nonprojectable_observations,
+        total_observations,
+        stats.robustified_observations,
+        stats
+            .minimum_weight
+            .map_or_else(|| "none".to_owned(), |value| format!("{value:.17e}")),
+        stats.weight_sum,
+    );
+}
+
 fn print_direct_trace(result: &visloc_rs::slam::BaResult) {
     for iteration in &result.iterations {
         println!(
@@ -3094,6 +3444,13 @@ fn parse_f64(value: &str, label: &str, path: &Path, line: usize) -> Result<f64, 
 mod tests {
     use super::*;
 
+    fn assert_close(actual: f64, expected: f64, tolerance: f64) {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "actual={actual:.17e} expected={expected:.17e} tolerance={tolerance:.3e}"
+        );
+    }
+
     #[test]
     fn parses_solver_and_rejects_pcg_for_direct() {
         let args = parse_args(
@@ -3182,6 +3539,7 @@ mod tests {
         assert!(!default.allow_unsupported_sensor_images_explicit);
         assert!(!default.matrix_free_column_scaling);
         assert!(!default.matrix_free_adaptive_damping);
+        assert!(!default.huber_loss_3px);
     }
 
     #[test]
@@ -3469,6 +3827,143 @@ mod tests {
                 "--export-oracle-fixture",
                 "fixture.txt",
                 "--matrix-free-adaptive-damping",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(export.contains("standalone operation"));
+    }
+
+    #[test]
+    fn parses_huber_loss_only_for_adaptive_column_scaled_matrix_free() {
+        let args = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--matrix-free-column-scaling",
+                "--matrix-free-adaptive-damping",
+                "--huber-loss-3px",
+                "--pcg-max-iterations",
+                "512",
+                "--pcg-relative-tolerance",
+                "1e-8",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap();
+        assert!(args.huber_loss_3px);
+
+        let duplicate = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--matrix-free-column-scaling",
+                "--matrix-free-adaptive-damping",
+                "--huber-loss-3px",
+                "--huber-loss-3px",
+                "--pcg-max-iterations",
+                "512",
+                "--pcg-relative-tolerance",
+                "1e-8",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(duplicate.contains("duplicate argument"));
+
+        let missing_adaptive = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--matrix-free-column-scaling",
+                "--huber-loss-3px",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(missing_adaptive.contains("requires matrix-free column-scaled adaptive mode"));
+
+        let direct = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "direct",
+                "--out-dir",
+                "out",
+                "--huber-loss-3px",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(direct.contains("requires matrix-free column-scaled adaptive mode"));
+
+        let fixed_landmark = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--solver",
+                "matrix-free",
+                "--out-dir",
+                "out",
+                "--matrix-free-column-scaling",
+                "--matrix-free-adaptive-damping",
+                "--huber-loss-3px",
+                "--fixed-landmark-ids",
+                "frozen.txt",
+                "--pcg-max-iterations",
+                "512",
+                "--pcg-relative-tolerance",
+                "1e-8",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .unwrap_err();
+        assert!(fixed_landmark.contains("cannot be combined"));
+
+        let export = parse_args(
+            [
+                "compare",
+                "--model",
+                "model",
+                "--rig-manifest",
+                "rig.txt",
+                "--export-oracle-fixture",
+                "fixture.txt",
+                "--huber-loss-3px",
             ]
             .into_iter()
             .map(str::to_owned),
@@ -4315,6 +4810,145 @@ mod tests {
             sensor_zero_image_by_frame: BTreeMap::from([(0, 0)]),
         };
         (source, manifest)
+    }
+
+    #[test]
+    fn huber_stats_match_boundary_outlier_and_all_rig_observations() {
+        let (source, manifest) = publication_fixture();
+        let mut prepared = build_problem(&source, &manifest).unwrap();
+        let kernel = RobustKernel::Huber {
+            delta: HUBER_LOSS_3PX_DELTA,
+        };
+        let baseline = stream_huber_reprojection_stats(&prepared.ba, &kernel).unwrap();
+        assert_eq!(baseline.valid_observations, 2);
+        assert_eq!(baseline.nonprojectable_observations, 0);
+        assert_eq!(baseline.robustified_observations, 0);
+        assert_close(baseline.raw_cost, 0.0, 1.0e-12);
+        assert_close(
+            baseline.robust_cost,
+            prepared.ba.robust_cost(&kernel),
+            1.0e-12,
+        );
+
+        // Exactly delta is still in the quadratic branch.
+        prepared.ba.rig_observations[0].xy = Point2::new(-3.0, 0.0);
+        let boundary = stream_huber_reprojection_stats(&prepared.ba, &kernel).unwrap();
+        assert_eq!(
+            boundary.valid_observations,
+            prepared.ba.rig_observations.len()
+        );
+        assert_eq!(boundary.robustified_observations, 0);
+        assert_close(boundary.raw_cost, 9.0, 1.0e-12);
+        assert_close(boundary.robust_cost, 9.0, 1.0e-12);
+        assert_close(boundary.weight_sum, 2.0, 1.0e-12);
+        assert_close(boundary.minimum_weight.unwrap(), 1.0, 1.0e-12);
+
+        // A 5px residual is linearized with rho=2*delta*sqrt(s)-delta²
+        // and rho'=delta/sqrt(s), while the second observation remains exact.
+        prepared.ba.rig_observations[0].xy = Point2::new(-5.0, 0.0);
+        let outlier = stream_huber_reprojection_stats(&prepared.ba, &kernel).unwrap();
+        assert_eq!(
+            outlier.valid_observations,
+            prepared.ba.rig_observations.len()
+        );
+        assert_eq!(outlier.robustified_observations, 1);
+        assert_close(outlier.raw_cost, 25.0, 1.0e-12);
+        assert_close(outlier.robust_cost, 21.0, 1.0e-12);
+        assert_close(outlier.minimum_weight.unwrap(), 0.6, 1.0e-12);
+        assert_close(outlier.weight_sum, 1.6, 1.0e-12);
+        assert_close(
+            outlier.robust_cost,
+            prepared.ba.robust_cost(&kernel),
+            1.0e-12,
+        );
+        ensure_huber_initially_eligible(&outlier).unwrap();
+    }
+
+    #[test]
+    fn huber_stats_reject_nonprojectable_initial_candidate() {
+        let (source, manifest) = publication_fixture();
+        let mut prepared = build_problem(&source, &manifest).unwrap();
+        prepared.ba.landmarks.insert(7, Point3::new(0.0, 0.0, -2.0));
+        let kernel = RobustKernel::Huber {
+            delta: HUBER_LOSS_3PX_DELTA,
+        };
+        let stats = stream_huber_reprojection_stats(&prepared.ba, &kernel).unwrap();
+        assert_eq!(stats.valid_observations, 0);
+        assert_eq!(stats.nonprojectable_observations, 2);
+        let error = ensure_huber_initially_eligible(&stats).unwrap_err();
+        assert!(error.contains("nonprojectable_observations=2"));
+    }
+
+    #[test]
+    fn huber_adaptive_uses_robust_cost_and_preserves_rig_observations() {
+        let (source, manifest) = publication_fixture();
+        let mut prepared = build_problem(&source, &manifest).unwrap();
+        prepared.ba.add_pose(1, Pose::identity());
+        let extra_observations = prepared.ba.rig_observations.clone();
+        for mut observation in extra_observations {
+            observation.keyframe_id = 1;
+            prepared.ba.add_rig_observation(observation);
+        }
+        prepared.ba.rig_observations[0].xy = Point2::new(-5.0, 0.0);
+        let kernel = RobustKernel::Huber {
+            delta: HUBER_LOSS_3PX_DELTA,
+        };
+        let initial_stats = stream_huber_reprojection_stats(&prepared.ba, &kernel).unwrap();
+        ensure_huber_initially_eligible(&initial_stats).unwrap();
+        let initial_observation_count = prepared.ba.rig_observations.len();
+        let initial_extrinsics: Vec<SE3> = prepared
+            .ba
+            .rig_observations
+            .iter()
+            .map(|observation| observation.sensor_from_rig.clone())
+            .collect();
+        let anchor = prepared.ba.poses[&0].clone();
+        let config = BaConfig {
+            max_iterations: BA_MAX_ITERATIONS,
+            initial_lambda: Some(BA_INITIAL_LAMBDA),
+            linear_solver: LinearSolver::Sparse,
+            robust_kernel: kernel,
+            refine_intrinsics: false,
+            refine_distortion: false,
+            parallel: false,
+            ..BaConfig::default()
+        };
+        let result = prepared
+            .ba
+            .optimize_matrix_free_column_scaled_adaptive(
+                &config,
+                MatrixFreeBaColumnScalingOptions {
+                    pcg: MatrixFreeBaOptions {
+                        max_pcg_iterations: ADAPTIVE_PCG_MAX_ITERATIONS,
+                        pcg_relative_tolerance: ADAPTIVE_PCG_RELATIVE_TOLERANCE,
+                        pcg_absolute_tolerance: PCG_TOLERANCE,
+                    },
+                },
+            )
+            .unwrap();
+        assert_close(result.ba.initial_cost, initial_stats.robust_cost, 1.0e-10);
+        assert!(result
+            .ba
+            .iterations
+            .iter()
+            .any(|iteration| iteration.step_accepted));
+        assert!(result.ba.iterations.iter().any(|iteration| {
+            iteration.step_accepted && iteration.cost_after < iteration.cost_before
+        }));
+        let final_stats = stream_huber_reprojection_stats(&prepared.ba, &kernel).unwrap();
+        assert_eq!(final_stats.valid_observations, initial_observation_count);
+        assert_eq!(final_stats.nonprojectable_observations, 0);
+        assert_close(result.ba.final_cost, final_stats.robust_cost, 1.0e-10);
+        assert_eq!(prepared.ba.poses[&0], anchor);
+        assert_eq!(
+            prepared
+                .ba
+                .rig_observations
+                .iter()
+                .map(|observation| observation.sensor_from_rig.clone())
+                .collect::<Vec<_>>(),
+            initial_extrinsics
+        );
     }
 
     fn write_publication_inputs(


### PR DESCRIPTION
## Summary
- Predeclare one frozen 1k Huber-3 intervention; retain all 4,716 variable points and 130,900 observations.
- Add driver-only --huber-loss-3px for adaptive column-scaled matrix-free mode, with explicit raw/robust accounting and scalar-only statistics.
- Preserve default/OFF path; do not change the library solver or README performance claims.

## Verified experiment
Implementation c026f404d92ff466c691ac86e240ab2df5629504; binary SHA cdbdf63466e9cca7940014d20605ec9485c566f184a86ac7c11dd5476fea23f3.
Four serial 180s-bounded processes all exit 0. Legacy/adaptive controls reproduce PR #91 model bytes and 40/82 numerical rows; Huber repeat reproduces three model files and 85 rows.

| Arm | Wall s | Peak RSS KiB | Accepted LM |
| --- | ---: | ---: | ---: |
| Legacy None | 19.84 | 84652 | 3 |
| Adaptive None | 22.26 | 84856 | 15 |
| Huber-3 | 22.00 | 85156 | 13 |
| Huber-3 repeat | 22.43 | 85108 | 13 |

Independent identity/support/calibration/anchor/depth audits pass. Independent raw/robust costs agree within 7e-10. All runs have converged=false after 20 iterations.

**Rejected:** post-only GT 308-image RMSE/p95 0.028822200/0.044018261 m fail legacy 0.026608055/0.041099985 m, despite mean reprojection improving to 0.673262240 px. No atlas/default promotion or loss-scale sweep. These local BA process timings do not establish COLMAP native mapper/E2E superiority.

## Validation
- Agent and independent root: 28 example tests and example-only clippy -D warnings pass.
- Root: existing library Huber derivative and matrix-free rig regression pass.
- git diff --check and documentation links pass.
- Source/input hashes unchanged; same-model post-score repeat exact.
- Final head 8cda545e9b374c288c286fead4ab73d6f274532f: all nine CI jobs pass, run 34184156416.

Evidence: benchmarks/electro/m8-openloris-frozen-huber-ba-{preflight-v1,v1}.json.
Full M8-M10 native/10k quality/tier/restart/100k gates remain open.