### PR TITLE
feat: explicit native BA component anchors with paired evidence

### DIFF
--- a/benchmarks/electro/m8-openloris-5000-component-anchors-v1.json
+++ b/benchmarks/electro/m8-openloris-5000-component-anchors-v1.json
@@ -1,0 +1,308 @@
+{
+  "schema": "m8-openloris-5000-component-anchors-v1",
+  "status": "repeatable-mixed-quality-not-promoted",
+  "audit_program": "import json,re,hashlib\nfrom pathlib import Path\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice\")\nruns={}\nfor arm in (\"anchored-control\",\"component-a\",\"component-b\"):\n log=(b/(arm+\".log\")).read_text();time=(b/(arm+\".time\")).read_text()\n assert \"Exit status: 0\" in time,arm\n hashes={}\n for n in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n  data=(b/arm/\"model/component-000\"/n).read_bytes()\n  hashes[n]=hashlib.sha256(data).hexdigest()\n  ref=\"legacy\" if arm==\"anchored-control\" else \"component-a\"\n  assert data==(b/ref/\"model/component-000\"/n).read_bytes(),(arm,n)\n result=[l for l in log.splitlines() if l.startswith(\"rig-multimodel result:\")][-1]\n assert \"registered_frames=2500/2500 registered_images=5000/5000\" in result\n runs[arm]=dict(model_sha256=hashes,mapper_seconds=float(re.search(r\"mapper_seconds=([0-9.]+)\",result)[1]),peak_rss_kib=int(re.search(r\"Maximum resident set size \\(kbytes\\): (\\d+)\",time)[1]),added_anchors=len(re.findall(r\"^rig-ba-component-anchor:\",log,re.M)),result=result,time_output=time,log_sha256=hashlib.sha256(log.encode()).hexdigest())\nprint(json.dumps(dict(control_exact_to_legacy=True,candidate_repeats_exact=True,runs=runs),indent=2))\n",
+  "audit": {"control_exact_to_legacy":true,"candidate_repeats_exact":true,"runs":{"anchored-control":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"ae3ccbe3d67c90b5793e0fcdcdd1d98609f3e0434516b9182f1bfe2e15d5c24b","points3D.txt":"165da10b52e54637f6c1db926ea0b4d6d7cf89bb11de02e68a07f0a952d595b2"},"mapper_seconds":53.41758,"peak_rss_kib":722628,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=2500/2500 registered_images=5000/5000 tracks=34832 observations=310473 mean_reprojection_px=0.831376558 mapper_seconds=53.417580 VmHWM_KiB=722628 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-36eb021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 55.08\n\tSystem time (seconds): 0.76\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:55.85\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 722628\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 218934\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 186\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 97928\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"f94dca4f5c7b03156190ed489057122cdebaedd61972d67b86aef9cf6885cfd1"},"component-a":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"d774c57603f4abeba4ffd757083d15030e9cdfc97629a6b581ad8c7ffd31e16a","points3D.txt":"e0fdfc9042f5b2c1c5842574170746b71fe8c4d08cf6e1ec74269a5260990433"},"mapper_seconds":53.641363,"peak_rss_kib":722944,"added_anchors":39,"result":"rig-multimodel result: models=1 registered_frames=2500/2500 registered_images=5000/5000 tracks=34877 observations=310757 mean_reprojection_px=0.837363763 mapper_seconds=53.641363 VmHWM_KiB=722944 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-36eb021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-anchor-disconnected-components --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 55.10\n\tSystem time (seconds): 0.80\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:55.91\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 722944\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 218977\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 450\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 97952\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"abe33db182470a785be51b1f45895357671cf2344b4e7a2dc7da254efd078541"},"component-b":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"d774c57603f4abeba4ffd757083d15030e9cdfc97629a6b581ad8c7ffd31e16a","points3D.txt":"e0fdfc9042f5b2c1c5842574170746b71fe8c4d08cf6e1ec74269a5260990433"},"mapper_seconds":62.541108,"peak_rss_kib":722764,"added_anchors":39,"result":"rig-multimodel result: models=1 registered_frames=2500/2500 registered_images=5000/5000 tracks=34877 observations=310757 mean_reprojection_px=0.837363763 mapper_seconds=62.541108 VmHWM_KiB=722764 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-36eb021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-anchor-disconnected-components --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 64.24\n\tSystem time (seconds): 0.77\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 1:05.02\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 722764\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 218985\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 333\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 97952\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"236ba832401846d24f94a921bcb744c3f860fea287839a7f0ff5045dc8c67129"}}},
+  "build_commit": "36eb02159f88211fd2e57db75a43d9cadbb494ca",
+  "binary_sha256": "779c6295f5cf62503790da530b9da3c3a1afcf3735e903fed9799501cb49db2b",
+  "commands": {
+    "anchored-control": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-36eb021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/anchored-control.log 2>&1",
+    "component-a": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-36eb021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-anchor-disconnected-components --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a.log 2>&1",
+    "component-b": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-36eb021 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-anchor-disconnected-components --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-b.log 2>&1"
+  },
+  "score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model/component-000/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-5000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "score": {
+    "component_weighted_max_m": 1.7734574749905712,
+    "component_weighted_median_m": 0.20503839478868358,
+    "component_weighted_p95_m": 0.4908657808368514,
+    "component_weighted_rmse_m": 0.2612838426865665,
+    "components": [
+      {
+        "gt_scored": 4308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model/component-000/images.txt",
+        "images_txt_sha256": "d774c57603f4abeba4ffd757083d15030e9cdfc97629a6b581ad8c7ffd31e16a",
+        "max_m": 1.7734574749905712,
+        "median_m": 0.20503839478868358,
+        "p95_m": 0.4908657808368514,
+        "reference_extent_m": 38.74424995549824,
+        "registered": 5000,
+        "relative_rmse": 0.0067438095455887755,
+        "rmse_m": 0.2612838426865665,
+        "sim3_scale": 0.9938441026262718,
+        "trajectory_segments": [
+          {
+            "images": 432,
+            "max_m": 0.506713268091604,
+            "median_m": 0.3562849784805559,
+            "p95_m": 0.5048184292840885,
+            "rmse_m": 0.3858309770468895,
+            "segment": 0,
+            "timestamp_end": 1560000022.233627,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 430,
+            "max_m": 0.527322363664105,
+            "median_m": 0.28707702596739604,
+            "p95_m": 0.3267461030326456,
+            "rmse_m": 0.2582182255838123,
+            "segment": 1,
+            "timestamp_end": 1560000029.39037,
+            "timestamp_start": 1560000022.26696
+          },
+          {
+            "images": 432,
+            "max_m": 0.3978846808335473,
+            "median_m": 0.08709586970835434,
+            "p95_m": 0.211408543788244,
+            "rmse_m": 0.14366827616037697,
+            "segment": 2,
+            "timestamp_end": 1560000036.590301,
+            "timestamp_start": 1560000029.423703
+          },
+          {
+            "images": 430,
+            "max_m": 0.2869387898446156,
+            "median_m": 0.2001175628945729,
+            "p95_m": 0.27304331106443824,
+            "rmse_m": 0.21298905981732408,
+            "segment": 3,
+            "timestamp_end": 1560000043.747026,
+            "timestamp_start": 1560000036.623635
+          },
+          {
+            "images": 430,
+            "max_m": 0.2683538076642539,
+            "median_m": 0.22539512806735046,
+            "p95_m": 0.2550038580987005,
+            "rmse_m": 0.22780244166811112,
+            "segment": 4,
+            "timestamp_end": 1560000050.913754,
+            "timestamp_start": 1560000043.780359
+          },
+          {
+            "images": 432,
+            "max_m": 1.7734574749905712,
+            "median_m": 0.20630344879339735,
+            "p95_m": 0.21956543461236594,
+            "rmse_m": 0.23813583035788388,
+            "segment": 5,
+            "timestamp_end": 1560000058.113778,
+            "timestamp_start": 1560000050.947087
+          },
+          {
+            "images": 430,
+            "max_m": 0.21720479415061827,
+            "median_m": 0.18495599370567115,
+            "p95_m": 0.20867016359661666,
+            "rmse_m": 0.1878899021953068,
+            "segment": 6,
+            "timestamp_end": 1560000065.28046,
+            "timestamp_start": 1560000058.147112
+          },
+          {
+            "images": 430,
+            "max_m": 0.21040438982247434,
+            "median_m": 0.17644460730202183,
+            "p95_m": 0.1992312480320828,
+            "rmse_m": 0.17566478628325646,
+            "segment": 7,
+            "timestamp_end": 1560000072.46712,
+            "timestamp_start": 1560000065.313794
+          },
+          {
+            "images": 432,
+            "max_m": 0.408916477525652,
+            "median_m": 0.2191612830146134,
+            "p95_m": 0.40133017560710565,
+            "rmse_m": 0.2688884188619065,
+            "segment": 8,
+            "timestamp_end": 1560000079.667106,
+            "timestamp_start": 1560000072.500453
+          },
+          {
+            "images": 430,
+            "max_m": 0.7270466868474564,
+            "median_m": 0.27357372108385036,
+            "p95_m": 0.7021550179554233,
+            "rmse_m": 0.39238080494666266,
+            "segment": 9,
+            "timestamp_end": 1560000086.84128,
+            "timestamp_start": 1560000079.700439
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 4308,
+    "gt_scored_images": 4308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-5000.json",
+    "manifest_images": 5000,
+    "manifest_sha256": "ac9762deb0b3f0aed591d320e0441e8e739089105ac9e898ef9aca431bde875f",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 5000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 432,
+        "max_m": 0.506713268091604,
+        "median_m": 0.3562849784805559,
+        "p95_m": 0.5048184292840885,
+        "rmse_m": 0.3858309770468895,
+        "segment": 0,
+        "timestamp_end": 1560000022.233627,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 430,
+        "max_m": 0.527322363664105,
+        "median_m": 0.28707702596739604,
+        "p95_m": 0.3267461030326456,
+        "rmse_m": 0.2582182255838123,
+        "segment": 1,
+        "timestamp_end": 1560000029.39037,
+        "timestamp_start": 1560000022.26696
+      },
+      {
+        "images": 432,
+        "max_m": 0.3978846808335473,
+        "median_m": 0.08709586970835434,
+        "p95_m": 0.211408543788244,
+        "rmse_m": 0.14366827616037697,
+        "segment": 2,
+        "timestamp_end": 1560000036.590301,
+        "timestamp_start": 1560000029.423703
+      },
+      {
+        "images": 430,
+        "max_m": 0.2869387898446156,
+        "median_m": 0.2001175628945729,
+        "p95_m": 0.27304331106443824,
+        "rmse_m": 0.21298905981732408,
+        "segment": 3,
+        "timestamp_end": 1560000043.747026,
+        "timestamp_start": 1560000036.623635
+      },
+      {
+        "images": 430,
+        "max_m": 0.2683538076642539,
+        "median_m": 0.22539512806735046,
+        "p95_m": 0.2550038580987005,
+        "rmse_m": 0.22780244166811112,
+        "segment": 4,
+        "timestamp_end": 1560000050.913754,
+        "timestamp_start": 1560000043.780359
+      },
+      {
+        "images": 432,
+        "max_m": 1.7734574749905712,
+        "median_m": 0.20630344879339735,
+        "p95_m": 0.21956543461236594,
+        "rmse_m": 0.23813583035788388,
+        "segment": 5,
+        "timestamp_end": 1560000058.113778,
+        "timestamp_start": 1560000050.947087
+      },
+      {
+        "images": 430,
+        "max_m": 0.21720479415061827,
+        "median_m": 0.18495599370567115,
+        "p95_m": 0.20867016359661666,
+        "rmse_m": 0.1878899021953068,
+        "segment": 6,
+        "timestamp_end": 1560000065.28046,
+        "timestamp_start": 1560000058.147112
+      },
+      {
+        "images": 430,
+        "max_m": 0.21040438982247434,
+        "median_m": 0.17644460730202183,
+        "p95_m": 0.1992312480320828,
+        "rmse_m": 0.17566478628325646,
+        "segment": 7,
+        "timestamp_end": 1560000072.46712,
+        "timestamp_start": 1560000065.313794
+      },
+      {
+        "images": 432,
+        "max_m": 0.408916477525652,
+        "median_m": 0.2191612830146134,
+        "p95_m": 0.40133017560710565,
+        "rmse_m": 0.2688884188619065,
+        "segment": 8,
+        "timestamp_end": 1560000079.667106,
+        "timestamp_start": 1560000072.500453
+      },
+      {
+        "images": 430,
+        "max_m": 0.7270466868474564,
+        "median_m": 0.27357372108385036,
+        "p95_m": 0.7021550179554233,
+        "rmse_m": 0.39238080494666266,
+        "segment": 9,
+        "timestamp_end": 1560000086.84128,
+        "timestamp_start": 1560000079.700439
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model/component-000 --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/rig-manifest-5000.txt",
+  "geometry": [
+    {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model/component-000",
+      "image_poses": 5000,
+      "supported_images": 5000,
+      "unsupported_image_ids": [],
+      "landmarks": 34877,
+      "observations": 310757,
+      "mean_reprojection_px": 0.8373637632621903,
+      "observation_weighted_mean_reprojection_px": 0.8373637632621903,
+      "point_weighted_mean_reprojection_px": 0.7714273840375536,
+      "max_track_mean_reprojection_px": 3.921759608646246,
+      "max_reprojection_px": 3.9995252845996943,
+      "max_stored_mean_difference_px": 3.921759608646246,
+      "nonpositive_depth_observations": 0,
+      "tracks_with_multiple_keypoints_in_one_image": 0,
+      "excess_same_image_track_observations": 0,
+      "bidirectional_references_valid": true,
+      "rig": {
+        "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/rig-manifest-5000.txt",
+        "rig_frames": 2500,
+        "supported_rig_frames": 2500,
+        "unsupported_rig_frame_ids": [],
+        "max_inferred_rig_center_disagreement_m": 8.573196552916493e-11,
+        "max_inferred_rig_rotation_disagreement_deg": 0.0000017075472925031877,
+        "fixed_sensor_extrinsics_valid": true,
+        "track_connected_components": 2,
+        "track_connected_component_sizes": [
+          2499,
+          1
+        ],
+        "track_connected_component_frame_ranges": [
+          [
+            0,
+            2499
+          ],
+          [
+            1616,
+            1616
+          ]
+        ]
+      }
+    }
+  ],
+  "limits": [
+    "Both candidate runs exited zero and models match exactly; control matches Legacy exactly.",
+    "RMSE and maximum improve, but p95 and mean reprojection worsen versus paired Legacy. No all-quality gate or promotion.",
+    "5k derived mapper-only prefix, not independent native end-to-end.",
+    "No COLMAP speed or memory advantage established."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,19 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> PR103はhead `9f7cfeb` CI9成功後 `a82a4bb` にmerge、旧branch整理済み。
+> 現branch `feat/m8-ba-component-anchors`。既定OFFの
+> `--ba-anchor-disconnected-components` は既存固定poseのない各BA成分の最小frame IDを固定。
+> 選択順不変/既存anchor保持/単独poseテストと有効時native固定状態/rollbackテスト通過。
+> clippy/CLI check通過。build `36eb02159f88211fd2e57db75a43d9cadbb494ca`、release52.95秒。
+> binary SHA256 `779c6295f5cf62503790da530b9da3c3a1afcf3735e903fed9799501cb49db2b`。
+> 5k対照 `tier-5000-slice/anchored-control` はexit0、Legacy bytes一致、mapper53.417580秒。
+> 候補component-aはexit0、全5000画像。RMSE0.261284/最大1.773457 mへ改善するが、
+> p950.490866 m/再投影0.837364 pxは対照より悪化。全品質gate未達、既定化なし。
+> track成分2499/1、孤立frame1616。支持/正深度/固定rig正常。component-bもexit0、反復bytes一致。
+> 各追加anchor39。mapper53.641/62.541秒対control53.418秒で高速化主張なし。
+> 証跡 `m8-openloris-5000-component-anchors-v1.json`。次は品質の残差要因を調べる。
+> [設計と検証契約](openloris_ba_component_anchors.md)。既存mono scale/弱い幾何は別問題。
+
 > 現branch `diag/m8-ba-anchor-connectivity`、親PR102はCI実行中。
 > build `4fbb952b600d36bc312c04f97c076f0a3ee1c7f8` に既定OFFの
 > `VISLOC_SFM_TRACE_BA_CONNECTIVITY` を追加。実際のBA採用観測のlandmark-starで

--- a/docs/openloris_ba_component_anchors.md
+++ b/docs/openloris_ba_component_anchors.md
@@ -1,0 +1,31 @@
+# Native BA component anchoring — unmeasured candidate
+
+The certified 5k diagnostic found 306/20,000 pose/solve records without any
+path to a fixed pose through actual BA observations. The five largest
+anchor-distance changes all occurred in these components. This motivates
+an explicit `--ba-anchor-disconnected-components` arm, default off.
+
+Before solving, build a landmark-star graph from accepted observations.
+For each component without an existing fixed pose, fix its lowest frame ID
+at its current pose. Existing fixed poses are preserved. Pose IDs without
+observations are singleton components. Selection is deterministic and does
+not use GT, trajectory jumps, reprojection threshold sweeps or solve failure.
+Graph storage is linear in observations, landmarks and poses; no pose clique
+or dense global matrix is added. Existing solver policy remains unchanged.
+
+This removes a component's rigid gauge but is not a general rank or quality
+guarantee: monocular scale, weak geometry and incorrect initial placement
+can remain. Ceres documents SfM gauge ambiguity and the distinction between
+structural and numerical rank deficiency in its
+[official covariance documentation](https://raw.githubusercontent.com/ceres-solver/ceres-solver/master/docs/source/nnls_covariance.rst).
+That source motivates handling gauge explicitly; it does not certify our
+frame-selection rule or this candidate's reconstruction quality.
+
+Validation: test independent/stereo-only/no-observation components,
+existing anchors and input-order invariance; then native fixed-state checks.
+Run a same-binary Legacy control and two candidate repeats with unchanged
+5k inputs. Audit registration, depth, calibration, reprojection, whole-model
+GT scoring and repeatability. Do not remove outlier images or separately
+align disconnected track components. If useful, run the independent tier
+ladder and 10k; 5k is a derived mapper-only slice, not native E2E evidence.
+Frame 1416 already deforms while connected, so this is not presumed sufficient.

--- a/docs/openloris_ba_component_anchors.md
+++ b/docs/openloris_ba_component_anchors.md
@@ -1,4 +1,19 @@
-# Native BA component anchoring — unmeasured candidate
+# Native BA component anchoring — mixed quality, not promoted
+
+## First paired 5k result
+
+Same-binary control matches historical Legacy bytes. Both candidate repeats
+match exactly and register all 5,000 images, adding 39 component anchors each.
+RMSE improves 0.477216 → 0.261284 m and maximum 10.094671 → 1.773457 m.
+However p95 worsens 0.478983 → 0.490866 m and raw mean reprojection worsens
+0.831377 → 0.837364 px. This does not pass an all-quality nonregression gate.
+Every image has support; depth and fixed rig calibration are valid. Published
+track components change from 2495/2/2/1 frames to 2499/1 (singleton 1616).
+Mapper seconds: control 53.417580, candidates 53.641363 / 62.541108.
+No speedup, large-tier or native-E2E claim. Keep default off; do not select
+alternative anchors or thresholds using GT. Diagnose remaining geometric
+weakness before extending or promoting this arm.
+[Commands, repeat audit and independent scores](../benchmarks/electro/m8-openloris-5000-component-anchors-v1.json).
 
 The certified 5k diagnostic found 306/20,000 pose/solve records without any
 path to a fixed pose through actual BA observations. The five largest

--- a/examples/generalized_rig_sfm.rs
+++ b/examples/generalized_rig_sfm.rs
@@ -124,6 +124,7 @@ struct Args {
     final_ba_min_pose_observations: usize,
     ba_huber_delta: f64,
     ba_backend: RigBaBackend,
+    ba_anchor_disconnected_components: bool,
     structure_refinement_iterations: usize,
     preview_rig_correspondence_csr: bool,
     preview_pair_confidence_conflicts: bool,
@@ -246,6 +247,7 @@ fn parse_args() -> Result<Args, String> {
     let mut final_ba_min_pose_observations = defaults.final_ba_min_pose_observations;
     let mut ba_huber_delta = 6.0;
     let mut ba_backend = defaults.ba_backend;
+    let mut ba_anchor_disconnected_components = defaults.ba_anchor_disconnected_components;
     let mut ba_backend_seen = false;
     let mut structure_refinement_iterations = defaults.structure_refinement_iterations;
     let mut preview_rig_correspondence_csr = false;
@@ -557,6 +559,7 @@ fn parse_args() -> Result<Args, String> {
                 ba_backend_seen = true;
                 ba_backend = parse_ba_backend(&value()?)?;
             }
+            "--ba-anchor-disconnected-components" => ba_anchor_disconnected_components = true,
             "--structure-refinement-iterations" => {
                 structure_refinement_iterations =
                     value()?.parse().map_err(|error| format!("{error}"))?
@@ -616,6 +619,7 @@ fn parse_args() -> Result<Args, String> {
                     "[--local-ba-every 10] [--local-ba-window 40] ",
                     "[--local-ba-iterations 8] [--ba-huber-delta 6] ",
                     "[--ba-backend legacy|matrix-free|matrix-free-cluster8|matrix-free-cluster8-restart1|matrix-free-qr|bounded-direct64-qr] ",
+                    "[--ba-anchor-disconnected-components] ",
                     "[--structure-refinement-iterations 5] ",
                     "[--metric-anchored-cycle-tracks|--metric-temporal-cycle-tracks|",
                     "--metric-sparse-cycle-tracks|",
@@ -907,6 +911,7 @@ fn parse_args() -> Result<Args, String> {
         final_ba_min_pose_observations,
         ba_huber_delta,
         ba_backend,
+        ba_anchor_disconnected_components,
         structure_refinement_iterations,
         preview_rig_correspondence_csr,
         preview_pair_confidence_conflicts,
@@ -1686,6 +1691,7 @@ fn mapper_config(args: &Args) -> RigSfmConfig {
         ba_metric_tracks_only: args.ba_metric_tracks_only,
         final_ba_min_pose_observations: args.final_ba_min_pose_observations,
         ba_backend: args.ba_backend,
+        ba_anchor_disconnected_components: args.ba_anchor_disconnected_components,
         structure_refinement_iterations: args.structure_refinement_iterations,
         dynamic_correspondence_tracking: args.dynamic_correspondence_tracking,
         ba_config: visloc_rs::BaConfig {

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -237,6 +237,9 @@ pub struct RigSfmConfig {
     pub final_ba_min_pose_observations: usize,
     pub final_bundle_adjustment: bool,
     pub ba_backend: RigBaBackend,
+    /// Fix the lowest frame ID in each BA observation component lacking a
+    /// fixed pose. Removes its rigid gauge, not every possible degeneracy.
+    pub ba_anchor_disconnected_components: bool,
     pub ba_config: BaConfig,
     pub local_ba_every: usize,
     pub local_ba_window_size: usize,
@@ -311,6 +314,7 @@ impl Default for RigSfmConfig {
             final_ba_min_pose_observations: 0,
             final_bundle_adjustment: true,
             ba_backend: RigBaBackend::Legacy,
+            ba_anchor_disconnected_components: false,
             ba_config: BaConfig {
                 linear_solver: LinearSolver::Sparse,
                 robust_kernel: RobustKernel::Huber { delta: 6.0 },
@@ -4681,10 +4685,9 @@ fn run_windowed_final_ba(
     Ok(aggregate)
 }
 
-fn rig_ba_anchor_reachable(
+fn rig_ba_pose_edges(
     observations: impl IntoIterator<Item = (u64, u64)>,
-    fixed: impl IntoIterator<Item = u64>,
-) -> BTreeSet<u64> {
+) -> BTreeMap<u64, Vec<u64>> {
     // A landmark star preserves connectivity without a pose-pair clique.
     // Storage is O(observations + landmarks + poses), never O(poses squared).
     let mut first = BTreeMap::new();
@@ -4696,6 +4699,14 @@ fn rig_ba_anchor_reachable(
             edges.entry(representative).or_default().push(pose);
         }
     }
+    edges
+}
+
+fn rig_ba_anchor_reachable(
+    observations: impl IntoIterator<Item = (u64, u64)>,
+    fixed: impl IntoIterator<Item = u64>,
+) -> BTreeSet<u64> {
+    let edges = rig_ba_pose_edges(observations);
     let mut reached: BTreeSet<_> = fixed.into_iter().collect();
     let mut pending: Vec<_> = reached.iter().copied().collect();
     while let Some(pose) = pending.pop() {
@@ -4708,6 +4719,38 @@ fn rig_ba_anchor_reachable(
         }
     }
     reached
+}
+
+fn rig_ba_component_anchors(
+    observations: impl IntoIterator<Item = (u64, u64)>,
+    poses: impl IntoIterator<Item = u64>,
+    fixed: &BTreeSet<u64>,
+) -> Vec<u64> {
+    let edges = rig_ba_pose_edges(observations);
+    let poses: BTreeSet<_> = poses.into_iter().collect();
+    let mut visited = BTreeSet::new();
+    let mut anchors = Vec::new();
+    for pose in poses {
+        if !visited.insert(pose) {
+            continue;
+        }
+        let mut has_fixed = false;
+        let mut pending = vec![pose];
+        while let Some(current) = pending.pop() {
+            has_fixed |= fixed.contains(&current);
+            if let Some(neighbors) = edges.get(&current) {
+                for &neighbor in neighbors {
+                    if visited.insert(neighbor) {
+                        pending.push(neighbor);
+                    }
+                }
+            }
+        }
+        if !has_fixed {
+            anchors.push(pose);
+        }
+    }
+    anchors
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4817,6 +4860,20 @@ fn run_rig_bundle_adjustment(
         }
     }
     let mut matrix_free_report = None;
+    if config.ba_anchor_disconnected_components {
+        let anchors = rig_ba_component_anchors(
+            problem
+                .rig_observations
+                .iter()
+                .map(|o| (o.keyframe_id, o.landmark_id)),
+            problem.poses.keys().copied(),
+            &problem.fixed_poses,
+        );
+        for id in anchors {
+            problem.fix_pose(id);
+            eprintln!("rig-ba-component-anchor: frame={id} original_anchor={anchor_frame_index}");
+        }
+    }
     if std::env::var_os("VISLOC_SFM_TRACE_BA_CONNECTIVITY").is_some() {
         let reached = rig_ba_anchor_reachable(
             problem
@@ -9147,6 +9204,23 @@ mod tests {
     }
 
     #[test]
+    fn component_anchors_preserve_fixed_components_and_are_order_independent() {
+        let observations = [(0, 10), (1, 10), (2, 11), (3, 11), (4, 12), (4, 12)];
+        let fixed = BTreeSet::from([1]);
+        assert_eq!(
+            rig_ba_component_anchors(observations, 0..6, &fixed),
+            vec![2, 4, 5]
+        );
+        assert_eq!(
+            rig_ba_component_anchors(observations.into_iter().rev(), (0..6).rev(), &fixed),
+            vec![2, 4, 5]
+        );
+        let all_fixed = BTreeSet::from([1, 3, 4, 5]);
+        assert!(rig_ba_component_anchors(observations, 0..6, &all_fixed).is_empty());
+        assert!(!RigSfmConfig::default().ba_anchor_disconnected_components);
+    }
+
+    #[test]
     fn bounded_policy_selects_before_solve_and_preserves_fixed_state() {
         for n in [0, 1, 63, 64] {
             assert_eq!(
@@ -9168,6 +9242,18 @@ mod tests {
     }
 
     fn check_fixed_rotation_backend(backend: RigBaBackend) {
+        check_fixed_rotation_backend_with_component_anchors(backend, false);
+    }
+
+    #[test]
+    fn component_anchoring_native_preserves_fixed_state_and_rollback() {
+        check_fixed_rotation_backend_with_component_anchors(RigBaBackend::BoundedDirect64Qr, true);
+    }
+
+    fn check_fixed_rotation_backend_with_component_anchors(
+        backend: RigBaBackend,
+        component_anchors: bool,
+    ) {
         let rig = GeneralizedCameraRig::new(vec![
             RigSensor {
                 camera: Camera::pinhole(1, 848, 800, 285.0, 286.0, 425.5, 398.5),
@@ -9288,6 +9374,7 @@ mod tests {
             / world_points.len() as f64;
         let active_frames = HashSet::from([0, 1]);
         let config = RigSfmConfig {
+            ba_anchor_disconnected_components: component_anchors,
             final_bundle_adjustment: false,
             structure_refinement_iterations: 0,
             ..RigSfmConfig::default()


### PR DESCRIPTION
Default-off component gauge anchoring via actual sparse BA observations, preserving existing fixed poses. Deterministic selection and enabled native fixed-state tests pass; clippy and CLI check pass. Paired 5k control matches Legacy, both candidate repeats match exactly. Full registration; RMSE/max improve but p95/reprojection worsen, so no quality promotion or performance claim. Evidence and limitations included. Full goal remains open.