### PR TITLE
diag(vision): explain generalized PnP boundary failures

### DIFF
--- a/benchmarks/electro/m8-openloris-2500-boundary-pnp-v1.json
+++ b/benchmarks/electro/m8-openloris-2500-boundary-pnp-v1.json
@@ -1,0 +1,19 @@
+{
+  "schema": "m8-openloris-2500-boundary-pnp-v1",
+  "command": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-debug\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-debug.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY VISLOC_SFM_DEBUG=1 RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-debug.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-b011cde --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-2500/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-2500/pipeline-sparse7n/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-debug/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-debug.log 2>&1",
+  "audit_program": "import json\nfrom pathlib import Path\nroot=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n\")\nassert \"Exit status: 0\" in (root/\"pnp-debug.time\").read_text()\nfor name in [\"cameras.txt\",\"images.txt\",\"points3D.txt\"]:\n assert (root/\"pnp-debug/model\"/name).read_bytes()==(root/\"legacy/model\"/name).read_bytes()\nlines=[s for s in (root/\"pnp-debug.log\").read_text().splitlines() if \"frame=612 \" in s or \"frame=613 \" in s]\nprint(json.dumps({\"debug_model_exact\":True,\"boundary_registration_attempts\":lines}))\n",
+  "audit": {
+    "debug_model_exact": true,
+    "boundary_registration_attempts": [
+      "rig-sfm-debug: frame=613 support=29 sensors=2 pnp=estimation-failed",
+      "rig-sfm-debug: frame=612 support=25 sensors=2 pnp=estimation-failed"
+    ]
+  },
+  "interpretation": [
+    "Actual in-loop counts differ from final-model associations: frame 612 has 25 cached correspondences, frame 613 has 29, both across two sensors.",
+    "Both fail inside GeneralizedPnPRansac, before mapper-level inlier-count acceptance. Merely lowering mapper sensor-count gate is not supported.",
+    "Current generalized estimator already tries DLT and per-sensor P3P hypotheses scored across the rig; do not duplicate that path as a proposed fix.",
+    "Need hypothesis-generation and pooled-inlier diagnostics to distinguish degenerate samples from inconsistent 2D/3D geometry. No thresholds changed.",
+    "Model-byte parity establishes observational debug mode only; no quality or performance claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-2500-central-pnp-v1.json
+++ b/benchmarks/electro/m8-openloris-2500-central-pnp-v1.json
@@ -1,0 +1,30 @@
+{
+  "schema": "m8-openloris-2500-central-pnp-v1",
+  "commit": "a70cc26013bc49841ed73d92a6c3aafc8fe9d3d9",
+  "binary_sha256": "3dbe54ef8c81e5e6ff29a90158ad23bf48b3eca2105545023aa8c94d0b0f9d67",
+  "command": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-central\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-central.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY VISLOC_SFM_DEBUG_PNP_HYPOTHESES=1 VISLOC_SFM_DEBUG=1 RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-central.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-a70cc26 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-2500/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-2500/pipeline-sparse7n/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-central/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-central.log 2>&1",
+  "audit_program": "import json\nfrom pathlib import Path\nroot=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n\")\nassert \"Exit status: 0\" in (root/\"pnp-central.time\").read_text()\nfor name in [\"cameras.txt\",\"images.txt\",\"points3D.txt\"]:\n assert (root/\"pnp-central/model\"/name).read_bytes()==(root/\"legacy/model\"/name).read_bytes()\nlines=(root/\"pnp-central.log\").read_text().splitlines()\nout=[lines[i-3:i+1] for i,s in enumerate(lines) if \"frame=612 \" in s or \"frame=613 \" in s]\nprint(json.dumps({\"model_bytes_exact\":True,\"boundary\":out}))\n",
+  "audit": {
+    "model_bytes_exact": true,
+    "boundary": [
+      [
+        "generalized-pnp-central: sensor=0 correspondences=13 central_inliers=5 pooled_inliers=5 own_sensor_inliers=5",
+        "generalized-pnp-central: sensor=1 correspondences=16 central_inliers=5 pooled_inliers=5 own_sensor_inliers=5",
+        "generalized-pnp-hypotheses: correspondences=29 dlt_hypotheses=11 central_reports=2 pooled_inliers=5 required=6 prior=false",
+        "rig-sfm-debug: frame=613 support=29 sensors=2 pnp=estimation-failed"
+      ],
+      [
+        "generalized-pnp-central: sensor=0 correspondences=11 central_inliers=5 pooled_inliers=5 own_sensor_inliers=5",
+        "generalized-pnp-central: sensor=1 correspondences=14 central_inliers=5 pooled_inliers=5 own_sensor_inliers=5",
+        "generalized-pnp-hypotheses: correspondences=25 dlt_hypotheses=26 central_reports=2 pooled_inliers=5 required=6 prior=false",
+        "rig-sfm-debug: frame=612 support=25 sensors=2 pnp=estimation-failed"
+      ]
+    ]
+  },
+  "interpretation": [
+    "Each central report has only five inliers, all in its own sensor and none in the other sensor.",
+    "This does not support a claim that strong central estimates disagree only because of rig conversion; it also does not uniquely identify the geometric cause.",
+    "Native debug output is Legacy-byte-exact. Sampling, thresholds and updates unchanged.",
+    "Next investigate map correspondence consistency or independently triangulated stereo support without weakening acceptance. No default or quality promotion."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-2500-pnp-hypotheses-v1.json
+++ b/benchmarks/electro/m8-openloris-2500-pnp-hypotheses-v1.json
@@ -1,0 +1,26 @@
+{
+  "schema": "m8-openloris-2500-pnp-hypotheses-v1",
+  "commit": "015ab1bed6cb7e7e3d7a87dcac3e2f28c32ec871",
+  "binary_sha256": "78d7ebed13f1eb1471039612e8a46fd9765aae66537aecea90b6a9cb525b5aa9",
+  "command": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-hypotheses\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-hypotheses.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY VISLOC_SFM_DEBUG_PNP_HYPOTHESES=1 VISLOC_SFM_DEBUG=1 RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-hypotheses.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-015ab1b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-2500/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-2500/pipeline-sparse7n/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-hypotheses/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n/pnp-hypotheses.log 2>&1",
+  "audit_program": "import json\nfrom pathlib import Path\nroot=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-sparse7n\")\nassert \"Exit status: 0\" in (root/\"pnp-hypotheses.time\").read_text()\nfor name in [\"cameras.txt\",\"images.txt\",\"points3D.txt\"]:\n assert (root/\"pnp-hypotheses/model\"/name).read_bytes()==(root/\"legacy/model\"/name).read_bytes()\nlines=(root/\"pnp-hypotheses.log\").read_text().splitlines()\nout=[]\nfor i,line in enumerate(lines):\n if \"frame=612 \" in line or \"frame=613 \" in line:\n  assert lines[i-1].startswith(\"generalized-pnp-hypotheses:\")\n  out.append({\"attempt\":line,\"hypotheses\":lines[i-1]})\nprint(json.dumps({\"model_bytes_exact\":True,\"boundary\":out}))\n",
+  "audit": {
+    "model_bytes_exact": true,
+    "boundary": [
+      {
+        "attempt": "rig-sfm-debug: frame=613 support=29 sensors=2 pnp=estimation-failed",
+        "hypotheses": "generalized-pnp-hypotheses: correspondences=29 dlt_hypotheses=11 central_reports=2 pooled_inliers=5 required=6 prior=false"
+      },
+      {
+        "attempt": "rig-sfm-debug: frame=612 support=25 sensors=2 pnp=estimation-failed",
+        "hypotheses": "generalized-pnp-hypotheses: correspondences=25 dlt_hypotheses=26 central_reports=2 pooled_inliers=5 required=6 prior=false"
+      }
+    ]
+  },
+  "interpretation": [
+    "Candidates exist for both boundary frames: DLT 26/11 and two central reports each, but pooled best support is five against six required.",
+    "Central report count is not the number of internal P3P hypotheses or roots.",
+    "No threshold change justified; investigate correspondence consistency or additional independently validated geometric support.",
+    "Debug model bytes equal paired Legacy. No performance or full-tier quality claim."
+  ]
+}

--- a/crates/vision/src/pnp/generalized.rs
+++ b/crates/vision/src/pnp/generalized.rs
@@ -414,6 +414,8 @@ impl GeneralizedPnPRansac {
         let mut rng = SmallRng::seed_from_u64(self.seed);
         let mut indices = (0..correspondences.len()).collect::<Vec<_>>();
         let mut required_iterations = self.iterations;
+        let mut dlt_hypotheses = 0usize;
+        let mut central_hypotheses = 0usize;
         for iteration in 0..self.iterations {
             indices.shuffle(&mut rng);
             let sample = indices
@@ -424,6 +426,7 @@ impl GeneralizedPnPRansac {
             let Some(pose) = self.pose_estimator.estimate_pose(rig, &sample) else {
                 continue;
             };
+            dlt_hypotheses += 1;
             let score = score_pose(rig, &pose, correspondences, self.reprojection_threshold);
             if score.is_better_than(&best_score) {
                 best_pose = Some(pose);
@@ -482,6 +485,7 @@ impl GeneralizedPnPRansac {
             else {
                 continue;
             };
+            central_hypotheses += 1;
             let world_to_rig = rig.sensors()[sensor_index]
                 .sensor_from_rig
                 .inverse()
@@ -496,6 +500,12 @@ impl GeneralizedPnPRansac {
             }
         }
 
+        if std::env::var_os("VISLOC_SFM_DEBUG_PNP_HYPOTHESES").is_some() {
+            eprintln!(
+                "generalized-pnp-hypotheses: correspondences={} dlt_hypotheses={dlt_hypotheses} central_reports={central_hypotheses} pooled_inliers={} required={sample_size} prior={}",
+                correspondences.len(), best_score.inliers.len(), pose_prior.is_some(),
+            );
+        }
         if best_score.inliers.len() < sample_size {
             return None;
         }

--- a/crates/vision/src/pnp/generalized.rs
+++ b/crates/vision/src/pnp/generalized.rs
@@ -494,6 +494,17 @@ impl GeneralizedPnPRansac {
                 world_to_camera: world_to_rig,
             };
             let score = score_pose(rig, &pose, correspondences, self.reprojection_threshold);
+            if std::env::var_os("VISLOC_SFM_DEBUG_PNP_HYPOTHESES").is_some() {
+                let own_sensor_inliers = score
+                    .inliers
+                    .iter()
+                    .filter(|&&i| correspondences[i].sensor_index == sensor_index)
+                    .count();
+                eprintln!(
+                    "generalized-pnp-central: sensor={sensor_index} correspondences={} central_inliers={} pooled_inliers={} own_sensor_inliers={own_sensor_inliers}",
+                    sensor_correspondences.len(), report.inliers.len(), score.inliers.len(),
+                );
+            }
             if score.is_better_than(&best_score) {
                 best_pose = Some(pose);
                 best_score = score;

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,11 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 境界PnP: PR #99はCI9項目通過後 `28bf0e2` へmerge、旧branch整理済み。
+> 現branch `diag/m8-boundary-pnp`。build `015ab1b` の診断モデルはLegacy bytes一致。
+> frame612/613は25/29対応・2sensorで推定失敗。DLT候補26/11、central report各2は得られるが、
+> pooled inliersは両方5で必要6未満。閾値変更なし。各sensor内とrig全体のinlier比較ログを追加中。
+> 証跡 `m8-openloris-2500-pnp-hypotheses-v1.json`。次は追加ログのnative parity確認。
+
 > bounded policy 1k: build `b011cde`、Legacyとpolicy2反復はchampion bytes一致。
 > policyは各86回すべて直接法、QR0回。mapper4.28/4.51 s対Legacy4.42 s、速度改善主張なし。
 > 証跡 `m8-openloris-bounded-native-1k-v1.json`。次tierでは選択経路のcoverageを必ず確認。

--- a/docs/openloris_bounded_native_ba.md
+++ b/docs/openloris_bounded_native_ba.md
@@ -66,6 +66,13 @@ pooled scores have only five inliers against six required. Candidate generation
 is not absent; investigate 2D/3D consistency or independently verified support
 without lowering the acceptance threshold. [Audit](../benchmarks/electro/m8-openloris-2500-pnp-hypotheses-v1.json).
 
+The opt-in diagnostic additionally reports each successful central sensor
+estimate's own inlier count and its pooled/own-sensor inlier counts after rig
+conversion. This separates weak per-camera fits from disagreement across
+sensors without changing sampling or choosing a different hypothesis.
+Native validation of these additional fields remains pending; the recorded
+`015ab1b` result above predates them.
+
 The objective remains native quality, speed and bounded 10k memory, not forcing
 every small BA window through an iterative solver. Same-state evidence shows
 117 unavailable QR steps on the Legacy path; paired small-window measurements

--- a/docs/openloris_bounded_native_ba.md
+++ b/docs/openloris_bounded_native_ba.md
@@ -44,6 +44,14 @@ camera alone explains this boundary. Inspect actual registration rejection
 at 612/613 before changing thresholds or enabling recovery.
 [Pair/3D association audit](../benchmarks/electro/m8-openloris-2500-boundary-support-v1.json).
 
+Actual registration debug (same certified binary, model-byte-exact) reports
+frame 612 with 25 correspondences / two sensors and frame 613 with 29 / two
+sensors; both return `pnp=estimation-failed`, not the mapper's sensor or inlier
+gate. The generalized estimator already includes per-sensor P3P hypotheses
+in addition to DLT. Next distinguish hypothesis failure from insufficient
+pooled inliers internally, without relaxing gates or adding duplicate P3P.
+[In-loop boundary evidence](../benchmarks/electro/m8-openloris-2500-boundary-pnp-v1.json).
+
 The objective remains native quality, speed and bounded 10k memory, not forcing
 every small BA window through an iterative solver. Same-state evidence shows
 117 unavailable QR steps on the Legacy path; paired small-window measurements

--- a/docs/openloris_bounded_native_ba.md
+++ b/docs/openloris_bounded_native_ba.md
@@ -73,6 +73,14 @@ sensors without changing sampling or choosing a different hypothesis.
 Native validation of these additional fields remains pending; the recorded
 `015ab1b` result above predates them.
 
+Native verification at `a70cc26` is Legacy-byte-exact. For both frames 612/613,
+each sensor's central report has five inliers; pooling retains the same five
+own-sensor inliers and gains zero from the other sensor. Central fits are
+already weak, rather than strong single-camera poses only disagreeing after
+rig conversion. Investigate map correspondence consistency or independently
+triangulated stereo support; do not lower the six-inlier requirement.
+[Central/pooled evidence](../benchmarks/electro/m8-openloris-2500-central-pnp-v1.json).
+
 The objective remains native quality, speed and bounded 10k memory, not forcing
 every small BA window through an iterative solver. Same-state evidence shows
 117 unavailable QR steps on the Legacy path; paired small-window measurements

--- a/docs/openloris_bounded_native_ba.md
+++ b/docs/openloris_bounded_native_ba.md
@@ -60,6 +60,12 @@ hypothesis history, does not change RNG draws/scoring/refinement, and requires
 native byte-parity verification before interpreting measured output. Six
 generalized-related tests pass. This is diagnostic instrumentation, not a fix.
 
+Measured `015ab1b` is model-byte-exact to Legacy. Frame 612 generates 26 DLT
+hypotheses and two central reports; frame 613 generates 11 and two. Both best
+pooled scores have only five inliers against six required. Candidate generation
+is not absent; investigate 2D/3D consistency or independently verified support
+without lowering the acceptance threshold. [Audit](../benchmarks/electro/m8-openloris-2500-pnp-hypotheses-v1.json).
+
 The objective remains native quality, speed and bounded 10k memory, not forcing
 every small BA window through an iterative solver. Same-state evidence shows
 117 unavailable QR steps on the Legacy path; paired small-window measurements

--- a/docs/openloris_bounded_native_ba.md
+++ b/docs/openloris_bounded_native_ba.md
@@ -52,6 +52,14 @@ in addition to DLT. Next distinguish hypothesis failure from insufficient
 pooled inliers internally, without relaxing gates or adding duplicate P3P.
 [In-loop boundary evidence](../benchmarks/electro/m8-openloris-2500-boundary-pnp-v1.json).
 
+`VISLOC_SFM_DEBUG_PNP_HYPOTHESES` now enables one scalar summary per eligible
+generalized-PnP call: successful DLT hypothesis count, successful central
+sensor reports (not the internal number of P3P roots), best pooled inliers,
+minimum sample support and prior presence. It retains no correspondence or
+hypothesis history, does not change RNG draws/scoring/refinement, and requires
+native byte-parity verification before interpreting measured output. Six
+generalized-related tests pass. This is diagnostic instrumentation, not a fix.
+
 The objective remains native quality, speed and bounded 10k memory, not forcing
 every small BA window through an iterative solver. Same-state evidence shows
 117 unavailable QR steps on the Legacy path; paired small-window measurements

--- a/docs/openloris_bounded_native_ba.md
+++ b/docs/openloris_bounded_native_ba.md
@@ -81,6 +81,20 @@ rig conversion. Investigate map correspondence consistency or independently
 triangulated stereo support; do not lower the six-inlier requirement.
 [Central/pooled evidence](../benchmarks/electro/m8-openloris-2500-central-pnp-v1.json).
 
+Input-policy correction: the sparse7n snapshot contains only three same-frame
+stereo edges overall and none at frames 608–613. Enabling the existing direct
+stereo bridge alone therefore lacks the local triangulation input it needs.
+Do not generalize that diagnostic input's failure to the established M8 graph.
+The earlier dense ANN 2.5k promotion evidence already includes 1,250 same-frame
+candidate pairs and full registration. Its retained snapshot at
+`/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps`
+was rechecked: SHA256 `165bca7bd5c85b32a8138e421c0a32a74b1426c454f3c93d2926e3c39d583574`,
+matching `m8-openloris-dense256x2-2500-ann-gap128.json`. The envelope has 2,500
+images / 901,397 feature rows. Next use that retained, rig-aware graph for a
+paired current-binary Legacy/policy check before adding a recovery mechanism.
+This is a different input contract from sparse7n and requires separate evidence;
+historical full registration does not prove current policy success.
+
 The objective remains native quality, speed and bounded 10k memory, not forcing
 every small BA window through an iterative solver. Same-state evidence shows
 117 unavailable QR steps on the Legacy path; paired small-window measurements


### PR DESCRIPTION
Opt-in scalar PnP diagnostics report successful DLT candidates, central sensor reports and pooled inlier support. Additional per-sensor logs distinguish central support from pooled support; no RNG/scoring/refinement or acceptance changes.

Certified native 2.5k diagnostic at 015ab1b reproduces Legacy model bytes. Boundary frames 612/613 have 25/29 correspondences over two sensors, DLT candidates 26/11 and two central reports each, but only five pooled inliers against six required. This identifies the rejection mechanism, not its unique geometric cause. Additional per-sensor fields at final head still require native replay.

Six generalized-related tests and clippy pass. No performance claim or threshold relaxation. Evidence: benchmarks/electro/m8-openloris-2500-pnp-hypotheses-v1.json. Full CI and M8–M10 goal remain pending.