### PR TITLE
feat(sfm): add opt-in native rig matrix-free backend and quality evidence

### DIFF
--- a/benchmarks/electro/m8-openloris-native-rig-matrix-free-preflight-v1.json
+++ b/benchmarks/electro/m8-openloris-native-rig-matrix-free-preflight-v1.json
@@ -1,0 +1,353 @@
+{
+  "schema": "visloc_m8_native_rig_matrix_free_preflight_v1",
+  "status": "native_main_control_reproduced_candidate_not_run",
+  "certificate": {
+    "base_main": "ece2b7148d51d02e63b6edf30cba38ab7ad5a026",
+    "contract_commit": "aeea017",
+    "binary_sha256": "7a7446459817b492724f7b784894f826c1bbd1888637590a310d646a1ee39bcd",
+    "driver_sha256": "4f6ef90b8b0390ec4a33550c17921d7d0587dace91c7e9ee7d506eed7dee9174",
+    "rig_source_sha256": "6207233bd7b7252cd3cc25f23e17d8ca29d06fb774be5683bd8c65c7f4d51294",
+    "bundle_sha256": "8f84b49c8b4704ce8a4a918cbc18dcbb39d1191c326f00c233ce1c22e3275e4b",
+    "build_command": "cargo build --release --example generalized_rig_sfm",
+    "build_exit": 0,
+    "build_reported_seconds": 5.78,
+    "feature_identity": {
+      "path": "/home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256",
+      "file_count": 1000,
+      "total_bytes": 302873132,
+      "tree_sha256": "4de9d6ae8da31d77fab32fee09507a9aee1d8bcf10312255f5ef065a31055e5d"
+    },
+    "feature_hash_algorithm": "scripts/run_official_baselines.py directory_identity: sorted relative path length/path, size, file contents",
+    "historical_feature_hash": "abcfa6a9d4df344d1781bc2560b5e4cdcae08b39ed303063535e7e1e926a304a",
+    "historical_feature_hash_comparison": "Historical evidence does not specify algorithm; new independently specified tree hash differs. Do not claim feature-tree hash equality; require exact historical control model reproduction and freeze actual current files for candidate comparison.",
+    "snapshot_sha256": "4964cbbe87aca7d78b33c71fbf0be4d186e5dc78e42df20b78f045775eb79aad",
+    "rig_sha256": "6bcd670c475c66a82aaa9b96247331ca1686df2676d569cf7ed01c3158c35900",
+    "command": "env -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-main-ece2b71 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model > /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control.log 2>&1",
+    "before_run": true
+  },
+  "actual_control": {
+    "model_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "937098610a0ec29c37bbc9c649e9385050d9ce6782f3154fcc2c02613281b8ee",
+      "points3D.txt": "11eb71b6a45f248770429a91a8841e64e028089350515f3f87366c468ae399af"
+    },
+    "historical_model_bytes_exact": true,
+    "wall_seconds": 4.42,
+    "peak_rss_kib": 81916,
+    "mapper_seconds": 3.864511,
+    "logged_vmhwm_kib": 82120,
+    "exit_code": 0,
+    "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62452 KiB\nrig-replay BA: observations=120217 cost=267541.992667814->121458.389207945 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2658 observations=27716 mean_reprojection_px=0.671637382 seed_frame=26 mapper_seconds=3.864511 total_seconds=4.415297 VmHWM_KiB=82120 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=39217 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=29751 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2607 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model\n",
+    "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-main-ece2b71 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model\"\n\tUser time (seconds): 4.33\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:04.42\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 81916\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 1\n\tMinor (reclaiming a frame) page faults: 23487\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 20\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7288\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+    "artifact_sha256": {
+      "log": "18d9afb0f4c3754673ab9c96303a51fb16cffb2b54b88840dc73e35e7d3b4066",
+      "time": "83ac93d24fbb501cebada6dd91fbcc4209e89c08a23540ea2640b24df674773a"
+    }
+  },
+  "control_audit_program": "import json,hashlib,re\nfrom pathlib import Path\nroot=Path('/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1')\nold=Path('/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000-champion-default/model')\nnames=('cameras.txt','images.txt','points3D.txt')\nhashes={}\nfor name in names:\n    a=(root/'main-control/model'/name).read_bytes();b=(old/name).read_bytes()\n    assert a==b,name\n    hashes[name]=hashlib.sha256(a).hexdigest()\nlog=(root/'main-control.log').read_text();time=(root/'main-control.time').read_text()\nassert 'Exit status: 0' in time\nassert 'registered_frames=500/500 registered_images=1000/1000' in log\nprint(json.dumps(dict(model_sha256=hashes,historical_model_bytes_exact=True,\n wall_seconds=4.42,peak_rss_kib=int(re.search(r'Maximum resident set size \\(kbytes\\):\\s*(\\d+)',time).group(1)),\n mapper_seconds=float(re.search(r'mapper_seconds=([0-9.]+)',log).group(1)),\n logged_vmhwm_kib=int(re.search(r'VmHWM_KiB=(\\d+)',log).group(1)),\n exit_code=0,log=log,time_output=time,artifact_sha256={ext:hashlib.sha256((root/('main-control.'+ext)).read_bytes()).hexdigest() for ext in ('log','time')}),indent=2))\n",
+  "geometry": {
+    "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model",
+    "image_poses": 1000,
+    "supported_images": 1000,
+    "unsupported_image_ids": [],
+    "landmarks": 2658,
+    "observations": 27716,
+    "mean_reprojection_px": 0.6716373819326764,
+    "observation_weighted_mean_reprojection_px": 0.6716373819326764,
+    "point_weighted_mean_reprojection_px": 0.6926260545829283,
+    "max_track_mean_reprojection_px": 3.6361350989931407,
+    "max_reprojection_px": 3.999702884107455,
+    "max_stored_mean_difference_px": 3.6361350989931407,
+    "nonpositive_depth_observations": 0,
+    "tracks_with_multiple_keypoints_in_one_image": 0,
+    "excess_same_image_track_observations": 0,
+    "bidirectional_references_valid": true,
+    "rig": {
+      "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+      "rig_frames": 500,
+      "supported_rig_frames": 500,
+      "unsupported_rig_frame_ids": [],
+      "max_inferred_rig_center_disagreement_m": 2.8057036402022433e-12,
+      "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+      "fixed_sensor_extrinsics_valid": true,
+      "track_connected_components": 1,
+      "track_connected_component_sizes": [
+        500
+      ],
+      "track_connected_component_frame_ranges": [
+        [
+          0,
+          499
+        ]
+      ]
+    }
+  },
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+  "post_only_control_score": {
+    "component_weighted_max_m": 0.061655609452973735,
+    "component_weighted_median_m": 0.017618963368611313,
+    "component_weighted_p95_m": 0.03777877644562742,
+    "component_weighted_rmse_m": 0.02269532080131782,
+    "components": [
+      {
+        "gt_scored": 308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model/images.txt",
+        "images_txt_sha256": "937098610a0ec29c37bbc9c649e9385050d9ce6782f3154fcc2c02613281b8ee",
+        "max_m": 0.061655609452973735,
+        "median_m": 0.017618963368611313,
+        "p95_m": 0.03777877644562742,
+        "reference_extent_m": 1.9718678959594034,
+        "registered": 1000,
+        "relative_rmse": 0.011509554391459634,
+        "rmse_m": 0.02269532080131782,
+        "sim3_scale": 1.4490576076547674,
+        "trajectory_segments": [
+          {
+            "images": 32,
+            "max_m": 0.02376709176290114,
+            "median_m": 0.016614248251229993,
+            "p95_m": 0.02264454115422436,
+            "rmse_m": 0.01701246921154381,
+            "segment": 0,
+            "timestamp_end": 1560000015.556828,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 30,
+            "max_m": 0.020345203673943383,
+            "median_m": 0.015553289816758582,
+            "p95_m": 0.018524738088439064,
+            "rmse_m": 0.015662872689440315,
+            "segment": 1,
+            "timestamp_end": 1560000016.056906,
+            "timestamp_start": 1560000015.590162
+          },
+          {
+            "images": 32,
+            "max_m": 0.029789370866338434,
+            "median_m": 0.017575077411365755,
+            "p95_m": 0.026192336607714653,
+            "rmse_m": 0.018191055368425413,
+            "segment": 2,
+            "timestamp_end": 1560000016.590147,
+            "timestamp_start": 1560000016.09024
+          },
+          {
+            "images": 30,
+            "max_m": 0.029039892601553745,
+            "median_m": 0.0173041064658622,
+            "p95_m": 0.026881808660431997,
+            "rmse_m": 0.018414618026452095,
+            "segment": 3,
+            "timestamp_end": 1560000017.09023,
+            "timestamp_start": 1560000016.623481
+          },
+          {
+            "images": 30,
+            "max_m": 0.03145999124211512,
+            "median_m": 0.019304233422133273,
+            "p95_m": 0.031297290077024406,
+            "rmse_m": 0.022113163259593453,
+            "segment": 4,
+            "timestamp_end": 1560000017.590167,
+            "timestamp_start": 1560000017.123563
+          },
+          {
+            "images": 32,
+            "max_m": 0.025331559314235693,
+            "median_m": 0.015084822984179614,
+            "p95_m": 0.022610648463029383,
+            "rmse_m": 0.01599836592075795,
+            "segment": 5,
+            "timestamp_end": 1560000018.123552,
+            "timestamp_start": 1560000017.623501
+          },
+          {
+            "images": 30,
+            "max_m": 0.03515775449883854,
+            "median_m": 0.01786602953314173,
+            "p95_m": 0.03512414032712174,
+            "rmse_m": 0.022390198576631513,
+            "segment": 6,
+            "timestamp_end": 1560000018.623534,
+            "timestamp_start": 1560000018.156885
+          },
+          {
+            "images": 30,
+            "max_m": 0.04719692172406938,
+            "median_m": 0.024994360206321314,
+            "p95_m": 0.040189463636722565,
+            "rmse_m": 0.027389289448966812,
+            "segment": 7,
+            "timestamp_end": 1560000019.123582,
+            "timestamp_start": 1560000018.656868
+          },
+          {
+            "images": 32,
+            "max_m": 0.061655609452973735,
+            "median_m": 0.03149146513004092,
+            "p95_m": 0.05554173116603057,
+            "rmse_m": 0.03326717554987066,
+            "segment": 8,
+            "timestamp_end": 1560000019.666914,
+            "timestamp_start": 1560000019.156915
+          },
+          {
+            "images": 30,
+            "max_m": 0.04562000671325229,
+            "median_m": 0.02813789539772577,
+            "p95_m": 0.04290624165629987,
+            "rmse_m": 0.029120942383992085,
+            "segment": 9,
+            "timestamp_end": 1560000020.166894,
+            "timestamp_start": 1560000019.700247
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 308,
+    "gt_scored_images": 308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+    "manifest_images": 1000,
+    "manifest_sha256": "f1ed9292c806103c1d129340f429bc74e5ba4842c6092b836d541cd518256baa",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 1000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 32,
+        "max_m": 0.02376709176290114,
+        "median_m": 0.016614248251229993,
+        "p95_m": 0.02264454115422436,
+        "rmse_m": 0.01701246921154381,
+        "segment": 0,
+        "timestamp_end": 1560000015.556828,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 30,
+        "max_m": 0.020345203673943383,
+        "median_m": 0.015553289816758582,
+        "p95_m": 0.018524738088439064,
+        "rmse_m": 0.015662872689440315,
+        "segment": 1,
+        "timestamp_end": 1560000016.056906,
+        "timestamp_start": 1560000015.590162
+      },
+      {
+        "images": 32,
+        "max_m": 0.029789370866338434,
+        "median_m": 0.017575077411365755,
+        "p95_m": 0.026192336607714653,
+        "rmse_m": 0.018191055368425413,
+        "segment": 2,
+        "timestamp_end": 1560000016.590147,
+        "timestamp_start": 1560000016.09024
+      },
+      {
+        "images": 30,
+        "max_m": 0.029039892601553745,
+        "median_m": 0.0173041064658622,
+        "p95_m": 0.026881808660431997,
+        "rmse_m": 0.018414618026452095,
+        "segment": 3,
+        "timestamp_end": 1560000017.09023,
+        "timestamp_start": 1560000016.623481
+      },
+      {
+        "images": 30,
+        "max_m": 0.03145999124211512,
+        "median_m": 0.019304233422133273,
+        "p95_m": 0.031297290077024406,
+        "rmse_m": 0.022113163259593453,
+        "segment": 4,
+        "timestamp_end": 1560000017.590167,
+        "timestamp_start": 1560000017.123563
+      },
+      {
+        "images": 32,
+        "max_m": 0.025331559314235693,
+        "median_m": 0.015084822984179614,
+        "p95_m": 0.022610648463029383,
+        "rmse_m": 0.01599836592075795,
+        "segment": 5,
+        "timestamp_end": 1560000018.123552,
+        "timestamp_start": 1560000017.623501
+      },
+      {
+        "images": 30,
+        "max_m": 0.03515775449883854,
+        "median_m": 0.01786602953314173,
+        "p95_m": 0.03512414032712174,
+        "rmse_m": 0.022390198576631513,
+        "segment": 6,
+        "timestamp_end": 1560000018.623534,
+        "timestamp_start": 1560000018.156885
+      },
+      {
+        "images": 30,
+        "max_m": 0.04719692172406938,
+        "median_m": 0.024994360206321314,
+        "p95_m": 0.040189463636722565,
+        "rmse_m": 0.027389289448966812,
+        "segment": 7,
+        "timestamp_end": 1560000019.123582,
+        "timestamp_start": 1560000018.656868
+      },
+      {
+        "images": 32,
+        "max_m": 0.061655609452973735,
+        "median_m": 0.03149146513004092,
+        "p95_m": 0.05554173116603057,
+        "rmse_m": 0.03326717554987066,
+        "segment": 8,
+        "timestamp_end": 1560000019.666914,
+        "timestamp_start": 1560000019.156915
+      },
+      {
+        "images": 30,
+        "max_m": 0.04562000671325229,
+        "median_m": 0.02813789539772577,
+        "p95_m": 0.04290624165629987,
+        "rmse_m": 0.029120942383992085,
+        "segment": 9,
+        "timestamp_end": 1560000020.166894,
+        "timestamp_start": 1560000019.700247
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "post_only_control_score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/main-control/model/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "feature_identity": {
+    "path": "/home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256",
+    "file_count": 1000,
+    "total_bytes": 302873132,
+    "tree_sha256": "4de9d6ae8da31d77fab32fee09507a9aee1d8bcf10312255f5ef065a31055e5d"
+  },
+  "feature_identity_command": "python3 -c 'import json,sys;from pathlib import Path;sys.path.insert(0,\"scripts\");from run_official_baselines import directory_identity;print(json.dumps(directory_identity(Path(\"/home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256\"))))'",
+  "gates": {
+    "trajectory_rmse_max_m": 0.02269532080131782,
+    "trajectory_p95_max_m": 0.03777877644562742,
+    "mean_reprojection_max_px": 0.6716373819326764,
+    "supported_images_min": 1000,
+    "supported_rig_frames_min": 500
+  },
+  "interpretation": [
+    "Current main produces byte-exact historical champion model files on the actual native rig inputs; same scorer also produces exact RMSE/p95.",
+    "The historical feature-tree digest lacks an algorithm specification. Do not assert historical full-file digest equality. Freeze the present 1000-file 302873132-byte tree with the documented independent algorithm for paired candidate/control runs; historical model and quality references remain unchanged.",
+    "Published historical/current point ERROR fields are zero placeholders, so independent reprojection is authoritative; max_stored_mean_difference is not a geometry regression.",
+    "Native mapping may change downstream tracks when the backend changes. Test per-output bidirectional consistency and report membership changes rather than falsely imposing the frozen-observation comparator's identity policy.",
+    "Fixed anchors are per BA call. Test/guard them there; a final model's seed/frame-zero pose is not asserted equal across different local-BA trajectories.",
+    "The first main-control run establishes correctness only, not a statistically measured speed change. /usr/bin/time RSS81916 KiB and process self-reported VmHWM82120 KiB are recorded separately; comparisons will consistently use external process RSS.",
+    "Verified-snapshot replay excludes frontend feature extraction/matching. Full native E2E and all10k/tier/restart/100k gates remain unmet."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-native-rig-matrix-free-v1.json
+++ b/benchmarks/electro/m8-openloris-native-rig-matrix-free-v1.json
@@ -1,0 +1,457 @@
+{
+  "schema": "visloc_m8_native_rig_matrix_free_v1",
+  "status": "failed_native_quality_not_promoted",
+  "certificate": {
+    "schema": "visloc_native_rig_matrix_free_candidate_certificate_v1",
+    "commit": "0298e0c5482fe45edaa4a55985e5ef4d21e66f69",
+    "binary_sha256": "dd8a63c4a4d9ab53ee6448c7a5120fa0bb130d3ea1d36402ec9e5d772940a4cf",
+    "driver_sha256": "54768eaf0f7ba5e641c4344ab8d8e56671e535dc9b0da3601fce63a9c8c34b46",
+    "rig_source_sha256": "bd90b56d2415387e0e354cc52af81931d2b69b2f1a09a49fe22afc3d789dfbee",
+    "bundle_sha256": "0daed4d9957acaffb7a30753b7fd9ad15ad17684e88cd72d338ce649c68d94b3",
+    "build_command": "cargo build --release --example generalized_rig_sfm",
+    "build_exit": 0,
+    "build_seconds": 47.66,
+    "feature_tree_sha256": "4de9d6ae8da31d77fab32fee09507a9aee1d8bcf10312255f5ef065a31055e5d",
+    "snapshot_sha256": "4964cbbe87aca7d78b33c71fbf0be4d186e5dc78e42df20b78f045775eb79aad",
+    "rig_sha256": "6bcd670c475c66a82aaa9b96247331ca1686df2676d569cf7ed01c3158c35900",
+    "before_candidate_run": true
+  },
+  "commands": {
+    "legacy": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy.time\nenv -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-candidate-0298e0c --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy/model > /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy.log 2>&1",
+    "a": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a.time\nenv -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-candidate-0298e0c --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-backend matrix-free --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a/model > /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a.log 2>&1",
+    "b": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b.time\nenv -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-candidate-0298e0c --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-backend matrix-free --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b/model > /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b.log 2>&1"
+  },
+  "runs": {
+    "candidate-legacy": {
+      "wall_seconds": 3.81,
+      "mapper_seconds": 3.345699,
+      "peak_rss_kib": 81876,
+      "backend_calls": 0,
+      "backend_iterations": 0,
+      "accepted_steps": 0,
+      "pcg_failures": 0,
+      "zero_accepted_calls": 0,
+      "used_backends": [],
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62460 KiB\nrig-replay BA: observations=120217 cost=267541.992667814->121458.389207945 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2658 observations=27716 mean_reprojection_px=0.671637382 seed_frame=26 mapper_seconds=3.345699 total_seconds=3.801447 VmHWM_KiB=82192 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=39217 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=29751 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2607 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-candidate-0298e0c --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/candidate-legacy/model\"\n\tUser time (seconds): 3.71\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:03.81\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 81876\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23489\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 20\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7288\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "937098610a0ec29c37bbc9c649e9385050d9ce6782f3154fcc2c02613281b8ee",
+        "points3D.txt": "11eb71b6a45f248770429a91a8841e64e028089350515f3f87366c468ae399af"
+      }
+    },
+    "matrix-free-a": {
+      "wall_seconds": 5.45,
+      "mapper_seconds": 5.001141,
+      "peak_rss_kib": 82260,
+      "backend_calls": 86,
+      "backend_iterations": 688,
+      "accepted_steps": 71,
+      "pcg_failures": 589,
+      "zero_accepted_calls": 52,
+      "used_backends": [
+        "matrix-free"
+      ],
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62424 KiB\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=8 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=8 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=8 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=5 pcg_failures=3\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=3\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=2 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=2 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=4 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=7 pcg_failures=1\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=2 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=3\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-replay BA: observations=123045 cost=317975.898557338->235126.310879321 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2796 observations=28039 mean_reprojection_px=0.725010589 seed_frame=26 mapper_seconds=5.001141 total_seconds=5.440205 VmHWM_KiB=82328 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=38285 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=30077 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2732 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-candidate-0298e0c --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-backend matrix-free --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a/model\"\n\tUser time (seconds): 5.37\n\tSystem time (seconds): 0.07\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:05.45\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82260\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23590\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 45\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7336\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "b26c183d752e4c8a3d5a0fb3ea067b7881ccb2f626f6bb663d813b74aeb56750",
+        "points3D.txt": "cc8d1327f493bf154ee39d602709d1c90fda012f79e3e80cf737b3f45199c1ec"
+      }
+    },
+    "matrix-free-b": {
+      "wall_seconds": 5.28,
+      "mapper_seconds": 4.850592,
+      "peak_rss_kib": 82396,
+      "backend_calls": 86,
+      "backend_iterations": 688,
+      "accepted_steps": 71,
+      "pcg_failures": 589,
+      "zero_accepted_calls": 52,
+      "used_backends": [
+        "matrix-free"
+      ],
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62460 KiB\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=8 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=8 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=8 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=5 pcg_failures=3\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=3\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=2 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=2 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=6\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=4 pcg_failures=0\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=7 pcg_failures=1\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=2 pcg_failures=5\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=7\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=1 pcg_failures=3\nrig-ba-backend: requested=matrix-free used=matrix-free eligibility=eligible iterations=8 accepted=0 pcg_failures=8\nrig-replay BA: observations=123045 cost=317975.898557338->235126.310879321 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2796 observations=28039 mean_reprojection_px=0.725010589 seed_frame=26 mapper_seconds=4.850592 total_seconds=5.270588 VmHWM_KiB=82492 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=38285 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=30077 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2732 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/rig-candidate-0298e0c --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-backend matrix-free --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b/model\"\n\tUser time (seconds): 5.18\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:05.28\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82396\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23594\n\tVoluntary context switches: 3\n\tInvoluntary context switches: 29\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7336\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "b26c183d752e4c8a3d5a0fb3ea067b7881ccb2f626f6bb663d813b74aeb56750",
+        "points3D.txt": "cc8d1327f493bf154ee39d602709d1c90fda012f79e3e80cf737b3f45199c1ec"
+      }
+    }
+  },
+  "run_audit_program": "import json,hashlib,re\nfrom pathlib import Path\nroot=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1\")\nout={}\nfor arm in (\"candidate-legacy\",\"matrix-free-a\",\"matrix-free-b\"):\n    log=(root/(arm+\".log\")).read_text(); timing=(root/(arm+\".time\")).read_text()\n    assert \"Exit status: 0\" in timing\n    rows=re.findall(r\"rig-ba-backend: requested=matrix-free used=([^ ]+) eligibility=eligible iterations=(\\d+) accepted=(\\d+) pcg_failures=(\\d+)\",log)\n    match=re.search(r\"Elapsed \\(wall clock\\) time \\(h:mm:ss or m:ss\\):\\s*(\\S+)\",timing)\n    parts=list(map(float,match.group(1).split(\":\")));wall=0\n    for part in parts:wall=wall*60+part\n    out[arm]=dict(wall_seconds=wall,mapper_seconds=float(re.search(r\"mapper_seconds=([0-9.]+)\",log).group(1)),peak_rss_kib=int(re.search(r\"Maximum resident set size \\(kbytes\\):\\s*(\\d+)\",timing).group(1)),backend_calls=len(rows),backend_iterations=sum(int(r[1]) for r in rows),accepted_steps=sum(int(r[2]) for r in rows),pcg_failures=sum(int(r[3]) for r in rows),zero_accepted_calls=sum(int(r[2])==0 for r in rows),used_backends=sorted(set(r[0] for r in rows)),log=log,time_output=timing,model_sha256={name:hashlib.sha256((root/arm/\"model\"/name).read_bytes()).hexdigest() for name in (\"cameras.txt\",\"images.txt\",\"points3D.txt\")})\nprint(json.dumps(out))\n",
+  "identity": {
+    "arms": {
+      "matrix-free-a": {
+        "image_identity_and_ordered_xy_exact": true,
+        "camera_bytes_exact": true,
+        "keypoints": 256000,
+        "changed_point_id_assignments": 28048,
+        "model_sha256": {
+          "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+          "images.txt": "b26c183d752e4c8a3d5a0fb3ea067b7881ccb2f626f6bb663d813b74aeb56750",
+          "points3D.txt": "cc8d1327f493bf154ee39d602709d1c90fda012f79e3e80cf737b3f45199c1ec"
+        }
+      },
+      "matrix-free-b": {
+        "image_identity_and_ordered_xy_exact": true,
+        "camera_bytes_exact": true,
+        "keypoints": 256000,
+        "changed_point_id_assignments": 28048,
+        "model_sha256": {
+          "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+          "images.txt": "b26c183d752e4c8a3d5a0fb3ea067b7881ccb2f626f6bb663d813b74aeb56750",
+          "points3D.txt": "cc8d1327f493bf154ee39d602709d1c90fda012f79e3e80cf737b3f45199c1ec"
+        }
+      }
+    },
+    "repeat_model_bytes_exact": true,
+    "note": "Point IDs may be renumbered; changed assignments are not a semantic track-overlap score. Native final anchor equality is not asserted."
+  },
+  "identity_audit_program": "import json,hashlib\nfrom pathlib import Path\nroot=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1\")\ndef images(model):\n    result={}\n    with (model/\"images.txt\").open() as stream:\n        for line in stream:\n            if not line.strip() or line.lstrip().startswith(\"#\"): continue\n            row=line.split()\n            assert len(row)==10\n            key=int(row[0]); assert key not in result\n            fields=next(stream).split(); assert len(fields)%3==0\n            result[key]=(row[8:],tuple((fields[i],fields[i+1]) for i in range(0,len(fields),3)),tuple(int(fields[i+2]) for i in range(0,len(fields),3)))\n    return result\nreference=root/\"candidate-legacy/model\"\na=images(reference)\nreports={}\nfor arm in (\"matrix-free-a\",\"matrix-free-b\"):\n    model=root/arm/\"model\"; b=images(model)\n    assert a.keys()==b.keys()\n    assert (reference/\"cameras.txt\").read_bytes()==(model/\"cameras.txt\").read_bytes()\n    changed=0\n    for key in a:\n        assert a[key][:2]==b[key][:2],key\n        changed+=sum(x!=y for x,y in zip(a[key][2],b[key][2]))\n    reports[arm]={\"image_identity_and_ordered_xy_exact\":True,\"camera_bytes_exact\":True,\"keypoints\":sum(len(v[1]) for v in b.values()),\"changed_point_id_assignments\":changed,\"model_sha256\":{name:hashlib.sha256((model/name).read_bytes()).hexdigest() for name in (\"cameras.txt\",\"images.txt\",\"points3D.txt\")}}\nassert reports[\"matrix-free-a\"][\"model_sha256\"]==reports[\"matrix-free-b\"][\"model_sha256\"]\nprint(json.dumps({\"arms\":reports,\"repeat_model_bytes_exact\":True,\"note\":\"Point IDs may be renumbered; changed assignments are not a semantic track-overlap score. Native final anchor equality is not asserted.\"},indent=2))\n",
+  "geometry": [
+    {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a/model",
+      "image_poses": 1000,
+      "supported_images": 1000,
+      "unsupported_image_ids": [],
+      "landmarks": 2796,
+      "observations": 28039,
+      "mean_reprojection_px": 0.7250105890746412,
+      "observation_weighted_mean_reprojection_px": 0.7250105890746412,
+      "point_weighted_mean_reprojection_px": 0.7661887303221293,
+      "max_track_mean_reprojection_px": 3.7153768236804883,
+      "max_reprojection_px": 3.9989832366548588,
+      "max_stored_mean_difference_px": 3.7153768236804883,
+      "nonpositive_depth_observations": 0,
+      "tracks_with_multiple_keypoints_in_one_image": 0,
+      "excess_same_image_track_observations": 0,
+      "bidirectional_references_valid": true,
+      "rig": {
+        "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+        "rig_frames": 500,
+        "supported_rig_frames": 500,
+        "unsupported_rig_frame_ids": [],
+        "max_inferred_rig_center_disagreement_m": 3.5333994244867857e-12,
+        "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+        "fixed_sensor_extrinsics_valid": true,
+        "track_connected_components": 1,
+        "track_connected_component_sizes": [
+          500
+        ],
+        "track_connected_component_frame_ranges": [
+          [
+            0,
+            499
+          ]
+        ]
+      }
+    },
+    {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-b/model",
+      "image_poses": 1000,
+      "supported_images": 1000,
+      "unsupported_image_ids": [],
+      "landmarks": 2796,
+      "observations": 28039,
+      "mean_reprojection_px": 0.7250105890746412,
+      "observation_weighted_mean_reprojection_px": 0.7250105890746412,
+      "point_weighted_mean_reprojection_px": 0.7661887303221293,
+      "max_track_mean_reprojection_px": 3.7153768236804883,
+      "max_reprojection_px": 3.9989832366548588,
+      "max_stored_mean_difference_px": 3.7153768236804883,
+      "nonpositive_depth_observations": 0,
+      "tracks_with_multiple_keypoints_in_one_image": 0,
+      "excess_same_image_track_observations": 0,
+      "bidirectional_references_valid": true,
+      "rig": {
+        "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+        "rig_frames": 500,
+        "supported_rig_frames": 500,
+        "unsupported_rig_frame_ids": [],
+        "max_inferred_rig_center_disagreement_m": 3.5333994244867857e-12,
+        "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+        "fixed_sensor_extrinsics_valid": true,
+        "track_connected_components": 1,
+        "track_connected_component_sizes": [
+          500
+        ],
+        "track_connected_component_frame_ranges": [
+          [
+            0,
+            499
+          ]
+        ]
+      }
+    }
+  ],
+  "score": {
+    "component_weighted_max_m": 0.38532028757228093,
+    "component_weighted_median_m": 0.12305291224209121,
+    "component_weighted_p95_m": 0.23457971888053844,
+    "component_weighted_rmse_m": 0.1402194052540633,
+    "components": [
+      {
+        "gt_scored": 308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a/model/images.txt",
+        "images_txt_sha256": "b26c183d752e4c8a3d5a0fb3ea067b7881ccb2f626f6bb663d813b74aeb56750",
+        "max_m": 0.38532028757228093,
+        "median_m": 0.12305291224209121,
+        "p95_m": 0.23457971888053844,
+        "reference_extent_m": 1.9718678959594034,
+        "registered": 1000,
+        "relative_rmse": 0.0711099387242877,
+        "rmse_m": 0.1402194052540633,
+        "sim3_scale": 1.925878814655657,
+        "trajectory_segments": [
+          {
+            "images": 32,
+            "max_m": 0.13314666023027175,
+            "median_m": 0.12660944981783828,
+            "p95_m": 0.13175533639495204,
+            "rmse_m": 0.12660910128633598,
+            "segment": 0,
+            "timestamp_end": 1560000015.556828,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 30,
+            "max_m": 0.13421088175962476,
+            "median_m": 0.12297164408818365,
+            "p95_m": 0.13286716288372977,
+            "rmse_m": 0.12465599749850989,
+            "segment": 1,
+            "timestamp_end": 1560000016.056906,
+            "timestamp_start": 1560000015.590162
+          },
+          {
+            "images": 32,
+            "max_m": 0.11835460242581088,
+            "median_m": 0.06691446485708313,
+            "p95_m": 0.10664213267021855,
+            "rmse_m": 0.06922262919556554,
+            "segment": 2,
+            "timestamp_end": 1560000016.590147,
+            "timestamp_start": 1560000016.09024
+          },
+          {
+            "images": 30,
+            "max_m": 0.1292082252130686,
+            "median_m": 0.07422340024990219,
+            "p95_m": 0.11903390306383671,
+            "rmse_m": 0.08093727526824546,
+            "segment": 3,
+            "timestamp_end": 1560000017.09023,
+            "timestamp_start": 1560000016.623481
+          },
+          {
+            "images": 30,
+            "max_m": 0.1894920226271827,
+            "median_m": 0.17151756930981876,
+            "p95_m": 0.18861200791052105,
+            "rmse_m": 0.16683885105188617,
+            "segment": 4,
+            "timestamp_end": 1560000017.590167,
+            "timestamp_start": 1560000017.123563
+          },
+          {
+            "images": 32,
+            "max_m": 0.19089533702744682,
+            "median_m": 0.17245509661216574,
+            "p95_m": 0.18787200071592905,
+            "rmse_m": 0.17048020024158386,
+            "segment": 5,
+            "timestamp_end": 1560000018.123552,
+            "timestamp_start": 1560000017.623501
+          },
+          {
+            "images": 30,
+            "max_m": 0.14209239797211382,
+            "median_m": 0.11659552905877216,
+            "p95_m": 0.13820139634054818,
+            "rmse_m": 0.11682018849253041,
+            "segment": 6,
+            "timestamp_end": 1560000018.623534,
+            "timestamp_start": 1560000018.156885
+          },
+          {
+            "images": 30,
+            "max_m": 0.08656632062908326,
+            "median_m": 0.04849934092625917,
+            "p95_m": 0.07657758006232568,
+            "rmse_m": 0.05317914821363875,
+            "segment": 7,
+            "timestamp_end": 1560000019.123582,
+            "timestamp_start": 1560000018.656868
+          },
+          {
+            "images": 32,
+            "max_m": 0.21491388846006124,
+            "median_m": 0.0921402236703915,
+            "p95_m": 0.19215256140398715,
+            "rmse_m": 0.11924155794496259,
+            "segment": 8,
+            "timestamp_end": 1560000019.666914,
+            "timestamp_start": 1560000019.156915
+          },
+          {
+            "images": 30,
+            "max_m": 0.38532028757228093,
+            "median_m": 0.23955006324350434,
+            "p95_m": 0.352942874873711,
+            "rmse_m": 0.25899898346651856,
+            "segment": 9,
+            "timestamp_end": 1560000020.166894,
+            "timestamp_start": 1560000019.700247
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 308,
+    "gt_scored_images": 308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+    "manifest_images": 1000,
+    "manifest_sha256": "f1ed9292c806103c1d129340f429bc74e5ba4842c6092b836d541cd518256baa",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 1000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 32,
+        "max_m": 0.13314666023027175,
+        "median_m": 0.12660944981783828,
+        "p95_m": 0.13175533639495204,
+        "rmse_m": 0.12660910128633598,
+        "segment": 0,
+        "timestamp_end": 1560000015.556828,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 30,
+        "max_m": 0.13421088175962476,
+        "median_m": 0.12297164408818365,
+        "p95_m": 0.13286716288372977,
+        "rmse_m": 0.12465599749850989,
+        "segment": 1,
+        "timestamp_end": 1560000016.056906,
+        "timestamp_start": 1560000015.590162
+      },
+      {
+        "images": 32,
+        "max_m": 0.11835460242581088,
+        "median_m": 0.06691446485708313,
+        "p95_m": 0.10664213267021855,
+        "rmse_m": 0.06922262919556554,
+        "segment": 2,
+        "timestamp_end": 1560000016.590147,
+        "timestamp_start": 1560000016.09024
+      },
+      {
+        "images": 30,
+        "max_m": 0.1292082252130686,
+        "median_m": 0.07422340024990219,
+        "p95_m": 0.11903390306383671,
+        "rmse_m": 0.08093727526824546,
+        "segment": 3,
+        "timestamp_end": 1560000017.09023,
+        "timestamp_start": 1560000016.623481
+      },
+      {
+        "images": 30,
+        "max_m": 0.1894920226271827,
+        "median_m": 0.17151756930981876,
+        "p95_m": 0.18861200791052105,
+        "rmse_m": 0.16683885105188617,
+        "segment": 4,
+        "timestamp_end": 1560000017.590167,
+        "timestamp_start": 1560000017.123563
+      },
+      {
+        "images": 32,
+        "max_m": 0.19089533702744682,
+        "median_m": 0.17245509661216574,
+        "p95_m": 0.18787200071592905,
+        "rmse_m": 0.17048020024158386,
+        "segment": 5,
+        "timestamp_end": 1560000018.123552,
+        "timestamp_start": 1560000017.623501
+      },
+      {
+        "images": 30,
+        "max_m": 0.14209239797211382,
+        "median_m": 0.11659552905877216,
+        "p95_m": 0.13820139634054818,
+        "rmse_m": 0.11682018849253041,
+        "segment": 6,
+        "timestamp_end": 1560000018.623534,
+        "timestamp_start": 1560000018.156885
+      },
+      {
+        "images": 30,
+        "max_m": 0.08656632062908326,
+        "median_m": 0.04849934092625917,
+        "p95_m": 0.07657758006232568,
+        "rmse_m": 0.05317914821363875,
+        "segment": 7,
+        "timestamp_end": 1560000019.123582,
+        "timestamp_start": 1560000018.656868
+      },
+      {
+        "images": 32,
+        "max_m": 0.21491388846006124,
+        "median_m": 0.0921402236703915,
+        "p95_m": 0.19215256140398715,
+        "rmse_m": 0.11924155794496259,
+        "segment": 8,
+        "timestamp_end": 1560000019.666914,
+        "timestamp_start": 1560000019.156915
+      },
+      {
+        "images": 30,
+        "max_m": 0.38532028757228093,
+        "median_m": 0.23955006324350434,
+        "p95_m": 0.352942874873711,
+        "rmse_m": 0.25899898346651856,
+        "segment": 9,
+        "timestamp_end": 1560000020.166894,
+        "timestamp_start": 1560000019.700247
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-matrix-free-v1/matrix-free-a/model/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "quality_limits": {
+    "rmse_m": 0.02269532080131782,
+    "p95_m": 0.03777877644562742,
+    "raw_mean_px": 0.6716373819326764
+  },
+  "checks": {
+    "root_rig_tests": 29,
+    "root_matrix_free_api_tests": 15,
+    "example_tests": 15,
+    "agent_clippy_fmt_diff_check": "pass",
+    "legacy_model_bytes_exact_to_main_and_historical": true,
+    "feature_tree_post_run_matches_certificate": true,
+    "cli_unknown_and_duplicate_rejected": true
+  },
+  "interpretation": [
+    "Default-off native dispatch implemented; not approved as a production or performance policy.",
+    "Native matrix-free fails all three quality limits. No tolerance/loss/window sweep or larger tier run is authorized by this result.",
+    "86 backend diagnostics cover 688 iterations, 589 PCG failures, 71 accepted steps and 52 zero-accepted calls. Mapper aggregate BA stats cover a different subset; do not equate counts.",
+    "Both native matrix-free model outputs are byte-exact. All 1000 images and 500 rig frames are supported, calibration and ordered keypoint xy identity retained, depths positive and one connected component.",
+    "The single same-binary legacy control and two candidate runs are correctness measurements, not the planned three-run performance gate. No measured speedup or memory improvement claimed.",
+    "GT score was run after geometric audit for arm a; arm b has identical model bytes, not a separate GT invocation.",
+    "Snapshot replay excludes feature extraction/matching. Full native E2E, COLMAP 10k parity and remaining M8–M10 gates remain open."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,14 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 続行（2026-09-08）: PR #92は最終head `8cda545`のCI9項目
+> （run `34184156416`）通過後、`ece2b71`へmerge。旧branch整理済み。
+> 現在 `feat/m8-native-rig-matrix-free`。次は[事前契約](openloris_native_rig_matrix_free.md)
+> に沿って、既存rig mapperの共通BA呼び出しに明示的matrix-free選択を接続します。
+> monocular経路への置き換えや別の局所BAパラメータ診断ではありません。
+> 小窓では高速化が未証明のため、従来設定と同じnative入力から品質・時間を比較します。
+> Huber6等のcaller設定は維持し、全pose固定時は明示的zero-pose landmark-only経路。
+> 大きなSchurへの暗黙fallbackなし。実装・native A/Bはまだ未完了です。
+
 > Frozen Huber BA完了（2026-09-08）: Luna Max `c026f40`をroot独立28テストと
 > clippy後にrelease認証。4本ともexit0、None対照はPR #91のモデル/trace一致、
 > Huber反復も3ファイル/85行一致。全identity/支持/校正/anchor/正深度を保持。

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,14 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> Native rig matrix-free検証（2026-09-08）: Luna Max実装 `0298e0c`、
+> root独立rig29/API15テスト通過。同一binaryのLegacyは既存championと全モデルbytes一致。
+> MFの2反復もbytes一致、1000画像/500frame支持・校正・正深度・xy順序は保持。
+> ただしRMSE/p95 **0.140219/0.234580 m**、raw mean **0.725011 px**で全品質基準失敗。
+> 688反復中589 PCG失敗、86呼び出し中52はaccepted stepなし。既定化・10k展開なし。
+> [結果と次の診断方針](openloris_native_rig_matrix_free.md)、
+> [証跡](../benchmarks/electro/m8-openloris-native-rig-matrix-free-v1.json)。
+> 現branch `feat/m8-native-rig-matrix-free` のPR/CI/mergeは未完了。READMEの性能主張は変更なし。
+
 > 続行（2026-09-08）: PR #92は最終head `8cda545`のCI9項目
 > （run `34184156416`）通過後、`ece2b71`へmerge。旧branch整理済み。
 > 現在 `feat/m8-native-rig-matrix-free`。次は[事前契約](openloris_native_rig_matrix_free.md)

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -133,6 +133,18 @@ one concrete integration that advances speed/memory while preserving the
 accuracy gate; do not substitute another local parameter-diagnostic ladder
 for the remaining native/tier/restart/100k outcome requirements.
 
+PR #92 merged as `ece2b71` after all nine checks on `8cda545`
+(run `34184156416`). The next
+[native rig integration contract](openloris_native_rig_matrix_free.md)
+targets the calibrated-rig mapper's common BA dispatch, not the monocular
+mapper. Its default-off selector preserves caller losses and observation
+policy and explicitly handles zero-pose landmark-only solves without a large
+Schur fallback. Root's current-main native 1k replay exactly reproduces the
+historical champion's three model files and post-only RMSE/p95. The
+[input/control certificate](../benchmarks/electro/m8-openloris-native-rig-matrix-free-preflight-v1.json)
+is frozen before candidate runs. Native matrix-free implementation, A/B and
+all larger outcome gates remain incomplete; small-window speedup is unproven.
+
 ## Current checkpoint (2026-09-07)
 
 The connected, observation-backed atlas now preserves 9,998 registered images,

--- a/docs/openloris_native_rig_matrix_free.md
+++ b/docs/openloris_native_rig_matrix_free.md
@@ -46,6 +46,11 @@ test. The atlas integrator's separate capped BA is not changed in this PR.
   partial solver state into mapper poses/tracks. No extra full-model clone,
   synthetic anchor, dense fallback, public `LinearSolver` variant or `BaConfig`
   change. Existing public rig APIs are re-exported consistently.
+- Reuse the matrix-free validator for the zero-pose path through a minimal
+  crate-private entry: only the requirement for a variable pose differs.
+  Do not duplicate or weaken camera, loss, LM or factor eligibility checks.
+  Successful eligibility/backend logs follow validation; a rejected request
+  must not first be logged as an eligible successful dispatch.
 
 ## Correctness and first native comparison
 

--- a/docs/openloris_native_rig_matrix_free.md
+++ b/docs/openloris_native_rig_matrix_free.md
@@ -1,6 +1,6 @@
 # Native rig matrix-free integration
 
-Status: predeclared; implementation and native A/B not yet completed.
+Status: implemented default-off; native 1k A/B fails quality, not promoted.
 
 ## Outcome and actual target
 
@@ -109,5 +109,47 @@ peak RSS 81,916 KiB. This single run is not a speedup measurement. The writer's
 historical zero point-ERROR placeholders remain unchanged; independently
 recomputed residuals, not stored ERROR, define the quality gate.
 [Certificate, inputs, commands and audits](../benchmarks/electro/m8-openloris-native-rig-matrix-free-preflight-v1.json)
-are saved before candidate execution. Native matrix-free implementation and
-A/B remain incomplete.
+were saved before candidate execution.
+
+## Native candidate result — not promoted
+
+Implementation `0298e0c` adds the strict selector without changing Legacy
+defaults. Root independently passed 29 rig tests and 15 matrix-free API tests;
+the example's 15 tests, scoped clippy and formatting checks also pass.
+The release CLI rejects unknown and duplicate backend options.
+
+The same candidate binary's option-absent output reproduces the main and
+historical champion model bytes exactly. Both matrix-free runs also match
+each other exactly, but fail the predeclared native quality limits:
+
+| Metric | Legacy control | Matrix-free |
+| --- | ---: | ---: |
+| Supported images / rig frames | 1,000 / 500 | 1,000 / 500 |
+| Trajectory RMSE (m) | 0.0226953 | 0.1402194 |
+| Trajectory p95 (m) | 0.0377788 | 0.2345797 |
+| Independent raw mean (px) | 0.6716374 | 0.7250106 |
+| Landmarks / observations | 2,658 / 27,716 | 2,796 / 28,039 |
+| Mapper time (s) | 3.345699 | 5.001141 / 4.850592 |
+| Process time (s) | 3.81 | 5.45 / 5.28 |
+| External peak RSS (KiB) | 81,876 | 82,260 / 82,396 |
+
+Calibration, image identities, all 256,000 ordered keypoint coordinates,
+positive depths, bidirectional references and one-component support pass.
+Native track memberships can change; this is not frozen-observation BA.
+The feature-tree digest remains unchanged after the runs.
+
+Each candidate logs 86 backend calls, 688 iterations, 589 PCG failures,
+71 accepted steps and 52 calls with no accepted step. These diagnostics
+cover a different subset from the mapper's aggregate BA line. Failed PCG
+steps are rolled back; eligibility does not mean numerical convergence.
+This identifies a practical failure of the strict default policy, not proof
+of a unique underlying cause or permission to relax the quality gate.
+
+The correctness runs show no speed or memory improvement; the planned
+three-run performance gate is not entered after quality failure. No 10k
+promotion, tolerance sweep, hidden direct fallback or README performance
+claim follows. Keep Legacy default. The next work must diagnose native
+linear-solve failures before proposing a bounded, separately predeclared
+policy; full native E2E and remaining M8–M10 gates stay open.
+
+[Candidate certificate, commands, logs and independent audits](../benchmarks/electro/m8-openloris-native-rig-matrix-free-v1.json).

--- a/docs/openloris_native_rig_matrix_free.md
+++ b/docs/openloris_native_rig_matrix_free.md
@@ -79,3 +79,30 @@ excludes feature extraction/matching and is not full native E2E.
 Failure stops promotion and larger performance claims. Passing only authorizes
 the next same-profile tier assessment. All final COLMAP/10k/native-E2E/restart/
 100k gates remain open, and README claims remain unchanged until verified.
+
+## Reproduced native main control
+
+Before implementation, root built the unmodified native code at main
+`ece2b71`, binary SHA
+`7a7446459817b492724f7b784894f826c1bbd1888637590a310d646a1ee39bcd`.
+The actual champion rig manifest, features256 directory and verified snapshot
+reproduce **all three historical model files byte-for-byte**. Independent
+audits confirm 1,000 supported images, 500 supported frames, 2,658 landmarks,
+27,716 observations, one component, fixed calibration and positive depth.
+Post-only RMSE/p95 also exactly reproduce 0.02269532080131782 /
+0.03777877644562742 m. Independent raw mean is 0.6716373819326764 px.
+
+The historical feature-tree hash did not specify its algorithm; it is not
+claimed equal to the new explicitly specified tree digest. Freeze the actual
+1,000 files / 302,873,132 bytes with `run_official_baselines.directory_identity`
+for candidate/control runs. Historical model and quality references stay
+unchanged. Their exact reproduction establishes the required mapper control,
+not historical equivalence of any ignored descriptor bytes.
+
+The first correctness run is 4.42 s process / 3.864511 s mapper, external
+peak RSS 81,916 KiB. This single run is not a speedup measurement. The writer's
+historical zero point-ERROR placeholders remain unchanged; independently
+recomputed residuals, not stored ERROR, define the quality gate.
+[Certificate, inputs, commands and audits](../benchmarks/electro/m8-openloris-native-rig-matrix-free-preflight-v1.json)
+are saved before candidate execution. Native matrix-free implementation and
+A/B remain incomplete.

--- a/docs/openloris_native_rig_matrix_free.md
+++ b/docs/openloris_native_rig_matrix_free.md
@@ -1,0 +1,81 @@
+# Native rig matrix-free integration
+
+Status: predeclared; implementation and native A/B not yet completed.
+
+## Outcome and actual target
+
+Connect the existing unscaled matrix-free BA API to the **native calibrated-rig
+mapper**, not a substitute monocular pipeline or another text-model driver.
+The [M8–M10 objective](openloris_m8_m10_plan.md) still requires COLMAP accuracy,
+faster mapper/native E2E and lower RSS at 10k, plus tier/restart/100k checks.
+This integration alone proves none of those outcome gates.
+
+`rig_sfm::run_rig_bundle_adjustment` currently dispatches every local/final BA
+to `BundleAdjustment::optimize`. Its legacy Schur construction expands each
+landmark's cross blocks into pose-pair blocks. The existing implicit backend
+avoids that expansion, but retains observation cross blocks, preconditioner
+caches and rollback state. It is not constant-memory BA.
+
+Ordinary rig mapping uses 40/60-frame windows; PCG may be slower there.
+A full-map rig call also exists in `refine_rig_sfm_with_fixed_frame_rotations`,
+but that rotation policy is not approved by this integration. Do not enlarge
+windows, change rotation policy, or claim full-map savings from a small-window
+test. The atlas integrator's separate capped BA is not changed in this PR.
+
+## One default-off implementation
+
+- Add `RigBaBackend::{Legacy, MatrixFreeStrict}` and a `RigSfmConfig` selector,
+  default `Legacy`. The name Legacy deliberately preserves callers that set
+  `BaConfig.linear_solver` themselves, rather than falsely labeling them Sparse.
+- Expose `generalized_rig_sfm --ba-backend legacy|matrix-free`; option absent
+  preserves the old output/log path. Keep the selector in the common native
+  rig BA dispatch so local, final-window and full-map rig calls use it.
+- Preserve caller robust loss, calibration, damping, iteration count, anchors,
+  fixed rotations, observation construction, filtering and write-back policy.
+  This does not promote the rejected adaptive, column-scaled or Huber-3 arms.
+- Use `MatrixFreeBaOptions::default()`: PCG maximum 128, relative and absolute
+  tolerances 1e-12, no restarts, no scaling or adaptive damping. No GT tuning.
+- Matrix-free errors must not fall back to a large legacy Schur solve. Report
+  requested/used backend and eligibility outcome explicitly, only when opted in.
+- All poses fixed with variable landmarks needs an explicit, bounded
+  landmark-only path: zero variable-pose Schur dimension, existing loss and
+  observation semantics, no silently skipped BA. Restrict it to supported pure
+  visual/fixed-calibration configuration; invalid configuration fails closed.
+  No-variable problems are explicit no-ops, not invented successful updates.
+- Validate and solve in the already-local BA problem. On error do not write
+  partial solver state into mapper poses/tracks. No extra full-model clone,
+  synthetic anchor, dense fallback, public `LinearSolver` variant or `BaConfig`
+  change. Existing public rig APIs are re-exported consistently.
+
+## Correctness and first native comparison
+
+Scoped tests cover selector defaults/CLI conflicts, unchanged legacy dispatch,
+small synthetic rig matrix-free vs direct, fixed anchor/rotations/calibration,
+observation retention, all-fixed landmark-only behavior, ineligible input and
+no write-back on failure. Reuse solver tests rather than another oracle ladder.
+
+Before candidate execution, certify source/binary and the actual 1k native
+feature/snapshot/rig inputs from
+[the path-specific champion](../benchmarks/electro/m8-openloris-visloc-rig-1k-champion.json).
+Reproduce an option-absent current-main control first. If historical defaults
+or inputs no longer reproduce it, resolve the discrepancy without changing
+the reference or weakening its quality limits.
+
+Then the candidate changes only `--ba-backend matrix-free`. Validate full
+registration/support, image/keypoint identity, fixed calibration and anchor,
+positive depth and each output's track consistency. Backend-dependent mapper
+decisions can change track membership; record that difference explicitly rather
+than pretending this is a frozen-observation BA comparison. Require deterministic
+repeat and no loss of registered/supported images or frames.
+
+Post-only quality limits: trajectory RMSE <= **0.02269532080131782 m**, p95 <=
+**0.03777877644562742 m**, and independently evaluated raw mean reprojection
+no worse than the reproduced champion (historically logged **0.671637382 px**).
+Use the exact scorer/GT/calibration convention. No scale or tolerance sweep.
+If quality passes, measure three unloaded runs against the same native control.
+Report mapper and process timing separately: verified-snapshot replay still
+excludes feature extraction/matching and is not full native E2E.
+
+Failure stops promotion and larger performance claims. Passing only authorizes
+the next same-profile tier assessment. All final COLMAP/10k/native-E2E/restart/
+100k gates remain open, and README claims remain unchanged until verified.

--- a/examples/generalized_rig_sfm.rs
+++ b/examples/generalized_rig_sfm.rs
@@ -32,8 +32,8 @@ use visloc_rs::{
     metric_temporal_quadrilateral_tracks_in_frame_gap, umeyama_similarity_transform,
     write_colmap_reconstruction_for_3dgs_with_cameras, Camera, FeatureSet, GeneralizedCameraRig,
     GlobalSfmEdge, LinearSolver, PairwiseMatches, Pose, PoseGraph, PoseGraphEdge,
-    PoseGraphEdgeKind, RigFrame, RigFrameImage, RigSensor, RigSfmConfig, RigSfmError, RigSfmResult,
-    RigTrackBuilder, RobustKernel, SE3,
+    PoseGraphEdgeKind, RigBaBackend, RigFrame, RigFrameImage, RigSensor, RigSfmConfig, RigSfmError,
+    RigSfmResult, RigTrackBuilder, RobustKernel, SE3,
 };
 
 #[derive(Debug)]
@@ -123,10 +123,21 @@ struct Args {
     ba_metric_tracks_only: bool,
     final_ba_min_pose_observations: usize,
     ba_huber_delta: f64,
+    ba_backend: RigBaBackend,
     structure_refinement_iterations: usize,
     preview_rig_correspondence_csr: bool,
     preview_pair_confidence_conflicts: bool,
     dynamic_correspondence_tracking: bool,
+}
+
+fn parse_ba_backend(value: &str) -> Result<RigBaBackend, String> {
+    match value {
+        "legacy" => Ok(RigBaBackend::Legacy),
+        "matrix-free" => Ok(RigBaBackend::MatrixFreeStrict),
+        other => Err(format!(
+            "--ba-backend must be legacy or matrix-free, got {other}"
+        )),
+    }
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -230,6 +241,8 @@ fn parse_args() -> Result<Args, String> {
     let mut ba_metric_tracks_only = defaults.ba_metric_tracks_only;
     let mut final_ba_min_pose_observations = defaults.final_ba_min_pose_observations;
     let mut ba_huber_delta = 6.0;
+    let mut ba_backend = defaults.ba_backend;
+    let mut ba_backend_seen = false;
     let mut structure_refinement_iterations = defaults.structure_refinement_iterations;
     let mut preview_rig_correspondence_csr = false;
     let mut preview_pair_confidence_conflicts = false;
@@ -533,6 +546,13 @@ fn parse_args() -> Result<Args, String> {
             "--ba-huber-delta" => {
                 ba_huber_delta = value()?.parse().map_err(|error| format!("{error}"))?
             }
+            "--ba-backend" => {
+                if ba_backend_seen {
+                    return Err("--ba-backend may be provided only once".into());
+                }
+                ba_backend_seen = true;
+                ba_backend = parse_ba_backend(&value()?)?;
+            }
             "--structure-refinement-iterations" => {
                 structure_refinement_iterations =
                     value()?.parse().map_err(|error| format!("{error}"))?
@@ -591,6 +611,7 @@ fn parse_args() -> Result<Args, String> {
                     "[--max-track-frame-gap 0] ",
                     "[--local-ba-every 10] [--local-ba-window 40] ",
                     "[--local-ba-iterations 8] [--ba-huber-delta 6] ",
+                    "[--ba-backend legacy|matrix-free] ",
                     "[--structure-refinement-iterations 5] ",
                     "[--metric-anchored-cycle-tracks|--metric-temporal-cycle-tracks|",
                     "--metric-sparse-cycle-tracks|",
@@ -881,6 +902,7 @@ fn parse_args() -> Result<Args, String> {
         ba_metric_tracks_only,
         final_ba_min_pose_observations,
         ba_huber_delta,
+        ba_backend,
         structure_refinement_iterations,
         preview_rig_correspondence_csr,
         preview_pair_confidence_conflicts,
@@ -1659,6 +1681,7 @@ fn mapper_config(args: &Args) -> RigSfmConfig {
         paired_pose_jump_max_closure_ratio: args.paired_pose_jump_max_closure_ratio,
         ba_metric_tracks_only: args.ba_metric_tracks_only,
         final_ba_min_pose_observations: args.final_ba_min_pose_observations,
+        ba_backend: args.ba_backend,
         structure_refinement_iterations: args.structure_refinement_iterations,
         dynamic_correspondence_tracking: args.dynamic_correspondence_tracking,
         ba_config: visloc_rs::BaConfig {
@@ -3686,6 +3709,17 @@ mod tests {
             validate_frame_range_compatibility(false, Some(4), true),
             Ok(())
         );
+    }
+
+    #[test]
+    fn parses_native_ba_backend_selector_strictly() {
+        assert_eq!(parse_ba_backend("legacy"), Ok(RigBaBackend::Legacy));
+        assert_eq!(
+            parse_ba_backend("matrix-free"),
+            Ok(RigBaBackend::MatrixFreeStrict)
+        );
+        assert!(parse_ba_backend("matrix_free").is_err());
+        assert!(parse_ba_backend("sparse").is_err());
     }
 
     #[test]

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -2010,6 +2010,19 @@ impl BundleAdjustment {
         })
     }
 
+    /// Validate the same pure-visual matrix-free contract for a bounded
+    /// landmark-only problem.  Native rig BA uses this only when every pose is
+    /// fixed, so the reduced pose system has dimension zero; it does not
+    /// expose a public solver mode or alter the ordinary matrix-free entry
+    /// point.
+    pub(crate) fn validate_matrix_free_landmark_only(
+        &self,
+        config: &BaConfig,
+        options: MatrixFreeBaOptions,
+    ) -> Result<(), MatrixFreeBaError> {
+        self.validate_matrix_free_entry_with_pose_requirement(config, options, false)
+    }
+
     /// Run matrix-free BA with explicit column equilibration and scaled LM
     /// damping.  This is a separate opt-in policy: the legacy matrix-free
     /// entry point keeps scalar `lambda * I` damping and its exact arithmetic.
@@ -2160,6 +2173,15 @@ impl BundleAdjustment {
         config: &BaConfig,
         options: MatrixFreeBaOptions,
     ) -> Result<(), MatrixFreeBaError> {
+        self.validate_matrix_free_entry_with_pose_requirement(config, options, true)
+    }
+
+    fn validate_matrix_free_entry_with_pose_requirement(
+        &self,
+        config: &BaConfig,
+        options: MatrixFreeBaOptions,
+        require_variable_pose: bool,
+    ) -> Result<(), MatrixFreeBaError> {
         if config.refine_intrinsics || config.refine_distortion {
             return Err(MatrixFreeBaError::Ineligible(
                 "intrinsics/distortion refinement is not supported",
@@ -2284,7 +2306,7 @@ impl BundleAdjustment {
         if self.landmarks.is_empty() {
             return Err(MatrixFreeBaError::Ba(BaError::NoLandmarks));
         }
-        if !self.poses.keys().any(|id| !self.fixed_poses.contains(id)) {
+        if require_variable_pose && !self.poses.keys().any(|id| !self.fixed_poses.contains(id)) {
             return Err(MatrixFreeBaError::Ineligible(
                 "matrix-free backend requires a variable pose",
             ));

--- a/pipelines/slam/src/bundle.rs
+++ b/pipelines/slam/src/bundle.rs
@@ -2020,6 +2020,11 @@ impl BundleAdjustment {
         config: &BaConfig,
         options: MatrixFreeBaOptions,
     ) -> Result<(), MatrixFreeBaError> {
+        if self.poses.keys().any(|id| !self.fixed_poses.contains(id)) {
+            return Err(MatrixFreeBaError::Ineligible(
+                "landmark-only matrix-free dispatch requires all poses fixed",
+            ));
+        }
         self.validate_matrix_free_entry_with_pose_requirement(config, options, false)
     }
 
@@ -10338,6 +10343,23 @@ mod matrix_free_ba_api_tests {
         assert!(matches!(
             bad_config.optimize_matrix_free(&config, MatrixFreeBaOptions::default()),
             Err(MatrixFreeBaError::InvalidConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn landmark_only_validation_rejects_variable_pose() {
+        let problem = make_problem();
+        let error = problem
+            .validate_matrix_free_landmark_only(
+                &matrix_free_config(),
+                MatrixFreeBaOptions::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            MatrixFreeBaError::Ineligible(
+                "landmark-only matrix-free dispatch requires all poses fixed"
+            )
         ));
     }
 

--- a/pipelines/slam/src/lib.rs
+++ b/pipelines/slam/src/lib.rs
@@ -36,8 +36,8 @@ pub mod rig_sfm;
 pub use rig_sfm::{
     incremental_rig_sfm, metric_temporal_quadrilateral_tracks,
     metric_temporal_quadrilateral_tracks_in_frame_gap, refine_rig_sfm_with_fixed_frame_rotations,
-    RigBaStats, RigFrame, RigFrameImage, RigSfmConfig, RigSfmError, RigSfmResult, RigSfmWorkStats,
-    RigTrackBuilder,
+    RigBaBackend, RigBaStats, RigFrame, RigFrameImage, RigSfmConfig, RigSfmError, RigSfmResult,
+    RigSfmWorkStats, RigTrackBuilder,
 };
 
 pub mod rig_correspondence;

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -18,7 +18,7 @@ use visloc_vision::pnp::{
 };
 use visloc_vision::two_view::{RelativePoseEstimator, TwoViewCorrespondence};
 
-use crate::bundle::{BaConfig, BaRigObservation, BundleAdjustment};
+use crate::bundle::{BaConfig, BaRigObservation, BundleAdjustment, MatrixFreeBaOptions};
 use crate::incremental_sfm::{
     build_tracks_confidence_ordered, build_tracks_confidence_ordered_with_trusted_prefix,
     build_tracks_detailed, build_tracks_incremental_correspondence,
@@ -82,6 +82,19 @@ pub enum RigTrackBuilder {
     /// Metric-first sparse cycles, retaining only tracks that contain a
     /// calibrated multi-sensor observation at one synchronized frame.
     MetricAnchoredCycle,
+}
+
+/// Bundle-adjustment backend used by the native calibrated-rig mapper.
+///
+/// `Legacy` is deliberately the default so existing callers retain their
+/// configured [`BaConfig`] (including its linear-solver choice).  The
+/// matrix-free entry point is an explicit, strict opt-in and never falls back
+/// to the legacy solve when it rejects an input or fails numerically.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RigBaBackend {
+    #[default]
+    Legacy,
+    MatrixFreeStrict,
 }
 
 /// Conservative controls for generalized-rig incremental reconstruction.
@@ -204,6 +217,7 @@ pub struct RigSfmConfig {
     /// from becoming numerically free after landmark/reprojection filtering.
     pub final_ba_min_pose_observations: usize,
     pub final_bundle_adjustment: bool,
+    pub ba_backend: RigBaBackend,
     pub ba_config: BaConfig,
     pub local_ba_every: usize,
     pub local_ba_window_size: usize,
@@ -277,6 +291,7 @@ impl Default for RigSfmConfig {
             ba_metric_tracks_only: false,
             final_ba_min_pose_observations: 0,
             final_bundle_adjustment: true,
+            ba_backend: RigBaBackend::Legacy,
             ba_config: BaConfig {
                 linear_solver: LinearSolver::Sparse,
                 robust_kernel: RobustKernel::Huber { delta: 6.0 },
@@ -4732,6 +4747,18 @@ fn run_rig_bundle_adjustment(
         }
     }
     if visual_observations == 0 {
+        if config.ba_backend == RigBaBackend::MatrixFreeStrict
+            && problem
+                .poses
+                .keys()
+                .any(|id| !problem.fixed_poses.contains(id))
+        {
+            let reason = "matrix-free backend has variable poses but no visual observations";
+            eprintln!(
+                "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+            );
+            return Err(RigSfmError::BundleAdjustment(reason.into()));
+        }
         return Ok(None);
     }
     if min_pose_observations > 0 {
@@ -4741,9 +4768,186 @@ fn run_rig_bundle_adjustment(
             }
         }
     }
-    let result = problem
-        .optimize(ba_config)
-        .map_err(|error| RigSfmError::BundleAdjustment(error.to_string()))?;
+    let mut matrix_free_report = None;
+    let (initial_cost, final_cost, iterations, converged) = match config.ba_backend {
+        RigBaBackend::Legacy => {
+            // Keep the historical call and caller-provided BaConfig entirely
+            // unchanged when the new selector is absent.
+            let result = problem
+                .optimize(ba_config)
+                .map_err(|error| RigSfmError::BundleAdjustment(error.to_string()))?;
+            (
+                result.initial_cost,
+                result.final_cost,
+                result.iterations.len(),
+                result.converged,
+            )
+        }
+        RigBaBackend::MatrixFreeStrict => {
+            let has_variable_pose = problem
+                .poses
+                .keys()
+                .any(|id| !problem.fixed_poses.contains(id));
+            let has_variable_landmark = problem
+                .landmarks
+                .keys()
+                .any(|id| !problem.fixed_landmarks.contains(id));
+
+            if !has_variable_pose && has_variable_landmark {
+                // The public matrix-free validator intentionally requires a
+                // variable pose.  A native window can nevertheless have all
+                // poses fixed while retaining variable landmarks.  This is a
+                // bounded landmark-only visual solve: its pose Schur dimension
+                // is exactly zero, so using the existing optimizer here does
+                // not create a hidden large legacy pose solve or change the
+                // observation/loss semantics.  Explicitly reject any
+                // calibration refinement rather than silently changing the
+                // requested problem.
+                if let Err(error) = problem
+                    .validate_matrix_free_landmark_only(ba_config, MatrixFreeBaOptions::default())
+                {
+                    eprintln!(
+                        "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={error}"
+                    );
+                    return Err(RigSfmError::BundleAdjustment(error.to_string()));
+                }
+                let result = problem
+                    .optimize(ba_config)
+                    .map_err(|error| {
+                        eprintln!(
+                            "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={error}"
+                        );
+                        RigSfmError::BundleAdjustment(error.to_string())
+                    })?;
+                matrix_free_report = Some((
+                    "landmark-only",
+                    result.iterations.len(),
+                    result
+                        .iterations
+                        .iter()
+                        .filter(|step| step.step_accepted)
+                        .count(),
+                    0usize,
+                ));
+                (
+                    result.initial_cost,
+                    result.final_cost,
+                    result.iterations.len(),
+                    result.converged,
+                )
+            } else if has_variable_pose {
+                let result = problem
+                    .optimize_matrix_free(ba_config, MatrixFreeBaOptions::default())
+                    .map_err(|error| {
+                        eprintln!(
+                            "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={error}"
+                        );
+                        RigSfmError::BundleAdjustment(error.to_string())
+                    })?;
+                matrix_free_report = Some((
+                    "matrix-free",
+                    result.iterations.len(),
+                    result
+                        .iterations
+                        .iter()
+                        .filter(|step| step.step_accepted)
+                        .count(),
+                    result
+                        .matrix_free_iterations
+                        .iter()
+                        .filter(|step| step.pcg_failure.is_some())
+                        .count(),
+                ));
+                (
+                    result.initial_cost,
+                    result.final_cost,
+                    result.iterations.len(),
+                    result.converged,
+                )
+            } else {
+                // This can only occur when the assembled problem has no
+                // variable state at all.  It is a genuine no-op, not a
+                // numerical failure, and has no mapper write-back to do.
+                if let Err(error) = problem
+                    .validate_matrix_free_landmark_only(ba_config, MatrixFreeBaOptions::default())
+                {
+                    eprintln!(
+                        "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={error}"
+                    );
+                    return Err(RigSfmError::BundleAdjustment(error.to_string()));
+                }
+                let cost = problem.robust_cost(&ba_config.robust_kernel);
+                if !cost.is_finite() {
+                    return Err(RigSfmError::BundleAdjustment(
+                        "matrix-free no-variable cost is non-finite".into(),
+                    ));
+                }
+                matrix_free_report = Some(("no-op", 0, 0, 0));
+                (cost, cost, 0, true)
+            }
+        }
+    };
+    if config.ba_backend == RigBaBackend::MatrixFreeStrict {
+        for &fixed_pose_id in &problem.fixed_poses {
+            let Some(original) = frame_poses
+                .get(fixed_pose_id as usize)
+                .and_then(Option::as_ref)
+            else {
+                let reason = format!("fixed pose {fixed_pose_id} disappeared during BA");
+                eprintln!(
+                    "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+                );
+                return Err(RigSfmError::BundleAdjustment(reason));
+            };
+            let Some(refined) = problem.poses.get(&fixed_pose_id) else {
+                let reason = format!("fixed pose {fixed_pose_id} disappeared from BA state");
+                eprintln!(
+                    "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+                );
+                return Err(RigSfmError::BundleAdjustment(reason));
+            };
+            if refined != original {
+                let reason = format!("fixed pose {fixed_pose_id} changed during matrix-free BA");
+                eprintln!(
+                    "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+                );
+                return Err(RigSfmError::BundleAdjustment(reason));
+            }
+        }
+        for &fixed_pose_id in &problem.fixed_pose_rotations {
+            let Some(original) = frame_poses
+                .get(fixed_pose_id as usize)
+                .and_then(Option::as_ref)
+            else {
+                let reason = format!("fixed-rotation pose {fixed_pose_id} disappeared during BA");
+                eprintln!(
+                    "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+                );
+                return Err(RigSfmError::BundleAdjustment(reason));
+            };
+            let Some(refined) = problem.poses.get(&fixed_pose_id) else {
+                let reason =
+                    format!("fixed-rotation pose {fixed_pose_id} disappeared from BA state");
+                eprintln!(
+                    "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+                );
+                return Err(RigSfmError::BundleAdjustment(reason));
+            };
+            if refined.world_to_camera.rotation != original.world_to_camera.rotation {
+                let reason =
+                    format!("fixed rotation pose {fixed_pose_id} changed during matrix-free BA");
+                eprintln!(
+                    "rig-ba-backend: requested=matrix-free used=none eligibility=error reason={reason}"
+                );
+                return Err(RigSfmError::BundleAdjustment(reason));
+            }
+        }
+        if let Some((used, iterations, accepted, pcg_failures)) = matrix_free_report {
+            eprintln!(
+                "rig-ba-backend: requested=matrix-free used={used} eligibility=eligible iterations={iterations} accepted={accepted} pcg_failures={pcg_failures}"
+            );
+        }
+    }
     for (frame, pose) in frame_poses.iter_mut().enumerate() {
         let Some(reference_pose) = problem.poses.get(&(frame as u64)) else {
             continue;
@@ -4768,10 +4972,10 @@ fn run_rig_bundle_adjustment(
     }
     Ok(Some(RigBaStats {
         observations: visual_observations,
-        initial_cost: result.initial_cost,
-        final_cost: result.final_cost,
-        iterations: result.iterations.len(),
-        converged: result.converged,
+        initial_cost,
+        final_cost,
+        iterations,
+        converged,
     }))
 }
 
@@ -8880,6 +9084,33 @@ mod tests {
             parallel: false,
             ..BaConfig::default()
         };
+        let mut matrix_free_frame_poses = frame_poses.clone();
+        let mut matrix_free_image_poses = image_poses.clone();
+        let mut matrix_free_tracks = tracks.clone();
+        let matrix_free_stats = run_rig_bundle_adjustment(
+            &rig,
+            &features,
+            &image_assignment,
+            &RigSfmConfig {
+                ba_backend: RigBaBackend::MatrixFreeStrict,
+                ..config
+            },
+            &active_frames,
+            0,
+            &ba_config,
+            0,
+            &[],
+            true,
+            &mut matrix_free_frame_poses,
+            &mut matrix_free_image_poses,
+            &mut matrix_free_tracks,
+        )
+        .unwrap()
+        .expect("matrix-free native rig fixture should have observations");
+        assert!(matrix_free_stats.final_cost <= matrix_free_stats.initial_cost);
+        for (before, after) in rotations_before.iter().zip(&matrix_free_frame_poses) {
+            assert!(before.angle_to(&after.as_ref().unwrap().world_to_camera.rotation) < 1.0e-10);
+        }
         let stats = run_rig_bundle_adjustment(
             &rig,
             &features,
@@ -8916,6 +9147,62 @@ mod tests {
         assert!(after_reprojection < before_reprojection);
         assert!(after_center_error < before_center_error);
         assert!(after_landmark_error < before_landmark_error);
+
+        let landmark_only_frame_poses = matrix_free_frame_poses.clone();
+        let mut landmark_only_image_poses = matrix_free_image_poses.clone();
+        let mut landmark_only_tracks = matrix_free_tracks.clone();
+        let landmark_only_stats = run_rig_bundle_adjustment(
+            &rig,
+            &features,
+            &image_assignment,
+            &RigSfmConfig {
+                ba_backend: RigBaBackend::MatrixFreeStrict,
+                ..config
+            },
+            &active_frames,
+            0,
+            &ba_config,
+            0,
+            &[1],
+            false,
+            &mut matrix_free_frame_poses,
+            &mut landmark_only_image_poses,
+            &mut landmark_only_tracks,
+        )
+        .unwrap()
+        .expect("landmark-only native rig fixture should have observations");
+        assert!(landmark_only_stats.final_cost <= landmark_only_stats.initial_cost);
+        assert_eq!(matrix_free_frame_poses, landmark_only_frame_poses);
+
+        let rejected_frame_poses = matrix_free_frame_poses.clone();
+        let mut rejected_image_poses = landmark_only_image_poses.clone();
+        let mut rejected_tracks = landmark_only_tracks.clone();
+        let error = run_rig_bundle_adjustment(
+            &rig,
+            &features,
+            &image_assignment,
+            &RigSfmConfig {
+                ba_backend: RigBaBackend::MatrixFreeStrict,
+                ..config
+            },
+            &active_frames,
+            0,
+            &BaConfig {
+                refine_intrinsics: true,
+                ..ba_config
+            },
+            0,
+            &[1],
+            false,
+            &mut matrix_free_frame_poses,
+            &mut rejected_image_poses,
+            &mut rejected_tracks,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, RigSfmError::BundleAdjustment(message) if message.contains("matrix-free"))
+        );
+        assert_eq!(matrix_free_frame_poses, rejected_frame_poses);
     }
 
     #[test]
@@ -9238,5 +9525,12 @@ mod tests {
                     if value == requested || (value.is_nan() && requested.is_nan())
             ));
         }
+    }
+
+    #[test]
+    fn native_ba_backend_defaults_to_legacy_and_is_explicit() {
+        let config = RigSfmConfig::default();
+        assert_eq!(config.ba_backend, RigBaBackend::Legacy);
+        assert_ne!(config.ba_backend, RigBaBackend::MatrixFreeStrict);
     }
 }

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -9084,9 +9084,27 @@ mod tests {
             parallel: false,
             ..BaConfig::default()
         };
+        let direct_frame_poses_before = frame_poses.clone();
+        let direct_observations_before = tracks
+            .iter()
+            .map(|track| track.observations.clone())
+            .collect::<Vec<_>>();
+        let direct_track_positions_before = tracks
+            .iter()
+            .map(|track| track.position)
+            .collect::<Vec<_>>();
         let mut matrix_free_frame_poses = frame_poses.clone();
         let mut matrix_free_image_poses = image_poses.clone();
         let mut matrix_free_tracks = tracks.clone();
+        let matrix_free_image_poses_before = matrix_free_image_poses.clone();
+        let matrix_free_observations_before = matrix_free_tracks
+            .iter()
+            .map(|track| track.observations.clone())
+            .collect::<Vec<_>>();
+        let matrix_free_track_positions_before = matrix_free_tracks
+            .iter()
+            .map(|track| track.position)
+            .collect::<Vec<_>>();
         let matrix_free_stats = run_rig_bundle_adjustment(
             &rig,
             &features,
@@ -9108,6 +9126,49 @@ mod tests {
         .unwrap()
         .expect("matrix-free native rig fixture should have observations");
         assert!(matrix_free_stats.final_cost <= matrix_free_stats.initial_cost);
+        assert!(matrix_free_frame_poses
+            .iter()
+            .zip(&direct_frame_poses_before)
+            .any(|(after, before)| after != before));
+        assert!(matrix_free_tracks
+            .iter()
+            .map(|track| track.position)
+            .zip(&matrix_free_track_positions_before)
+            .any(|(after, before)| after != *before));
+        assert_eq!(
+            matrix_free_tracks
+                .iter()
+                .map(|track| track.observations.clone())
+                .collect::<Vec<_>>(),
+            matrix_free_observations_before
+        );
+        assert!(matrix_free_image_poses
+            .iter()
+            .zip(&matrix_free_image_poses_before)
+            .any(|(after, before)| after != before));
+        let matrix_free_after_tracks = public_tracks(&matrix_free_tracks);
+        let (matrix_free_after_sum, matrix_free_after_count) = reprojection_error(
+            &rig,
+            &image_assignment,
+            &matrix_free_image_poses,
+            &matrix_free_after_tracks,
+        );
+        let matrix_free_after_reprojection = matrix_free_after_sum / matrix_free_after_count as f64;
+        let matrix_free_after_center_error = (matrix_free_frame_poses[1]
+            .as_ref()
+            .unwrap()
+            .camera_center_world()
+            - truth[1].camera_center_world())
+        .norm();
+        let matrix_free_after_landmark_error = matrix_free_tracks
+            .iter()
+            .zip(&world_points)
+            .map(|(track, point)| (track.position.unwrap() - point).norm())
+            .sum::<f64>()
+            / world_points.len() as f64;
+        assert!(matrix_free_after_reprojection < before_reprojection);
+        assert!(matrix_free_after_center_error < before_center_error);
+        assert!(matrix_free_after_landmark_error < before_landmark_error);
         for (before, after) in rotations_before.iter().zip(&matrix_free_frame_poses) {
             assert!(before.angle_to(&after.as_ref().unwrap().world_to_camera.rotation) < 1.0e-10);
         }
@@ -9126,8 +9187,10 @@ mod tests {
             &mut image_poses,
             &mut tracks,
         )
-        .unwrap();
-        assert!(stats.is_some());
+        .unwrap()
+        .expect("direct native rig fixture should have observations");
+        assert_eq!(matrix_free_stats.observations, stats.observations);
+        assert_eq!(matrix_free_stats.initial_cost, stats.initial_cost);
         for (before, after) in rotations_before.iter().zip(&frame_poses) {
             assert!(before.angle_to(&after.as_ref().unwrap().world_to_camera.rotation) < 1.0e-10);
         }
@@ -9147,6 +9210,22 @@ mod tests {
         assert!(after_reprojection < before_reprojection);
         assert!(after_center_error < before_center_error);
         assert!(after_landmark_error < before_landmark_error);
+        assert!(frame_poses
+            .iter()
+            .zip(&direct_frame_poses_before)
+            .any(|(after, before)| after != before));
+        assert!(tracks
+            .iter()
+            .map(|track| track.position)
+            .zip(&direct_track_positions_before)
+            .any(|(after, before)| after != *before));
+        assert_eq!(
+            tracks
+                .iter()
+                .map(|track| track.observations.clone())
+                .collect::<Vec<_>>(),
+            direct_observations_before
+        );
 
         let landmark_only_frame_poses = matrix_free_frame_poses.clone();
         let mut landmark_only_image_poses = matrix_free_image_poses.clone();
@@ -9177,6 +9256,8 @@ mod tests {
         let rejected_frame_poses = matrix_free_frame_poses.clone();
         let mut rejected_image_poses = landmark_only_image_poses.clone();
         let mut rejected_tracks = landmark_only_tracks.clone();
+        let rejected_image_poses_before = rejected_image_poses.clone();
+        let rejected_tracks_before = rejected_tracks.clone();
         let error = run_rig_bundle_adjustment(
             &rig,
             &features,
@@ -9203,6 +9284,8 @@ mod tests {
             matches!(error, RigSfmError::BundleAdjustment(message) if message.contains("matrix-free"))
         );
         assert_eq!(matrix_free_frame_poses, rejected_frame_poses);
+        assert_eq!(rejected_image_poses, rejected_image_poses_before);
+        assert_eq!(rejected_tracks, rejected_tracks_before);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ pub use visloc_slam::{
     PerPoseGravityPrior, PnPLoopClosureVerifier, PnPLoopClosureVerifierConfig, PoseGraph,
     PoseGraphEdge, PoseGraphEdgeKind, PoseGraphError, PoseGraphOptimizationStep,
     PoseGraphParseError, PoseGraphSe3Config, PoseGraphSe3IterationStats, PoseGraphSe3Result,
-    PositionPrior, PositionPriorObservation, ReconstructedLandmark, RigBaStats,
+    PositionPrior, PositionPriorObservation, ReconstructedLandmark, RigBaBackend, RigBaStats,
     RigCorrespondenceBuild, RigCorrespondenceBuildError, RigCorrespondenceCsr,
     RigCorrespondenceCsrBuilder, RigCorrespondencePreviewStats, RigFrame, RigFrameImage,
     RigObservationId, RigSfmConfig, RigSfmError, RigSfmResult, RigSfmWorkStats, RigTrackBuilder,


### PR DESCRIPTION
## Summary

Default-off strict matrix-free native rig backend, shared landmark-only eligibility, fixed-state rollback guards, CLI and tests. Legacy defaults remain unchanged.

## Native quality result: not promoted

RMSE 0.140219 m vs 0.022695 m, p95 0.234580 m vs 0.037779 m, raw mean 0.725011 px vs 0.671637 px: all fail. All 1000 images / 500 frames supported; geometry/identity/repeat audits pass. Same-binary Legacy exactly reproduces historical output.

The log field pcg_failures counts 589 failed linear steps in 688 iterations; it can include operator construction and back-substitution errors, not just PCG termination variants. Existing aggregate logs cannot identify the cause. No policy sweep, hidden fallback, 10k rollout, README performance claim or default change.

## Validation

Rig 29, matrix-free API 15, example 15 tests; scoped clippy/fmt/diff pass. Certified release/native evidence in docs/openloris_native_rig_matrix_free.md and benchmarks/electro/m8-openloris-native-rig-matrix-free-v1.json.

CI run 34186521565: all 9 jobs pass at exact head 13ce378406885a83a5eecdd232d52dafc8981d5c. Remaining M8–M10 objective is not complete.

Next bounded diagnostic: one identical-profile debug replay classifying existing linear_failure and solve_lambda records, without changing solver settings or interpreting debug-run timing as performance.