### PR TITLE
diag: audit fixed-anchor connectivity in native BA

### DIFF
--- a/benchmarks/electro/m8-openloris-5000-ba-connectivity-v1.json
+++ b/benchmarks/electro/m8-openloris-5000-ba-connectivity-v1.json
@@ -1,0 +1,388 @@
+{
+  "schema": "m8-openloris-5000-ba-connectivity-v1",
+  "build_commit": "4fbb952b600d36bc312c04f97c076f0a3ee1c7f8",
+  "binary_sha256": "a2b1523fccf956ca912ba051043e186dc0f7a95e2ce70a041cfb2851079b2fb0",
+  "command": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-connectivity-debug\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-connectivity-debug.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES VISLOC_SFM_TRACE_BA_CONNECTIVITY=1 VISLOC_SFM_TRACE_BA_POSE_MOTION=1 RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-connectivity-debug.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-4fbb952 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-connectivity-debug/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/ba-connectivity-debug.log 2>&1",
+  "audit_program": "import json,re,hashlib\nfrom pathlib import Path\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice\")\nassert \"Exit status: 0\" in (b/\"ba-connectivity-debug.time\").read_text()\nhashes={}\nfor n in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n data=(b/\"ba-connectivity-debug/model/component-000\"/n).read_bytes()\n assert data==(b/\"legacy/model/component-000\"/n).read_bytes(),n\n hashes[n]=hashlib.sha256(data).hexdigest()\nstate={}; rows=[]\nfor line in (b/\"ba-connectivity-debug.log\").read_text().splitlines():\n if not line.startswith((\"rig-ba-connectivity:\",\"rig-ba-pose-motion:\")): continue\n v=dict(re.findall(r\"(\\w+)=([^ ]+)\",line)); key=(int(v[\"frame\"]),int(v[\"anchor\"]))\n if line.startswith(\"rig-ba-connectivity:\"):\n  state[key]=v[\"connected_to_fixed\"]==\"true\"\n else:\n  assert key in state\n  before=float(v[\"anchor_distance_before\"]); after=float(v[\"anchor_distance_after\"])\n  rows.append(dict(frame=key[0],anchor=key[1],connected=state[key],fixed=v[\"fixed\"]==\"true\",before_m=before,after_m=after,delta_m=after-before))\nrows.sort(key=lambda r:abs(r[\"delta_m\"]),reverse=True)\nprint(json.dumps(dict(model_sha256=hashes,records=len(rows),unconnected_records=sum(not r[\"connected\"] for r in rows),top20=rows[:20],unconnected_top20=[r for r in rows if not r[\"connected\"]][:20],fixed_max_delta=max((abs(r[\"delta_m\"]) for r in rows if r[\"fixed\"]),default=0)),indent=2))\n",
+  "model_exact_to_legacy": true,
+  "result": {
+    "model_sha256": {
+      "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+      "images.txt": "ae3ccbe3d67c90b5793e0fcdcdd1d98609f3e0434516b9182f1bfe2e15d5c24b",
+      "points3D.txt": "165da10b52e54637f6c1db926ea0b4d6d7cf89bb11de02e68a07f0a952d595b2"
+    },
+    "records": 20000,
+    "unconnected_records": 306,
+    "top20": [
+      {
+        "frame": 1068,
+        "anchor": 1497,
+        "connected": false,
+        "fixed": false,
+        "before_m": 20.402023070321057,
+        "after_m": 10.549949318254983,
+        "delta_m": -9.852073752066074
+      },
+      {
+        "frame": 1070,
+        "anchor": 1414,
+        "connected": false,
+        "fixed": false,
+        "before_m": 9.257700743930144,
+        "after_m": 18.15578419594678,
+        "delta_m": 8.898083452016635
+      },
+      {
+        "frame": 1072,
+        "anchor": 1414,
+        "connected": false,
+        "fixed": false,
+        "before_m": 9.215972386513604,
+        "after_m": 18.10864885976597,
+        "delta_m": 8.892676473252367
+      },
+      {
+        "frame": 1071,
+        "anchor": 1505,
+        "connected": false,
+        "fixed": false,
+        "before_m": 11.695081012275438,
+        "after_m": 5.743255778398281,
+        "delta_m": -5.951825233877156
+      },
+      {
+        "frame": 1068,
+        "anchor": 1505,
+        "connected": false,
+        "fixed": false,
+        "before_m": 10.771384486963232,
+        "after_m": 5.9014997955210085,
+        "delta_m": -4.869884691442223
+      },
+      {
+        "frame": 1416,
+        "anchor": 1469,
+        "connected": true,
+        "fixed": false,
+        "before_m": 2.4492096812613418,
+        "after_m": 4.319578096286057,
+        "delta_m": 1.8703684150247155
+      },
+      {
+        "frame": 1416,
+        "anchor": 1497,
+        "connected": true,
+        "fixed": false,
+        "before_m": 2.180118291423177,
+        "after_m": 3.94594443392009,
+        "delta_m": 1.765826142496913
+      },
+      {
+        "frame": 1416,
+        "anchor": 1439,
+        "connected": true,
+        "fixed": false,
+        "before_m": 4.088346524875338,
+        "after_m": 5.561675286204834,
+        "delta_m": 1.4733287613294959
+      },
+      {
+        "frame": 1068,
+        "anchor": 1520,
+        "connected": false,
+        "fixed": false,
+        "before_m": 6.308161198240103,
+        "after_m": 4.943785913419117,
+        "delta_m": -1.3643752848209854
+      },
+      {
+        "frame": 1071,
+        "anchor": 1520,
+        "connected": false,
+        "fixed": false,
+        "before_m": 6.149557834858433,
+        "after_m": 4.891603606505427,
+        "delta_m": -1.2579542283530056
+      },
+      {
+        "frame": 1071,
+        "anchor": 1522,
+        "connected": false,
+        "fixed": false,
+        "before_m": 4.944887628733865,
+        "after_m": 3.8387122428643523,
+        "delta_m": -1.1061753858695123
+      },
+      {
+        "frame": 1068,
+        "anchor": 1522,
+        "connected": false,
+        "fixed": false,
+        "before_m": 4.996947314696256,
+        "after_m": 3.8967694818597844,
+        "delta_m": -1.1001778328364717
+      },
+      {
+        "frame": 1084,
+        "anchor": 1080,
+        "connected": true,
+        "fixed": false,
+        "before_m": 1.0394444361403896,
+        "after_m": 0.07702862813785091,
+        "delta_m": -0.9624158080025387
+      },
+      {
+        "frame": 1416,
+        "anchor": 1410,
+        "connected": true,
+        "fixed": false,
+        "before_m": 2.7221682770734708,
+        "after_m": 1.7797522616047743,
+        "delta_m": -0.9424160154686965
+      },
+      {
+        "frame": 774,
+        "anchor": 1382,
+        "connected": false,
+        "fixed": false,
+        "before_m": 10.3395889769679,
+        "after_m": 11.264293160394455,
+        "delta_m": 0.9247041834265559
+      },
+      {
+        "frame": 774,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 11.528690104246994,
+        "after_m": 12.41240466433836,
+        "delta_m": 0.8837145600913665
+      },
+      {
+        "frame": 1111,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 6.568483184403725,
+        "after_m": 7.344328493937348,
+        "delta_m": 0.7758453095336231
+      },
+      {
+        "frame": 1072,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.507979825797051,
+        "after_m": 8.27565827926188,
+        "delta_m": 0.7676784534648284
+      },
+      {
+        "frame": 1073,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.520529751536383,
+        "after_m": 8.2598092822258,
+        "delta_m": 0.7392795306894175
+      },
+      {
+        "frame": 1075,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.474621946239451,
+        "after_m": 8.213489678649797,
+        "delta_m": 0.7388677324103456
+      }
+    ],
+    "unconnected_top20": [
+      {
+        "frame": 1068,
+        "anchor": 1497,
+        "connected": false,
+        "fixed": false,
+        "before_m": 20.402023070321057,
+        "after_m": 10.549949318254983,
+        "delta_m": -9.852073752066074
+      },
+      {
+        "frame": 1070,
+        "anchor": 1414,
+        "connected": false,
+        "fixed": false,
+        "before_m": 9.257700743930144,
+        "after_m": 18.15578419594678,
+        "delta_m": 8.898083452016635
+      },
+      {
+        "frame": 1072,
+        "anchor": 1414,
+        "connected": false,
+        "fixed": false,
+        "before_m": 9.215972386513604,
+        "after_m": 18.10864885976597,
+        "delta_m": 8.892676473252367
+      },
+      {
+        "frame": 1071,
+        "anchor": 1505,
+        "connected": false,
+        "fixed": false,
+        "before_m": 11.695081012275438,
+        "after_m": 5.743255778398281,
+        "delta_m": -5.951825233877156
+      },
+      {
+        "frame": 1068,
+        "anchor": 1505,
+        "connected": false,
+        "fixed": false,
+        "before_m": 10.771384486963232,
+        "after_m": 5.9014997955210085,
+        "delta_m": -4.869884691442223
+      },
+      {
+        "frame": 1068,
+        "anchor": 1520,
+        "connected": false,
+        "fixed": false,
+        "before_m": 6.308161198240103,
+        "after_m": 4.943785913419117,
+        "delta_m": -1.3643752848209854
+      },
+      {
+        "frame": 1071,
+        "anchor": 1520,
+        "connected": false,
+        "fixed": false,
+        "before_m": 6.149557834858433,
+        "after_m": 4.891603606505427,
+        "delta_m": -1.2579542283530056
+      },
+      {
+        "frame": 1071,
+        "anchor": 1522,
+        "connected": false,
+        "fixed": false,
+        "before_m": 4.944887628733865,
+        "after_m": 3.8387122428643523,
+        "delta_m": -1.1061753858695123
+      },
+      {
+        "frame": 1068,
+        "anchor": 1522,
+        "connected": false,
+        "fixed": false,
+        "before_m": 4.996947314696256,
+        "after_m": 3.8967694818597844,
+        "delta_m": -1.1001778328364717
+      },
+      {
+        "frame": 774,
+        "anchor": 1382,
+        "connected": false,
+        "fixed": false,
+        "before_m": 10.3395889769679,
+        "after_m": 11.264293160394455,
+        "delta_m": 0.9247041834265559
+      },
+      {
+        "frame": 774,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 11.528690104246994,
+        "after_m": 12.41240466433836,
+        "delta_m": 0.8837145600913665
+      },
+      {
+        "frame": 1111,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 6.568483184403725,
+        "after_m": 7.344328493937348,
+        "delta_m": 0.7758453095336231
+      },
+      {
+        "frame": 1072,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.507979825797051,
+        "after_m": 8.27565827926188,
+        "delta_m": 0.7676784534648284
+      },
+      {
+        "frame": 1073,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.520529751536383,
+        "after_m": 8.2598092822258,
+        "delta_m": 0.7392795306894175
+      },
+      {
+        "frame": 1075,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.474621946239451,
+        "after_m": 8.213489678649797,
+        "delta_m": 0.7388677324103456
+      },
+      {
+        "frame": 1070,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.58722133207498,
+        "after_m": 8.32476741647635,
+        "delta_m": 0.7375460844013695
+      },
+      {
+        "frame": 1066,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.666911663536408,
+        "after_m": 8.404119375290193,
+        "delta_m": 0.7372077117537854
+      },
+      {
+        "frame": 1069,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.608176305080815,
+        "after_m": 8.345377488862104,
+        "delta_m": 0.7372011837812886
+      },
+      {
+        "frame": 1067,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.650464654304663,
+        "after_m": 8.38757314601857,
+        "delta_m": 0.7371084917139061
+      },
+      {
+        "frame": 1084,
+        "anchor": 1392,
+        "connected": false,
+        "fixed": false,
+        "before_m": 7.275697723260553,
+        "after_m": 8.011397221979443,
+        "delta_m": 0.7356994987188905
+      }
+    ],
+    "fixed_max_delta": 0
+  },
+  "limits": [
+    "Reachability uses only the actual accepted BA observations, not final tracks or raw pair connectivity.",
+    "The five largest anchor-distance changes are disconnected from every fixed pose. This does not establish that anchoring alone repairs global trajectory quality.",
+    "Frame 1416 deforms despite connectivity; connected geometry conditioning remains a separate concern.",
+    "Diagnostic timing and RSS are not certified performance results."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,17 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 現branch `diag/m8-ba-anchor-connectivity`、親PR102はCI実行中。
+> build `4fbb952b600d36bc312c04f97c076f0a3ee1c7f8` に既定OFFの
+> `VISLOC_SFM_TRACE_BA_CONNECTIVITY` を追加。実際のBA採用観測のlandmark-starで
+> 固定poseへの到達性を判定。密なpose cliqueなし、O(観測+点+pose)診断状態。
+> 接続単体テストと有効状態の固定/rollbackテスト、clippy通過。release42.71秒。
+> 5k `tier-5000-slice/ba-connectivity-debug` はexit0、Legacyモデルbytes一致。
+> binary SHA256 `a2b1523fccf956ca912ba051043e186dc0f7a95e2ce70a041cfb2851079b2fb0`。
+> 全20000 pose/BA記録中306件が全固定poseから未接続。変位上位5件は全て未接続。
+> 1070/1072のanchor1414のBAも未接続。次は独立成分のgauge固定をdefault-off検証。
+> 1416は接続済みでも変位するため十分条件ではない。品質変更はまだない。
+> 証跡 `m8-openloris-5000-ba-connectivity-v1.json`。
+
 > PR101は最終head `4ae1a8f` のCI9成功後、`a551e5a` にsquash merge・旧branch整理済み。
 > 現branch `diag/m8-ba-pose-motion`、build `49f3021`。既定OFFの
 > `VISLOC_SFM_TRACE_BA_POSE_MOTION` は各BAの固定anchor相対距離を前後で記録する。

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -4681,6 +4681,35 @@ fn run_windowed_final_ba(
     Ok(aggregate)
 }
 
+fn rig_ba_anchor_reachable(
+    observations: impl IntoIterator<Item = (u64, u64)>,
+    fixed: impl IntoIterator<Item = u64>,
+) -> BTreeSet<u64> {
+    // A landmark star preserves connectivity without a pose-pair clique.
+    // Storage is O(observations + landmarks + poses), never O(poses squared).
+    let mut first = BTreeMap::new();
+    let mut edges: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+    for (pose, landmark) in observations {
+        let representative = *first.entry(landmark).or_insert(pose);
+        if pose != representative {
+            edges.entry(pose).or_default().push(representative);
+            edges.entry(representative).or_default().push(pose);
+        }
+    }
+    let mut reached: BTreeSet<_> = fixed.into_iter().collect();
+    let mut pending: Vec<_> = reached.iter().copied().collect();
+    while let Some(pose) = pending.pop() {
+        if let Some(neighbors) = edges.get(&pose) {
+            for &neighbor in neighbors {
+                if reached.insert(neighbor) {
+                    pending.push(neighbor);
+                }
+            }
+        }
+    }
+    reached
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_rig_bundle_adjustment(
     rig: &GeneralizedCameraRig,
@@ -4788,6 +4817,21 @@ fn run_rig_bundle_adjustment(
         }
     }
     let mut matrix_free_report = None;
+    if std::env::var_os("VISLOC_SFM_TRACE_BA_CONNECTIVITY").is_some() {
+        let reached = rig_ba_anchor_reachable(
+            problem
+                .rig_observations
+                .iter()
+                .map(|o| (o.keyframe_id, o.landmark_id)),
+            problem.fixed_poses.iter().copied(),
+        );
+        for id in problem.poses.keys() {
+            eprintln!(
+                "rig-ba-connectivity: frame={id} anchor={anchor_frame_index} fixed={} connected_to_fixed={}",
+                problem.fixed_poses.contains(id), reached.contains(id),
+            );
+        }
+    }
     // Scalar-only context for pairing native windows with existing LM debug
     // records. No state copy, solve-policy change, or global pair graph.
     if std::env::var_os("VISLOC_SFM_DEBUG_BA").is_some()
@@ -9076,6 +9120,30 @@ mod tests {
     #[test]
     fn qr_native_preserves_fixed_state_and_rollback() {
         check_fixed_rotation_backend(RigBaBackend::MatrixFreeQr);
+    }
+
+    #[test]
+    fn ba_anchor_connectivity_uses_landmark_paths_not_stereo_support_alone() {
+        let observations = [
+            (0, 10),
+            (1, 10),
+            (1, 11),
+            (2, 11),
+            (3, 12),
+            (3, 12),
+            (4, 13),
+            (5, 13),
+        ];
+        assert_eq!(
+            rig_ba_anchor_reachable(observations, [0]),
+            BTreeSet::from([0, 1, 2])
+        );
+        assert_eq!(
+            rig_ba_anchor_reachable(observations, [0, 4]),
+            BTreeSet::from([0, 1, 2, 4, 5])
+        );
+        assert!(rig_ba_anchor_reachable(observations, []).is_empty());
+        assert_eq!(rig_ba_anchor_reachable([], [7]), BTreeSet::from([7]));
     }
 
     #[test]


### PR DESCRIPTION
Default-off sparse landmark-star reachability diagnostic for actual BA observations. Connectivity unit test, enabled fixed-state/rollback test, and clippy pass. Certified 5k replay exactly matches Legacy bytes. 306/20000 pose records lack a path to any fixed pose; the five largest anchor-relative changes are among them. No quality/solver/threshold changes. Next: test component gauge anchoring; connected outliers remain a separate issue.