### PR TITLE
diag: trace and audit native BA pose deformation

### DIFF
--- a/benchmarks/electro/m8-openloris-5000-ba-motion-v1.json
+++ b/benchmarks/electro/m8-openloris-5000-ba-motion-v1.json
@@ -1,0 +1,229 @@
+{
+  "schema": "m8-openloris-5000-ba-motion-v1",
+  "build_commit": "49f302178d9727a3840b463c9439c45c6da5261c",
+  "binary_sha256": "296a740951a94b486daa4ca4c7a2eb9dfc4de0b6b780e0bfbd9dc6092ea88e6d",
+  "command": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-motion-debug\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-motion-debug.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES VISLOC_SFM_TRACE_BA_POSE_MOTION=1 RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-motion-debug.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-49f3021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-motion-debug/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-motion-debug.log 2>&1",
+  "audit_program": "import json,re,hashlib\nfrom pathlib import Path\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice\")\nassert \"Exit status: 0\" in (b/\"ba-motion-debug.time\").read_text()\nfor name in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n assert (b/\"legacy/model/component-000\"/name).read_bytes()==(b/\"ba-motion-debug/model/component-000\"/name).read_bytes(),name\nrows=[]\nfor line in (b/\"ba-motion-debug.log\").read_text().splitlines():\n if not line.startswith(\"rig-ba-pose-motion:\"): continue\n v=dict(re.findall(r\"(\\w+)=([^ ]+)\",line))\n before=float(v[\"anchor_distance_before\"]);after=float(v[\"anchor_distance_after\"])\n rows.append(dict(frame=int(v[\"frame\"]),anchor=int(v[\"anchor\"]),fixed=v[\"fixed\"]==\"true\",before_m=before,after_m=after,delta_m=after-before))\nrows.sort(key=lambda r:abs(r[\"delta_m\"]),reverse=True)\nprint(json.dumps(dict(records=len(rows),top20=rows[:20],target_maxima={str(f):next((r for r in rows if r[\"frame\"]==f),None) for f in (791,1068,1070,1071,1072,1416)},fixed_max_delta=max((abs(r[\"delta_m\"]) for r in rows if r[\"fixed\"]),default=0)),indent=2))\n",
+  "model_exact_to_legacy": true,
+  "result": {
+    "records": 20000,
+    "top20": [
+      {
+        "frame": 1068,
+        "anchor": 1497,
+        "fixed": false,
+        "before_m": 20.402023070321057,
+        "after_m": 10.549949318254983,
+        "delta_m": -9.852073752066074
+      },
+      {
+        "frame": 1070,
+        "anchor": 1414,
+        "fixed": false,
+        "before_m": 9.257700743930144,
+        "after_m": 18.15578419594678,
+        "delta_m": 8.898083452016635
+      },
+      {
+        "frame": 1072,
+        "anchor": 1414,
+        "fixed": false,
+        "before_m": 9.215972386513604,
+        "after_m": 18.10864885976597,
+        "delta_m": 8.892676473252367
+      },
+      {
+        "frame": 1071,
+        "anchor": 1505,
+        "fixed": false,
+        "before_m": 11.695081012275438,
+        "after_m": 5.743255778398281,
+        "delta_m": -5.951825233877156
+      },
+      {
+        "frame": 1068,
+        "anchor": 1505,
+        "fixed": false,
+        "before_m": 10.771384486963232,
+        "after_m": 5.9014997955210085,
+        "delta_m": -4.869884691442223
+      },
+      {
+        "frame": 1416,
+        "anchor": 1469,
+        "fixed": false,
+        "before_m": 2.4492096812613418,
+        "after_m": 4.319578096286057,
+        "delta_m": 1.8703684150247155
+      },
+      {
+        "frame": 1416,
+        "anchor": 1497,
+        "fixed": false,
+        "before_m": 2.180118291423177,
+        "after_m": 3.94594443392009,
+        "delta_m": 1.765826142496913
+      },
+      {
+        "frame": 1416,
+        "anchor": 1439,
+        "fixed": false,
+        "before_m": 4.088346524875338,
+        "after_m": 5.561675286204834,
+        "delta_m": 1.4733287613294959
+      },
+      {
+        "frame": 1068,
+        "anchor": 1520,
+        "fixed": false,
+        "before_m": 6.308161198240103,
+        "after_m": 4.943785913419117,
+        "delta_m": -1.3643752848209854
+      },
+      {
+        "frame": 1071,
+        "anchor": 1520,
+        "fixed": false,
+        "before_m": 6.149557834858433,
+        "after_m": 4.891603606505427,
+        "delta_m": -1.2579542283530056
+      },
+      {
+        "frame": 1071,
+        "anchor": 1522,
+        "fixed": false,
+        "before_m": 4.944887628733865,
+        "after_m": 3.8387122428643523,
+        "delta_m": -1.1061753858695123
+      },
+      {
+        "frame": 1068,
+        "anchor": 1522,
+        "fixed": false,
+        "before_m": 4.996947314696256,
+        "after_m": 3.8967694818597844,
+        "delta_m": -1.1001778328364717
+      },
+      {
+        "frame": 1084,
+        "anchor": 1080,
+        "fixed": false,
+        "before_m": 1.0394444361403896,
+        "after_m": 0.07702862813785091,
+        "delta_m": -0.9624158080025387
+      },
+      {
+        "frame": 1416,
+        "anchor": 1410,
+        "fixed": false,
+        "before_m": 2.7221682770734708,
+        "after_m": 1.7797522616047743,
+        "delta_m": -0.9424160154686965
+      },
+      {
+        "frame": 774,
+        "anchor": 1382,
+        "fixed": false,
+        "before_m": 10.3395889769679,
+        "after_m": 11.264293160394455,
+        "delta_m": 0.9247041834265559
+      },
+      {
+        "frame": 774,
+        "anchor": 1392,
+        "fixed": false,
+        "before_m": 11.528690104246994,
+        "after_m": 12.41240466433836,
+        "delta_m": 0.8837145600913665
+      },
+      {
+        "frame": 1111,
+        "anchor": 1392,
+        "fixed": false,
+        "before_m": 6.568483184403725,
+        "after_m": 7.344328493937348,
+        "delta_m": 0.7758453095336231
+      },
+      {
+        "frame": 1072,
+        "anchor": 1392,
+        "fixed": false,
+        "before_m": 7.507979825797051,
+        "after_m": 8.27565827926188,
+        "delta_m": 0.7676784534648284
+      },
+      {
+        "frame": 1073,
+        "anchor": 1392,
+        "fixed": false,
+        "before_m": 7.520529751536383,
+        "after_m": 8.2598092822258,
+        "delta_m": 0.7392795306894175
+      },
+      {
+        "frame": 1075,
+        "anchor": 1392,
+        "fixed": false,
+        "before_m": 7.474621946239451,
+        "after_m": 8.213489678649797,
+        "delta_m": 0.7388677324103456
+      }
+    ],
+    "target_maxima": {
+      "791": {
+        "frame": 791,
+        "anchor": 900,
+        "fixed": false,
+        "before_m": 2.2034622059107645,
+        "after_m": 1.5635029955438602,
+        "delta_m": -0.6399592103669043
+      },
+      "1068": {
+        "frame": 1068,
+        "anchor": 1497,
+        "fixed": false,
+        "before_m": 20.402023070321057,
+        "after_m": 10.549949318254983,
+        "delta_m": -9.852073752066074
+      },
+      "1070": {
+        "frame": 1070,
+        "anchor": 1414,
+        "fixed": false,
+        "before_m": 9.257700743930144,
+        "after_m": 18.15578419594678,
+        "delta_m": 8.898083452016635
+      },
+      "1071": {
+        "frame": 1071,
+        "anchor": 1505,
+        "fixed": false,
+        "before_m": 11.695081012275438,
+        "after_m": 5.743255778398281,
+        "delta_m": -5.951825233877156
+      },
+      "1072": {
+        "frame": 1072,
+        "anchor": 1414,
+        "fixed": false,
+        "before_m": 9.215972386513604,
+        "after_m": 18.10864885976597,
+        "delta_m": 8.892676473252367
+      },
+      "1416": {
+        "frame": 1416,
+        "anchor": 1469,
+        "fixed": false,
+        "before_m": 2.4492096812613418,
+        "after_m": 4.319578096286057,
+        "delta_m": 1.8703684150247155
+      }
+    },
+    "fixed_max_delta": 0
+  },
+  "limitations": [
+    "Anchor-distance changes identify within-BA deformation, not its cause.",
+    "Local BA uses registration-order windows and only observations inside each window; connectivity to fixed anchors must be inspected before changing solver or thresholds.",
+    "Diagnostic timing is not a performance measurement."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-5000-registration-diagnostic-v1.json
+++ b/benchmarks/electro/m8-openloris-5000-registration-diagnostic-v1.json
@@ -1,0 +1,109 @@
+{
+  "schema": "m8-openloris-5000-registration-diagnostic-v1",
+  "command": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/support-debug\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/support-debug.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES VISLOC_SFM_TRACE_REGISTRATION=1 VISLOC_SFM_TEMPORAL_SUPPORT_BIN_FRAMES=1 RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/support-debug.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-b011cde --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/support-debug/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/support-debug.log 2>&1",
+  "audit_program": "import json,re\nfrom pathlib import Path\nimport numpy as np\nfrom scripts.score_openloris_model import load_model_centres\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice\")\ncentres=load_model_centres(b/\"legacy/model/component-000/images.txt\")\nrows=[]\nfor line in (b/\"support-debug.log\").read_text().splitlines():\n if not line.startswith(\"rig-registration-trace:\"): continue\n v=dict(re.findall(r\"(\\w+)=([^ ]+)\",line)); f=int(v[\"frame\"])\n if f not in {791,1068,1070,1071,1072,1416}: continue\n initial=np.array([float(v[k]) for k in (\"cx\",\"cy\",\"cz\")])\n final=centres[f\"cam1_{2*f:06d}.png\"]\n rows.append(dict(frame=f,support=int(v[\"support\"]),inliers=int(v[\"inliers\"]),initial_center=initial.tolist(),final_center=final.tolist(),displacement_m=float(np.linalg.norm(initial-final))))\nprint(json.dumps(rows,indent=2))\n\nimport hashlib\nassert \"Exit status: 0\" in (b/\"support-debug.time\").read_text()\nfor n in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n assert (b/\"legacy/model/component-000\"/n).read_bytes()==(b/\"support-debug/model/component-000\"/n).read_bytes(),n\n",
+  "model_exact_to_legacy": true,
+  "result": [
+    {
+      "frame": 791,
+      "support": 57,
+      "inliers": 48,
+      "initial_center": [
+        -1.0980148472759503,
+        0.1529340971763723,
+        0.9509074188409685
+      ],
+      "final_center": [
+        -1.9245049695540937,
+        0.13713115221918565,
+        1.0452155356999482
+      ],
+      "displacement_m": 0.8320034111697783
+    },
+    {
+      "frame": 1072,
+      "support": 31,
+      "inliers": 14,
+      "initial_center": [
+        -4.482383251722142,
+        -0.11362240801346452,
+        1.0303054000377214
+      ],
+      "final_center": [
+        4.688050406999565,
+        1.707621773707088,
+        4.935519241214398
+      ],
+      "displacement_m": 10.132348148567777
+    },
+    {
+      "frame": 1070,
+      "support": 28,
+      "inliers": 16,
+      "initial_center": [
+        -4.417368547857115,
+        -0.07289175232069661,
+        1.099986141795119
+      ],
+      "final_center": [
+        4.733600951359056,
+        1.7189082089753107,
+        4.943133490918397
+      ],
+      "displacement_m": 10.085661675069133
+    },
+    {
+      "frame": 1416,
+      "support": 32,
+      "inliers": 26,
+      "initial_center": [
+        -12.477105103198177,
+        -0.5452552028792977,
+        -0.5532656290281182
+      ],
+      "final_center": [
+        -14.016121374872162,
+        -1.225588745907337,
+        4.750889527067518
+      ],
+      "displacement_m": 5.5646641169240665
+    },
+    {
+      "frame": 1068,
+      "support": 27,
+      "inliers": 14,
+      "initial_center": [
+        4.768776828229134,
+        1.7500930335285925,
+        4.946988494575845
+      ],
+      "final_center": [
+        -11.755907416020346,
+        -0.8113039364126886,
+        -2.876019536874911
+      ],
+      "displacement_m": 18.46145710581682
+    },
+    {
+      "frame": 1071,
+      "support": 27,
+      "inliers": 11,
+      "initial_center": [
+        -3.394615741653432,
+        0.4206382690583085,
+        1.173829340673655
+      ],
+      "final_center": [
+        -11.790604415728097,
+        -0.8339675212465617,
+        -2.8210495490159135
+      ],
+      "displacement_m": 9.382202238682767
+    }
+  ],
+  "limitations": [
+    "Registration-to-final displacements are in mapper coordinates, not GT errors.",
+    "Intervening BA can change the common gauge; these displacements alone do not identify a failing BA call.",
+    "No geometry thresholds, repair settings, or model outputs changed."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,17 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> PR101は最終head `4ae1a8f` のCI9成功後、`a551e5a` にsquash merge・旧branch整理済み。
+> 現branch `diag/m8-ba-pose-motion`、build `49f3021`。既定OFFの
+> `VISLOC_SFM_TRACE_BA_POSE_MOTION` は各BAの固定anchor相対距離を前後で記録する。
+> 有効状態のbounded policy固定状態/rollbackテストとclippy通過、release57.19秒。
+> 5k `tier-5000-slice/ba-motion-debug` はexit0、Legacyモデルbytes一致。
+> 1070/1072はanchor1414との距離が同一BA内で約8.9m増加。固定pose距離変化0。
+> 次は登録順local BA窓内の観測連結性と固定anchorへの接続を診断する。
+> 証跡 `m8-openloris-5000-ba-motion-v1.json`。共通gauge移動だけでは説明できない。
+> binary SHA256 `296a740951a94b486daa4ca4c7a2eb9dfc4de0b6b780e0bfbd9dc6092ea88e6d`。
+> 前のsupport-debugはexit0・Legacy bytes一致。登録→最終の変位は共通gauge変化も含むので
+> BA原因の断定不可。証跡 `m8-openloris-5000-registration-diagnostic-v1.json`。
+
 > 5k外れ値診断: 孤立5frameは同一全体Sim(3)下で二乗誤差69.287%を占める。
 > 最大8画像は1068/1070/1071/1072、誤差8.21〜10.09 m。
 > 主成分内1416も5.577 mなので孤立解消だけで品質達成とは言えない。

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -5033,6 +5033,28 @@ fn run_rig_bundle_adjustment(
             );
         }
     }
+    // Diagnostic only: compare within one solve against its fixed anchor.
+    // Stream scalar records without retaining pose histories or pair graphs.
+    if std::env::var_os("VISLOC_SFM_TRACE_BA_POSE_MOTION").is_some() {
+        if let (Some(before_anchor), Some(after_anchor)) = (
+            frame_poses[anchor_frame_index].as_ref(),
+            problem.poses.get(&(anchor_frame_index as u64)),
+        ) {
+            for (&id, refined) in &problem.poses {
+                if let Some(original) = frame_poses[id as usize].as_ref() {
+                    let before = (original.camera_center_world()
+                        - before_anchor.camera_center_world())
+                    .norm();
+                    let after =
+                        (refined.camera_center_world() - after_anchor.camera_center_world()).norm();
+                    eprintln!(
+                        "rig-ba-pose-motion: frame={id} anchor={anchor_frame_index} fixed={} anchor_distance_before={before:.17e} anchor_distance_after={after:.17e}",
+                        problem.fixed_poses.contains(&id),
+                    );
+                }
+            }
+        }
+    }
     for (frame, pose) in frame_poses.iter_mut().enumerate() {
         let Some(reference_pose) = problem.poses.get(&(frame as u64)) else {
             continue;


### PR DESCRIPTION
Adds default-off scalar anchor-relative BA motion diagnostics. Enabled fixed-state/rollback test and clippy pass. Certified 5k replay is byte-identical to Legacy; frames 1070/1072 move about 8.9 m relative to fixed anchor 1414 within a solve. Evidence and handover included. No solver, threshold, repair, or README performance changes. Next: inspect actual local-window observation connectivity to fixed anchors. Full M8-M10 goal remains open.