### PR TITLE
feat: fixed boundary observations for native rig BA

### DIFF
--- a/benchmarks/electro/m8-openloris-1000-fixed-boundary-v1.json
+++ b/benchmarks/electro/m8-openloris-1000-fixed-boundary-v1.json
@@ -1,0 +1,336 @@
+{
+  "schema": "m8-openloris-1000-fixed-boundary-v1",
+  "status": "repeatable-native-quality-nonregression",
+  "build_commit": "7d99e07dbdbc95bc72d2e28805a75e51dbcd7270",
+  "binary_sha256": "d87194e92b472b9d74fd8d2e43d41faad5766f330afc3a6e9155c41816277d72",
+  "commands": {
+    "control": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control.log 2>&1",
+    "candidate-a": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a.log 2>&1",
+    "candidate-b": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b.log 2>&1"
+  },
+  "audit_program": "import json,re,hashlib\nfrom pathlib import Path\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1\")\nruns={}\nfor arm in (\"control\",\"candidate-a\",\"candidate-b\"):\n root=b/\"boundary-1k\"\n log=(root/(arm+\".log\")).read_text(); time=(root/(arm+\".time\")).read_text()\n assert \"Exit status: 0\" in time\n hashes={}\n for n in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n  data=(root/arm/\"model\"/n).read_bytes()\n  ref=b/\"legacy/model\" if arm==\"control\" else root/\"candidate-a/model\"\n  assert data==(ref/n).read_bytes()\n  hashes[n]=hashlib.sha256(data).hexdigest()\n assert \"registered_frames=500/500 registered_images=1000/1000\" in log\n runs[arm]=dict(model_sha256=hashes,mapper_seconds=float(re.search(r\"mapper_seconds=([0-9.]+)\",log)[1]),peak_rss_kib=int(re.search(r\"Maximum resident set size \\(kbytes\\): (\\d+)\",time)[1]),log=log,time_output=time)\nprint(json.dumps(runs))\n",
+  "runs": {
+    "control": {
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "937098610a0ec29c37bbc9c649e9385050d9ce6782f3154fcc2c02613281b8ee",
+        "points3D.txt": "11eb71b6a45f248770429a91a8841e64e028089350515f3f87366c468ae399af"
+      },
+      "mapper_seconds": 4.099038,
+      "peak_rss_kib": 82124,
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62424 KiB\nrig-replay BA: observations=120217 cost=267541.992667814->121458.389207945 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2658 observations=27716 mean_reprojection_px=0.671637382 seed_frame=26 mapper_seconds=4.099038 total_seconds=4.629451 VmHWM_KiB=82288 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=39217 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=29751 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2607 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/control/model\"\n\tUser time (seconds): 4.55\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:04.64\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82124\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23494\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 14\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7288\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+    },
+    "candidate-a": {
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "8849640e29a8e94f4b20eb7ff9ce542ad194714ec7134e63ce3aa4f0c4168122",
+        "points3D.txt": "5970f03895ac543a8624c1314690ca4a151a60f01bac131e59541e31fe5e217e"
+      },
+      "mapper_seconds": 5.574751,
+      "peak_rss_kib": 82576,
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62416 KiB\nrig-replay BA: observations=291504 cost=262276.462417485->261599.474569850 iterations=266 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2758 observations=28696 mean_reprojection_px=0.627506460 seed_frame=26 mapper_seconds=5.574751 total_seconds=6.105724 VmHWM_KiB=82844 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=39033 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=29585 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=1322 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model\"\n\tUser time (seconds): 6.03\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:06.11\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82576\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23650\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 35\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7320\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+    },
+    "candidate-b": {
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "8849640e29a8e94f4b20eb7ff9ce542ad194714ec7134e63ce3aa4f0c4168122",
+        "points3D.txt": "5970f03895ac543a8624c1314690ca4a151a60f01bac131e59541e31fe5e217e"
+      },
+      "mapper_seconds": 5.557141,
+      "peak_rss_kib": 82668,
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62424 KiB\nrig-replay BA: observations=291504 cost=262276.462417485->261599.474569850 iterations=266 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2758 observations=28696 mean_reprojection_px=0.627506460 seed_frame=26 mapper_seconds=5.557141 total_seconds=6.087114 VmHWM_KiB=82916 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=39033 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=29585 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=1322 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-b/model\"\n\tUser time (seconds): 6.01\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:06.09\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82668\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23650\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 30\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7320\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+    }
+  },
+  "score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "score": {
+    "component_weighted_max_m": 0.07290876821176002,
+    "component_weighted_median_m": 0.019407956146758748,
+    "component_weighted_p95_m": 0.03579905266275042,
+    "component_weighted_rmse_m": 0.022320363846997007,
+    "components": [
+      {
+        "gt_scored": 308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model/images.txt",
+        "images_txt_sha256": "8849640e29a8e94f4b20eb7ff9ce542ad194714ec7134e63ce3aa4f0c4168122",
+        "max_m": 0.07290876821176002,
+        "median_m": 0.019407956146758748,
+        "p95_m": 0.03579905266275042,
+        "reference_extent_m": 1.9718678959594034,
+        "registered": 1000,
+        "relative_rmse": 0.011319401209753523,
+        "rmse_m": 0.022320363846997007,
+        "sim3_scale": 1.1054060145069151,
+        "trajectory_segments": [
+          {
+            "images": 32,
+            "max_m": 0.025364634458811378,
+            "median_m": 0.020318432726648482,
+            "p95_m": 0.02448626203975152,
+            "rmse_m": 0.021035409564353735,
+            "segment": 0,
+            "timestamp_end": 1560000015.556828,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 30,
+            "max_m": 0.0260919974096313,
+            "median_m": 0.02147862657936666,
+            "p95_m": 0.02585999220892259,
+            "rmse_m": 0.021605379654804097,
+            "segment": 1,
+            "timestamp_end": 1560000016.056906,
+            "timestamp_start": 1560000015.590162
+          },
+          {
+            "images": 32,
+            "max_m": 0.025307700049190786,
+            "median_m": 0.011616296967643238,
+            "p95_m": 0.02128426341977138,
+            "rmse_m": 0.013387966157220321,
+            "segment": 2,
+            "timestamp_end": 1560000016.590147,
+            "timestamp_start": 1560000016.09024
+          },
+          {
+            "images": 30,
+            "max_m": 0.024522378321110542,
+            "median_m": 0.014906853636550537,
+            "p95_m": 0.023758982512368968,
+            "rmse_m": 0.017117771181377462,
+            "segment": 3,
+            "timestamp_end": 1560000017.09023,
+            "timestamp_start": 1560000016.623481
+          },
+          {
+            "images": 30,
+            "max_m": 0.03932352747156344,
+            "median_m": 0.030802477429595364,
+            "p95_m": 0.03602333066094054,
+            "rmse_m": 0.03119316288762792,
+            "segment": 4,
+            "timestamp_end": 1560000017.590167,
+            "timestamp_start": 1560000017.123563
+          },
+          {
+            "images": 32,
+            "max_m": 0.030764793214940394,
+            "median_m": 0.02362445231321761,
+            "p95_m": 0.028437493033856114,
+            "rmse_m": 0.023305563416301966,
+            "segment": 5,
+            "timestamp_end": 1560000018.123552,
+            "timestamp_start": 1560000017.623501
+          },
+          {
+            "images": 30,
+            "max_m": 0.024176872681516956,
+            "median_m": 0.014224374513265803,
+            "p95_m": 0.023707267650807665,
+            "rmse_m": 0.015816308929566536,
+            "segment": 6,
+            "timestamp_end": 1560000018.623534,
+            "timestamp_start": 1560000018.156885
+          },
+          {
+            "images": 30,
+            "max_m": 0.04148168967057716,
+            "median_m": 0.015087377639389103,
+            "p95_m": 0.03427766077843515,
+            "rmse_m": 0.019227536416593763,
+            "segment": 7,
+            "timestamp_end": 1560000019.123582,
+            "timestamp_start": 1560000018.656868
+          },
+          {
+            "images": 32,
+            "max_m": 0.07290876821176002,
+            "median_m": 0.017135425112421145,
+            "p95_m": 0.06341410099584521,
+            "rmse_m": 0.03389074394287479,
+            "segment": 8,
+            "timestamp_end": 1560000019.666914,
+            "timestamp_start": 1560000019.156915
+          },
+          {
+            "images": 30,
+            "max_m": 0.03028168709457916,
+            "median_m": 0.015161046325324178,
+            "p95_m": 0.0290511687877697,
+            "rmse_m": 0.017160222796289416,
+            "segment": 9,
+            "timestamp_end": 1560000020.166894,
+            "timestamp_start": 1560000019.700247
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 308,
+    "gt_scored_images": 308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+    "manifest_images": 1000,
+    "manifest_sha256": "f1ed9292c806103c1d129340f429bc74e5ba4842c6092b836d541cd518256baa",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 1000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 32,
+        "max_m": 0.025364634458811378,
+        "median_m": 0.020318432726648482,
+        "p95_m": 0.02448626203975152,
+        "rmse_m": 0.021035409564353735,
+        "segment": 0,
+        "timestamp_end": 1560000015.556828,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 30,
+        "max_m": 0.0260919974096313,
+        "median_m": 0.02147862657936666,
+        "p95_m": 0.02585999220892259,
+        "rmse_m": 0.021605379654804097,
+        "segment": 1,
+        "timestamp_end": 1560000016.056906,
+        "timestamp_start": 1560000015.590162
+      },
+      {
+        "images": 32,
+        "max_m": 0.025307700049190786,
+        "median_m": 0.011616296967643238,
+        "p95_m": 0.02128426341977138,
+        "rmse_m": 0.013387966157220321,
+        "segment": 2,
+        "timestamp_end": 1560000016.590147,
+        "timestamp_start": 1560000016.09024
+      },
+      {
+        "images": 30,
+        "max_m": 0.024522378321110542,
+        "median_m": 0.014906853636550537,
+        "p95_m": 0.023758982512368968,
+        "rmse_m": 0.017117771181377462,
+        "segment": 3,
+        "timestamp_end": 1560000017.09023,
+        "timestamp_start": 1560000016.623481
+      },
+      {
+        "images": 30,
+        "max_m": 0.03932352747156344,
+        "median_m": 0.030802477429595364,
+        "p95_m": 0.03602333066094054,
+        "rmse_m": 0.03119316288762792,
+        "segment": 4,
+        "timestamp_end": 1560000017.590167,
+        "timestamp_start": 1560000017.123563
+      },
+      {
+        "images": 32,
+        "max_m": 0.030764793214940394,
+        "median_m": 0.02362445231321761,
+        "p95_m": 0.028437493033856114,
+        "rmse_m": 0.023305563416301966,
+        "segment": 5,
+        "timestamp_end": 1560000018.123552,
+        "timestamp_start": 1560000017.623501
+      },
+      {
+        "images": 30,
+        "max_m": 0.024176872681516956,
+        "median_m": 0.014224374513265803,
+        "p95_m": 0.023707267650807665,
+        "rmse_m": 0.015816308929566536,
+        "segment": 6,
+        "timestamp_end": 1560000018.623534,
+        "timestamp_start": 1560000018.156885
+      },
+      {
+        "images": 30,
+        "max_m": 0.04148168967057716,
+        "median_m": 0.015087377639389103,
+        "p95_m": 0.03427766077843515,
+        "rmse_m": 0.019227536416593763,
+        "segment": 7,
+        "timestamp_end": 1560000019.123582,
+        "timestamp_start": 1560000018.656868
+      },
+      {
+        "images": 32,
+        "max_m": 0.07290876821176002,
+        "median_m": 0.017135425112421145,
+        "p95_m": 0.06341410099584521,
+        "rmse_m": 0.03389074394287479,
+        "segment": 8,
+        "timestamp_end": 1560000019.666914,
+        "timestamp_start": 1560000019.156915
+      },
+      {
+        "images": 30,
+        "max_m": 0.03028168709457916,
+        "median_m": 0.015161046325324178,
+        "p95_m": 0.0290511687877697,
+        "rmse_m": 0.017160222796289416,
+        "segment": 9,
+        "timestamp_end": 1560000020.166894,
+        "timestamp_start": 1560000019.700247
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+  "geometry": [
+    {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/boundary-1k/candidate-a/model",
+      "image_poses": 1000,
+      "supported_images": 1000,
+      "unsupported_image_ids": [],
+      "landmarks": 2758,
+      "observations": 28696,
+      "mean_reprojection_px": 0.6275064597556841,
+      "observation_weighted_mean_reprojection_px": 0.6275064597556841,
+      "point_weighted_mean_reprojection_px": 0.683020087201587,
+      "max_track_mean_reprojection_px": 3.3404063667271955,
+      "max_reprojection_px": 3.9946924047050105,
+      "max_stored_mean_difference_px": 3.3404063667271955,
+      "nonpositive_depth_observations": 0,
+      "tracks_with_multiple_keypoints_in_one_image": 0,
+      "excess_same_image_track_observations": 0,
+      "bidirectional_references_valid": true,
+      "rig": {
+        "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+        "rig_frames": 500,
+        "supported_rig_frames": 500,
+        "unsupported_rig_frame_ids": [],
+        "max_inferred_rig_center_disagreement_m": 4.064302840975175e-12,
+        "max_inferred_rig_rotation_disagreement_deg": 0.0000012074182697257333,
+        "fixed_sensor_extrinsics_valid": true,
+        "track_connected_components": 1,
+        "track_connected_component_sizes": [
+          500
+        ],
+        "track_connected_component_frame_ranges": [
+          [
+            0,
+            499
+          ]
+        ]
+      }
+    }
+  ],
+  "limits": [
+    "Mapper-only; not native end-to-end or 10k parity proof.",
+    "Control bytes match certified Legacy and candidate repeats match exactly.",
+    "GT scored after mapping only; no thresholds or combinations tuned."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-2500-fixed-boundary-v1.json
+++ b/benchmarks/electro/m8-openloris-2500-fixed-boundary-v1.json
@@ -1,0 +1,303 @@
+{
+  "schema": "m8-openloris-2500-fixed-boundary-v1",
+  "status": "repeatable-quality-improvement-slower-mapper",
+  "audit_program": "import json,re,hashlib\nfrom pathlib import Path\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann\")\nruns={}\nfor arm in (\"boundary-control\",\"boundary-a\",\"boundary-b\"):\n log=(b/(arm+\".log\")).read_text();time=(b/(arm+\".time\")).read_text()\n assert \"Exit status: 0\" in time,arm\n hashes={}\n for n in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n  data=(b/arm/\"model/component-000\"/n).read_bytes()\n  hashes[n]=hashlib.sha256(data).hexdigest()\n  ref=\"legacy\" if arm==\"boundary-control\" else \"boundary-a\"\n  assert data==(b/ref/\"model/component-000\"/n).read_bytes(),(arm,n)\n result=[l for l in log.splitlines() if l.startswith(\"rig-multimodel result:\")][-1]\n assert \"registered_frames=1250/1250 registered_images=2500/2500\" in result\n runs[arm]=dict(model_sha256=hashes,mapper_seconds=float(re.search(r\"mapper_seconds=([0-9.]+)\",result)[1]),peak_rss_kib=int(re.search(r\"Maximum resident set size \\(kbytes\\): (\\d+)\",time)[1]),added_anchors=len(re.findall(r\"^rig-ba-boundary-anchor:\",log,re.M)),result=result,time_output=time,log_sha256=hashlib.sha256(log.encode()).hexdigest())\nprint(json.dumps(dict(control_exact_to_legacy=True,candidate_repeats_exact=True,runs=runs),indent=2))\n",
+  "audit": {"control_exact_to_legacy":true,"candidate_repeats_exact":true,"runs":{"boundary-control":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"27d9a7b13491bc07883d1ac5ca22bdf24b67d0e6f645df59b4b9fdd46021e9e9","points3D.txt":"fb3f5a1f72988516060de30db18886360be15356064d1e6489d0750e3a41e066"},"mapper_seconds":36.262899,"peak_rss_kib":412848,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=1250/1250 registered_images=2500/2500 tracks=15937 observations=200975 mean_reprojection_px=0.788548738 mapper_seconds=36.262899 VmHWM_KiB=412848 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features-2500 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 36.95\n\tSystem time (seconds): 0.40\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:37.37\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 412848\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 117867\n\tVoluntary context switches: 6\n\tInvoluntary context switches: 200\n\tSwaps: 0\n\tFile system inputs: 480\n\tFile system outputs: 50000\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"7d3db10e65180d4d88c81317b6d0c13b20ac920eb10ce34938f18552025f60d0"},"boundary-a":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"8376836b437982a0f9983f476965732d33fd4c216fe11e03c374c0e843747b8e","points3D.txt":"ff5fce467daf3f862bd91bba7f08fb44ac97d7b9edd144dc4f05392b2da56997"},"mapper_seconds":50.634806,"peak_rss_kib":414132,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=1250/1250 registered_images=2500/2500 tracks=16216 observations=209789 mean_reprojection_px=0.778608078 mapper_seconds=50.634806 VmHWM_KiB=414132 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features-2500 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 51.26\n\tSystem time (seconds): 0.37\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:51.65\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 414132\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 118107\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 311\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 50208\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"063c7c27737d598e2539538ed2c455b90e0b598f1158c26d34de5b1964457bbd"},"boundary-b":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"8376836b437982a0f9983f476965732d33fd4c216fe11e03c374c0e843747b8e","points3D.txt":"ff5fce467daf3f862bd91bba7f08fb44ac97d7b9edd144dc4f05392b2da56997"},"mapper_seconds":50.015505,"peak_rss_kib":413672,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=1250/1250 registered_images=2500/2500 tracks=16216 observations=209789 mean_reprojection_px=0.778608078 mapper_seconds=50.015505 VmHWM_KiB=413672 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features-2500 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 50.66\n\tSystem time (seconds): 0.46\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:51.12\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 413672\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 118104\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 181\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 50208\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"6b0bc89a306dfe3a2f853f5505d211dff1e3c6b8cf4be1de1bb9417c19180890"}}},
+  "build_commit": "7d99e07dbdbc95bc72d2e28805a75e51dbcd7270",
+  "binary_sha256": "d87194e92b472b9d74fd8d2e43d41faad5766f330afc3a6e9155c41816277d72",
+  "commands": {
+    "boundary-control": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features-2500 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-control.log 2>&1",
+    "boundary-a": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features-2500 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a.log 2>&1",
+    "boundary-b": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features-2500 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-b.log 2>&1"
+  },
+  "score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model/component-000/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-2500.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "score": {
+    "component_weighted_max_m": 0.23897972300382764,
+    "component_weighted_median_m": 0.04441556308782537,
+    "component_weighted_p95_m": 0.13444919036954772,
+    "component_weighted_rmse_m": 0.0678533793554845,
+    "components": [
+      {
+        "gt_scored": 1808,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model/component-000/images.txt",
+        "images_txt_sha256": "8376836b437982a0f9983f476965732d33fd4c216fe11e03c374c0e843747b8e",
+        "max_m": 0.23897972300382764,
+        "median_m": 0.04441556308782537,
+        "p95_m": 0.13444919036954772,
+        "reference_extent_m": 11.886290399938378,
+        "registered": 2500,
+        "relative_rmse": 0.005708541275067305,
+        "rmse_m": 0.0678533793554845,
+        "sim3_scale": 1.005600566360447,
+        "trajectory_segments": [
+          {
+            "images": 182,
+            "max_m": 0.06480689916570728,
+            "median_m": 0.05792557628224364,
+            "p95_m": 0.0626704537283566,
+            "rmse_m": 0.052123044982255944,
+            "segment": 0,
+            "timestamp_end": 1560000018.056885,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 180,
+            "max_m": 0.23897972300382764,
+            "median_m": 0.12368482119875134,
+            "p95_m": 0.2069264499363809,
+            "rmse_m": 0.13263581752067688,
+            "segment": 1,
+            "timestamp_end": 1560000021.066952,
+            "timestamp_start": 1560000018.090218
+          },
+          {
+            "images": 182,
+            "max_m": 0.1030752646187911,
+            "median_m": 0.07035738288915153,
+            "p95_m": 0.09858378405729754,
+            "rmse_m": 0.07409401022966838,
+            "segment": 2,
+            "timestamp_end": 1560000024.090256,
+            "timestamp_start": 1560000021.100285
+          },
+          {
+            "images": 180,
+            "max_m": 0.13640565120059,
+            "median_m": 0.1131321994121473,
+            "p95_m": 0.13412190819879138,
+            "rmse_m": 0.10763826658991406,
+            "segment": 3,
+            "timestamp_end": 1560000027.100339,
+            "timestamp_start": 1560000024.123589
+          },
+          {
+            "images": 180,
+            "max_m": 0.0905960814044828,
+            "median_m": 0.051994517936544374,
+            "p95_m": 0.08471869413053529,
+            "rmse_m": 0.05847283492932296,
+            "segment": 4,
+            "timestamp_end": 1560000030.090238,
+            "timestamp_start": 1560000027.133672
+          },
+          {
+            "images": 182,
+            "max_m": 0.07571708421490732,
+            "median_m": 0.03334421810980163,
+            "p95_m": 0.06526413713131012,
+            "rmse_m": 0.04203667961031847,
+            "segment": 5,
+            "timestamp_end": 1560000033.123619,
+            "timestamp_start": 1560000030.123572
+          },
+          {
+            "images": 180,
+            "max_m": 0.057797371799831215,
+            "median_m": 0.007483803186113544,
+            "p95_m": 0.04451627386322267,
+            "rmse_m": 0.01709264902928753,
+            "segment": 6,
+            "timestamp_end": 1560000036.123641,
+            "timestamp_start": 1560000033.156953
+          },
+          {
+            "images": 180,
+            "max_m": 0.03593433562708534,
+            "median_m": 0.006546340895452359,
+            "p95_m": 0.01911233729989187,
+            "rmse_m": 0.00977577737830678,
+            "segment": 7,
+            "timestamp_end": 1560000039.123629,
+            "timestamp_start": 1560000036.156975
+          },
+          {
+            "images": 182,
+            "max_m": 0.08646034292947094,
+            "median_m": 0.0324803795200114,
+            "p95_m": 0.0808623006373772,
+            "rmse_m": 0.03965559005215818,
+            "segment": 8,
+            "timestamp_end": 1560000042.146964,
+            "timestamp_start": 1560000039.156962
+          },
+          {
+            "images": 180,
+            "max_m": 0.09293509264890325,
+            "median_m": 0.026872662845027234,
+            "p95_m": 0.0703090171072792,
+            "rmse_m": 0.0398209459939577,
+            "segment": 9,
+            "timestamp_end": 1560000045.147009,
+            "timestamp_start": 1560000042.180298
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 1808,
+    "gt_scored_images": 1808,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-2500.json",
+    "manifest_images": 2500,
+    "manifest_sha256": "b05a280dd4cc1279bda064b6f52f9207e67e0ebcfb892e516ebe4aa8e98eddf1",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 2500,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 182,
+        "max_m": 0.06480689916570728,
+        "median_m": 0.05792557628224364,
+        "p95_m": 0.0626704537283566,
+        "rmse_m": 0.052123044982255944,
+        "segment": 0,
+        "timestamp_end": 1560000018.056885,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 180,
+        "max_m": 0.23897972300382764,
+        "median_m": 0.12368482119875134,
+        "p95_m": 0.2069264499363809,
+        "rmse_m": 0.13263581752067688,
+        "segment": 1,
+        "timestamp_end": 1560000021.066952,
+        "timestamp_start": 1560000018.090218
+      },
+      {
+        "images": 182,
+        "max_m": 0.1030752646187911,
+        "median_m": 0.07035738288915153,
+        "p95_m": 0.09858378405729754,
+        "rmse_m": 0.07409401022966838,
+        "segment": 2,
+        "timestamp_end": 1560000024.090256,
+        "timestamp_start": 1560000021.100285
+      },
+      {
+        "images": 180,
+        "max_m": 0.13640565120059,
+        "median_m": 0.1131321994121473,
+        "p95_m": 0.13412190819879138,
+        "rmse_m": 0.10763826658991406,
+        "segment": 3,
+        "timestamp_end": 1560000027.100339,
+        "timestamp_start": 1560000024.123589
+      },
+      {
+        "images": 180,
+        "max_m": 0.0905960814044828,
+        "median_m": 0.051994517936544374,
+        "p95_m": 0.08471869413053529,
+        "rmse_m": 0.05847283492932296,
+        "segment": 4,
+        "timestamp_end": 1560000030.090238,
+        "timestamp_start": 1560000027.133672
+      },
+      {
+        "images": 182,
+        "max_m": 0.07571708421490732,
+        "median_m": 0.03334421810980163,
+        "p95_m": 0.06526413713131012,
+        "rmse_m": 0.04203667961031847,
+        "segment": 5,
+        "timestamp_end": 1560000033.123619,
+        "timestamp_start": 1560000030.123572
+      },
+      {
+        "images": 180,
+        "max_m": 0.057797371799831215,
+        "median_m": 0.007483803186113544,
+        "p95_m": 0.04451627386322267,
+        "rmse_m": 0.01709264902928753,
+        "segment": 6,
+        "timestamp_end": 1560000036.123641,
+        "timestamp_start": 1560000033.156953
+      },
+      {
+        "images": 180,
+        "max_m": 0.03593433562708534,
+        "median_m": 0.006546340895452359,
+        "p95_m": 0.01911233729989187,
+        "rmse_m": 0.00977577737830678,
+        "segment": 7,
+        "timestamp_end": 1560000039.123629,
+        "timestamp_start": 1560000036.156975
+      },
+      {
+        "images": 182,
+        "max_m": 0.08646034292947094,
+        "median_m": 0.0324803795200114,
+        "p95_m": 0.0808623006373772,
+        "rmse_m": 0.03965559005215818,
+        "segment": 8,
+        "timestamp_end": 1560000042.146964,
+        "timestamp_start": 1560000039.156962
+      },
+      {
+        "images": 180,
+        "max_m": 0.09293509264890325,
+        "median_m": 0.026872662845027234,
+        "p95_m": 0.0703090171072792,
+        "rmse_m": 0.0398209459939577,
+        "segment": 9,
+        "timestamp_end": 1560000045.147009,
+        "timestamp_start": 1560000042.180298
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model/component-000 --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt",
+  "geometry": [
+    {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-2500-ann/boundary-a/model/component-000",
+      "image_poses": 2500,
+      "supported_images": 2500,
+      "unsupported_image_ids": [],
+      "landmarks": 16216,
+      "observations": 209789,
+      "mean_reprojection_px": 0.7786080775818626,
+      "observation_weighted_mean_reprojection_px": 0.7786080775818626,
+      "point_weighted_mean_reprojection_px": 0.7730271624181324,
+      "max_track_mean_reprojection_px": 3.912475474720413,
+      "max_reprojection_px": 3.999624087615365,
+      "max_stored_mean_difference_px": 3.912475474720413,
+      "nonpositive_depth_observations": 0,
+      "tracks_with_multiple_keypoints_in_one_image": 0,
+      "excess_same_image_track_observations": 0,
+      "bidirectional_references_valid": true,
+      "rig": {
+        "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-2500-control-v1/rig-manifest.txt",
+        "rig_frames": 1250,
+        "supported_rig_frames": 1250,
+        "unsupported_rig_frame_ids": [],
+        "max_inferred_rig_center_disagreement_m": 1.8797367829837062e-11,
+        "max_inferred_rig_rotation_disagreement_deg": 0.0000017075472925031877,
+        "fixed_sensor_extrinsics_valid": true,
+        "track_connected_components": 1,
+        "track_connected_component_sizes": [
+          1250
+        ],
+        "track_connected_component_frame_ranges": [
+          [
+            0,
+            1249
+          ]
+        ]
+      }
+    }
+  ],
+  "limits": [
+    "Both repeats exit zero and models match exactly; control matches Legacy.",
+    "Independent 2.5k input but mapper-only, not native E2E.",
+    "Mapper50.634806s versus control36.262899s; no Legacy speedup.",
+    "No COLMAP/10k parity claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-5000-component-anchor-outliers-v1.json
+++ b/benchmarks/electro/m8-openloris-5000-component-anchor-outliers-v1.json
@@ -1,0 +1,160 @@
+{
+  "schema": "m8-openloris-5000-component-anchor-outliers-v1",
+  "audit_program": "import json\nfrom pathlib import Path\nfrom scripts import score_openloris_model as s\nroot=Path(\"/home/sasaki/datasets/openloris\")\nbase=root/\"corridor1-1-m8-bounded-native-v1/tier-5000-slice\"\nmanifest=s.load_manifest(root/\"corridor1-1-m5/manifests/tier-5000.json\")\ngt=root/\"official-groundtruth/calibration/corridor1-1\"\nref=s.interpolate_camera_centres(manifest,s.load_ground_truth(gt/\"groundtruth.txt\"),s.load_camera_extrinsics(gt/\"trans_matrix.yaml\"),max_gap_seconds=0.1)\nmetrics,errors,names=s.score_component(base/\"component-a/model/component-000/images.txt\",ref)\nframes={}\nfor line in (base/\"rig-manifest-5000.txt\").read_text().splitlines():\n f=line.split()\n if f and f[0]==\"F\": frames[f[2]]=int(f[1])\nisolated={1616}\nrows=[dict(name=n,frame=frames[n],error_m=float(e),isolated=frames[n] in isolated) for n,e in zip(names,errors)]\nrows.sort(key=lambda r:r[\"error_m\"],reverse=True)\ntotal=sum(r[\"error_m\"]**2 for r in rows)\nprint(json.dumps(dict(metrics=metrics,top20=rows[:20],isolated=[r for r in rows if r[\"isolated\"]],isolated_squared_error_fraction=sum(r[\"error_m\"]**2 for r in rows if r[\"isolated\"])/total),indent=2))\n",
+  "result": {
+    "metrics": {
+      "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/component-a/model/component-000/images.txt",
+      "images_txt_sha256": "d774c57603f4abeba4ffd757083d15030e9cdfc97629a6b581ad8c7ffd31e16a",
+      "registered": 5000,
+      "gt_scored": 4308,
+      "sim3_scale": 0.9938441026262718,
+      "rmse_m": 0.2612838426865665,
+      "median_m": 0.20503839478868358,
+      "p95_m": 0.4908657808368514,
+      "max_m": 1.7734574749905712,
+      "reference_extent_m": 38.74424995549824,
+      "relative_rmse": 0.0067438095455887755
+    },
+    "top20": [
+      {
+        "name": "cam2_003233.png",
+        "frame": 1616,
+        "error_m": 1.7734574749905712,
+        "isolated": true
+      },
+      {
+        "name": "cam1_003232.png",
+        "frame": 1616,
+        "error_m": 1.7698282374732621,
+        "isolated": true
+      },
+      {
+        "name": "cam1_004996.png",
+        "frame": 2498,
+        "error_m": 0.7270466868474564,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004998.png",
+        "frame": 2499,
+        "error_m": 0.7253122148550093,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004992.png",
+        "frame": 2496,
+        "error_m": 0.7249667809414118,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004994.png",
+        "frame": 2497,
+        "error_m": 0.7245807270270198,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004997.png",
+        "frame": 2498,
+        "error_m": 0.7240926571250271,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004999.png",
+        "frame": 2499,
+        "error_m": 0.7223580164813184,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004993.png",
+        "frame": 2496,
+        "error_m": 0.7220473904569293,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004995.png",
+        "frame": 2497,
+        "error_m": 0.7215854824766018,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004990.png",
+        "frame": 2495,
+        "error_m": 0.7197650765120431,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004991.png",
+        "frame": 2495,
+        "error_m": 0.7167721350597285,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004986.png",
+        "frame": 2493,
+        "error_m": 0.7154158322547338,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004984.png",
+        "frame": 2492,
+        "error_m": 0.713574989444891,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004988.png",
+        "frame": 2494,
+        "error_m": 0.7130226817278641,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004987.png",
+        "frame": 2493,
+        "error_m": 0.7124904418051662,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004985.png",
+        "frame": 2492,
+        "error_m": 0.7107492526373789,
+        "isolated": false
+      },
+      {
+        "name": "cam2_004989.png",
+        "frame": 2494,
+        "error_m": 0.7100770293162243,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004982.png",
+        "frame": 2491,
+        "error_m": 0.7091318432994911,
+        "isolated": false
+      },
+      {
+        "name": "cam1_004976.png",
+        "frame": 2488,
+        "error_m": 0.7074353871779874,
+        "isolated": false
+      }
+    ],
+    "isolated": [
+      {
+        "name": "cam2_003233.png",
+        "frame": 1616,
+        "error_m": 1.7734574749905712,
+        "isolated": true
+      },
+      {
+        "name": "cam1_003232.png",
+        "frame": 1616,
+        "error_m": 1.7698282374732621,
+        "isolated": true
+      }
+    ],
+    "isolated_squared_error_fraction": 0.02134430421795285
+  },
+  "limits": [
+    "GT diagnosis only, unchanged whole-model alignment.",
+    "Singleton 1616 contributes only 2.134% of squared error; targeting it alone is not an adequate global-quality plan."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-5000-fixed-boundary-v1.json
+++ b/benchmarks/electro/m8-openloris-5000-fixed-boundary-v1.json
@@ -1,0 +1,303 @@
+{
+  "schema": "m8-openloris-5000-fixed-boundary-v1",
+  "status": "repeatable-quality-improvement-slower-mapper",
+  "audit_program": "import json,re,hashlib\nfrom pathlib import Path\nb=Path(\"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice\")\nruns={}\nfor arm in (\"boundary-control\",\"boundary-a\",\"boundary-b\"):\n log=(b/(arm+\".log\")).read_text();time=(b/(arm+\".time\")).read_text()\n assert \"Exit status: 0\" in time,arm\n hashes={}\n for n in (\"cameras.txt\",\"images.txt\",\"points3D.txt\"):\n  data=(b/arm/\"model/component-000\"/n).read_bytes()\n  hashes[n]=hashlib.sha256(data).hexdigest()\n  ref=\"legacy\" if arm==\"boundary-control\" else \"boundary-a\"\n  assert data==(b/ref/\"model/component-000\"/n).read_bytes(),(arm,n)\n result=[l for l in log.splitlines() if l.startswith(\"rig-multimodel result:\")][-1]\n assert \"registered_frames=2500/2500 registered_images=5000/5000\" in result\n runs[arm]=dict(model_sha256=hashes,mapper_seconds=float(re.search(r\"mapper_seconds=([0-9.]+)\",result)[1]),peak_rss_kib=int(re.search(r\"Maximum resident set size \\(kbytes\\): (\\d+)\",time)[1]),added_anchors=len(re.findall(r\"^rig-ba-boundary-anchor:\",log,re.M)),result=result,time_output=time,log_sha256=hashlib.sha256(log.encode()).hexdigest())\nprint(json.dumps(dict(control_exact_to_legacy=True,candidate_repeats_exact=True,runs=runs),indent=2))\n",
+  "audit": {"control_exact_to_legacy":true,"candidate_repeats_exact":true,"runs":{"boundary-control":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"ae3ccbe3d67c90b5793e0fcdcdd1d98609f3e0434516b9182f1bfe2e15d5c24b","points3D.txt":"165da10b52e54637f6c1db926ea0b4d6d7cf89bb11de02e68a07f0a952d595b2"},"mapper_seconds":53.399406,"peak_rss_kib":722704,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=2500/2500 registered_images=5000/5000 tracks=34832 observations=310473 mean_reprojection_px=0.831376558 mapper_seconds=53.399406 VmHWM_KiB=722704 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 54.95\n\tSystem time (seconds): 0.80\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:55.76\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 722704\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 218949\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 297\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 97928\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"b7a278d019e88bb45088887973c2e308f83a4f0fb07f500b540e7711e5c5c746"},"boundary-a":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"c22edd5f4113209b20e71dd29da6d99824b37b8b6ccd03343da765d80491969a","points3D.txt":"bbea103bf4add01c50e2a910870d461a1ac7f84621964400153c9cbfcf7543ba"},"mapper_seconds":83.156035,"peak_rss_kib":724532,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=2500/2500 registered_images=5000/5000 tracks=35431 observations=327683 mean_reprojection_px=0.819133309 mapper_seconds=83.156035 VmHWM_KiB=724532 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 84.67\n\tSystem time (seconds): 0.82\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 1:25.50\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 724532\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 219392\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 460\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 98352\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"acc31d86e99b6800ab5dfdcc8554d66a7a937c2669d4cc3764d8e41d23825358"},"boundary-b":{"model_sha256":{"cameras.txt":"65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e","images.txt":"c22edd5f4113209b20e71dd29da6d99824b37b8b6ccd03343da765d80491969a","points3D.txt":"bbea103bf4add01c50e2a910870d461a1ac7f84621964400153c9cbfcf7543ba"},"mapper_seconds":91.704508,"peak_rss_kib":724796,"added_anchors":0,"result":"rig-multimodel result: models=1 registered_frames=2500/2500 registered_images=5000/5000 tracks=35431 observations=327683 mean_reprojection_px=0.819133309 mapper_seconds=91.704508 VmHWM_KiB=724796 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b/model","time_output":"\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10\"\n\tUser time (seconds): 93.64\n\tSystem time (seconds): 0.82\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 1:34.47\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 724796\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 219406\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 106\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 98352\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n","log_sha256":"11ad8a51b54750f03da84b7d761f56e84ca48d6df5c37ac587c578d705fb6ca0"}}},
+  "build_commit": "7d99e07dbdbc95bc72d2e28805a75e51dbcd7270",
+  "binary_sha256": "d87194e92b472b9d74fd8d2e43d41faad5766f330afc3a6e9155c41816277d72",
+  "commands": {
+    "boundary-control": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-control.log 2>&1",
+    "boundary-a": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a.log 2>&1",
+    "boundary-b": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b.time\nenv -u VISLOC_SFM_DEBUG -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_LM_QUALITY -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_PNP_HYPOTHESES RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-7d99e07 --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/source-rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1/mapping/verified-merged.vps --frame-range-start 0 --frame-range-count 2500 --ba-fixed-boundary-observations --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b/model --max-matches-per-pair 256 --max-models 2 --min-model-frames 10 > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-b.log 2>&1"
+  },
+  "score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model/component-000/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-5000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "score": {
+    "component_weighted_max_m": 0.33925036878065845,
+    "component_weighted_median_m": 0.14479738212401744,
+    "component_weighted_p95_m": 0.2710319960887621,
+    "component_weighted_rmse_m": 0.16433547955227995,
+    "components": [
+      {
+        "gt_scored": 4308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model/component-000/images.txt",
+        "images_txt_sha256": "c22edd5f4113209b20e71dd29da6d99824b37b8b6ccd03343da765d80491969a",
+        "max_m": 0.33925036878065845,
+        "median_m": 0.14479738212401744,
+        "p95_m": 0.2710319960887621,
+        "reference_extent_m": 38.74424995549824,
+        "registered": 5000,
+        "relative_rmse": 0.004241544996768196,
+        "rmse_m": 0.16433547955227995,
+        "sim3_scale": 0.9891575252421531,
+        "trajectory_segments": [
+          {
+            "images": 432,
+            "max_m": 0.33925036878065845,
+            "median_m": 0.22971896284982718,
+            "p95_m": 0.33676853536820917,
+            "rmse_m": 0.2535601254995467,
+            "segment": 0,
+            "timestamp_end": 1560000022.233627,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 430,
+            "max_m": 0.2213113136339037,
+            "median_m": 0.18524219162010014,
+            "p95_m": 0.21722942449258012,
+            "rmse_m": 0.16701954576637115,
+            "segment": 1,
+            "timestamp_end": 1560000029.39037,
+            "timestamp_start": 1560000022.26696
+          },
+          {
+            "images": 432,
+            "max_m": 0.07535035230180624,
+            "median_m": 0.06406403208683184,
+            "p95_m": 0.07272401782351903,
+            "rmse_m": 0.06340502618460617,
+            "segment": 2,
+            "timestamp_end": 1560000036.590301,
+            "timestamp_start": 1560000029.423703
+          },
+          {
+            "images": 430,
+            "max_m": 0.22267655493076707,
+            "median_m": 0.10874022773011005,
+            "p95_m": 0.2136677504037968,
+            "rmse_m": 0.13408771659097365,
+            "segment": 3,
+            "timestamp_end": 1560000043.747026,
+            "timestamp_start": 1560000036.623635
+          },
+          {
+            "images": 430,
+            "max_m": 0.25377461363201576,
+            "median_m": 0.22496102854834998,
+            "p95_m": 0.24734364974332104,
+            "rmse_m": 0.22823970240738983,
+            "segment": 4,
+            "timestamp_end": 1560000050.913754,
+            "timestamp_start": 1560000043.780359
+          },
+          {
+            "images": 432,
+            "max_m": 0.21814563203884593,
+            "median_m": 0.1575225856501507,
+            "p95_m": 0.20140471792776474,
+            "rmse_m": 0.16208024774384827,
+            "segment": 5,
+            "timestamp_end": 1560000058.113778,
+            "timestamp_start": 1560000050.947087
+          },
+          {
+            "images": 430,
+            "max_m": 0.13345886553454656,
+            "median_m": 0.0648540874982291,
+            "p95_m": 0.12238553289381254,
+            "rmse_m": 0.07941797896335155,
+            "segment": 6,
+            "timestamp_end": 1560000065.28046,
+            "timestamp_start": 1560000058.147112
+          },
+          {
+            "images": 430,
+            "max_m": 0.11782987747340097,
+            "median_m": 0.06643938725432519,
+            "p95_m": 0.10318237838129089,
+            "rmse_m": 0.07109536890751823,
+            "segment": 7,
+            "timestamp_end": 1560000072.46712,
+            "timestamp_start": 1560000065.313794
+          },
+          {
+            "images": 432,
+            "max_m": 0.2522672573320232,
+            "median_m": 0.21606397346668324,
+            "p95_m": 0.24286201241806005,
+            "rmse_m": 0.1790951996937295,
+            "segment": 8,
+            "timestamp_end": 1560000079.667106,
+            "timestamp_start": 1560000072.500453
+          },
+          {
+            "images": 430,
+            "max_m": 0.3012478612231952,
+            "median_m": 0.15736369524865465,
+            "p95_m": 0.28937916595369967,
+            "rmse_m": 0.18435462129202962,
+            "segment": 9,
+            "timestamp_end": 1560000086.84128,
+            "timestamp_start": 1560000079.700439
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 4308,
+    "gt_scored_images": 4308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-5000.json",
+    "manifest_images": 5000,
+    "manifest_sha256": "ac9762deb0b3f0aed591d320e0441e8e739089105ac9e898ef9aca431bde875f",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 5000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 432,
+        "max_m": 0.33925036878065845,
+        "median_m": 0.22971896284982718,
+        "p95_m": 0.33676853536820917,
+        "rmse_m": 0.2535601254995467,
+        "segment": 0,
+        "timestamp_end": 1560000022.233627,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 430,
+        "max_m": 0.2213113136339037,
+        "median_m": 0.18524219162010014,
+        "p95_m": 0.21722942449258012,
+        "rmse_m": 0.16701954576637115,
+        "segment": 1,
+        "timestamp_end": 1560000029.39037,
+        "timestamp_start": 1560000022.26696
+      },
+      {
+        "images": 432,
+        "max_m": 0.07535035230180624,
+        "median_m": 0.06406403208683184,
+        "p95_m": 0.07272401782351903,
+        "rmse_m": 0.06340502618460617,
+        "segment": 2,
+        "timestamp_end": 1560000036.590301,
+        "timestamp_start": 1560000029.423703
+      },
+      {
+        "images": 430,
+        "max_m": 0.22267655493076707,
+        "median_m": 0.10874022773011005,
+        "p95_m": 0.2136677504037968,
+        "rmse_m": 0.13408771659097365,
+        "segment": 3,
+        "timestamp_end": 1560000043.747026,
+        "timestamp_start": 1560000036.623635
+      },
+      {
+        "images": 430,
+        "max_m": 0.25377461363201576,
+        "median_m": 0.22496102854834998,
+        "p95_m": 0.24734364974332104,
+        "rmse_m": 0.22823970240738983,
+        "segment": 4,
+        "timestamp_end": 1560000050.913754,
+        "timestamp_start": 1560000043.780359
+      },
+      {
+        "images": 432,
+        "max_m": 0.21814563203884593,
+        "median_m": 0.1575225856501507,
+        "p95_m": 0.20140471792776474,
+        "rmse_m": 0.16208024774384827,
+        "segment": 5,
+        "timestamp_end": 1560000058.113778,
+        "timestamp_start": 1560000050.947087
+      },
+      {
+        "images": 430,
+        "max_m": 0.13345886553454656,
+        "median_m": 0.0648540874982291,
+        "p95_m": 0.12238553289381254,
+        "rmse_m": 0.07941797896335155,
+        "segment": 6,
+        "timestamp_end": 1560000065.28046,
+        "timestamp_start": 1560000058.147112
+      },
+      {
+        "images": 430,
+        "max_m": 0.11782987747340097,
+        "median_m": 0.06643938725432519,
+        "p95_m": 0.10318237838129089,
+        "rmse_m": 0.07109536890751823,
+        "segment": 7,
+        "timestamp_end": 1560000072.46712,
+        "timestamp_start": 1560000065.313794
+      },
+      {
+        "images": 432,
+        "max_m": 0.2522672573320232,
+        "median_m": 0.21606397346668324,
+        "p95_m": 0.24286201241806005,
+        "rmse_m": 0.1790951996937295,
+        "segment": 8,
+        "timestamp_end": 1560000079.667106,
+        "timestamp_start": 1560000072.500453
+      },
+      {
+        "images": 430,
+        "max_m": 0.3012478612231952,
+        "median_m": 0.15736369524865465,
+        "p95_m": 0.28937916595369967,
+        "rmse_m": 0.18435462129202962,
+        "segment": 9,
+        "timestamp_end": 1560000086.84128,
+        "timestamp_start": 1560000079.700439
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model/component-000 --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/rig-manifest-5000.txt",
+  "geometry": [
+    {
+      "model": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/boundary-a/model/component-000",
+      "image_poses": 5000,
+      "supported_images": 5000,
+      "unsupported_image_ids": [],
+      "landmarks": 35431,
+      "observations": 327683,
+      "mean_reprojection_px": 0.8191333094205278,
+      "observation_weighted_mean_reprojection_px": 0.8191333094205278,
+      "point_weighted_mean_reprojection_px": 0.7775723034962138,
+      "max_track_mean_reprojection_px": 3.921759620144394,
+      "max_reprojection_px": 3.9998657961491855,
+      "max_stored_mean_difference_px": 3.921759620144394,
+      "nonpositive_depth_observations": 0,
+      "tracks_with_multiple_keypoints_in_one_image": 0,
+      "excess_same_image_track_observations": 0,
+      "bidirectional_references_valid": true,
+      "rig": {
+        "rig_manifest": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/tier-5000-slice/rig-manifest-5000.txt",
+        "rig_frames": 2500,
+        "supported_rig_frames": 2500,
+        "unsupported_rig_frame_ids": [],
+        "max_inferred_rig_center_disagreement_m": 7.973332796774196e-11,
+        "max_inferred_rig_rotation_disagreement_deg": 0.0000017075472925031877,
+        "fixed_sensor_extrinsics_valid": true,
+        "track_connected_components": 1,
+        "track_connected_component_sizes": [
+          2500
+        ],
+        "track_connected_component_frame_ranges": [
+          [
+            0,
+            2499
+          ]
+        ]
+      }
+    }
+  ],
+  "limits": [
+    "Both repeats exited zero and produced exactly identical models; control matches Legacy.",
+    "Mapper83.156035s versus control53.399406s; not a speedup versus Legacy.",
+    "Derived 5k mapper-only slice, not independent native E2E or COLMAP parity certificate.",
+    "No component-anchoring combination, threshold change or GT-guided selection."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,22 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> PR104はhead `109705c` のCI9成功後 `1f98c5c` にmerge（成分固定は既定OFF維持）。
+> 現branch `feat/m8-fixed-boundary-ba`、build source `7d99e07dbdbc95bc72d2e28805a75e51dbcd7270`。
+> `--ba-fixed-boundary-observations` を既定OFF追加。窓内usable観測を持つtrackのみ、
+> 窓外usable観測を固定body poseとしてBAへ含める。成分固定と組み合わせずLegacy対照で測る。
+> 窓内1観測+窓外1観測の採用、固定pose/観測不変、窓外のみtrack除外テスト通過。
+> clippy/CLI check通過。release45.41秒、保存binary `rig-7d99e07`。
+> SHA256 `d87194e92b472b9d74fd8d2e43d41faad5766f330afc3a6e9155c41816277d72`。
+> 5k `tier-5000-slice/boundary-control` はexit0、Legacy bytes一致、mapper53.399406秒。
+> boundary-aはexit0、全5000画像、RMSE/p95 0.164335/0.271032m、再投影0.819133pxで対照より改善。
+> track成分2500frame一つ、支持/正深度/固定rig正常。mapper83.156035秒で対照53.399406秒より遅い。
+> boundary-bもexit0、候補反復bytes一致。mapper83.156/91.705秒、RSS724532/724796KiB。
+> 成分固定OFF。証跡 `m8-openloris-5000-fixed-boundary-v1.json`。
+> 1k `boundary-1k/control` はsession63512実行中。完走後candidate-a/bを逐次実行する。
+> 反復確認後、独立tier非回帰/10k品質へ。5kだけで全goal達成やCOLMAP優越を主張しない。
+> 実ソルバーのpose_indexはfixed pose除外をコード確認。追加観測/固定poseのRSSは未測定。
+> [契約](openloris_fixed_boundary_ba.md)。5k残存singleton1616は二乗誤差2.134%のみ。
+
 > PR103はhead `9f7cfeb` CI9成功後 `a82a4bb` にmerge、旧branch整理済み。
 > 現branch `feat/m8-ba-component-anchors`。既定OFFの
 > `--ba-anchor-disconnected-components` は既存固定poseのない各BA成分の最小frame IDを固定。

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -12,7 +12,10 @@
 > track成分2500frame一つ、支持/正深度/固定rig正常。mapper83.156035秒で対照53.399406秒より遅い。
 > boundary-bもexit0、候補反復bytes一致。mapper83.156/91.705秒、RSS724532/724796KiB。
 > 成分固定OFF。証跡 `m8-openloris-5000-fixed-boundary-v1.json`。
-> 1k `boundary-1k/control` はsession63512実行中。完走後candidate-a/bを逐次実行する。
+> 1k control/candidate-a/bはexit0、control Legacy bytes一致、候補反復bytes一致。
+> RMSE/p95 0.022320/0.035799m、再投影0.627506px、全1000画像・幾何正常で既存品質gate通過。
+> mapper5.575/5.557秒対control4.099秒。証跡 `m8-openloris-1000-fixed-boundary-v1.json`。
+> 次は独立dense ANN2.5kと10k、native E2Eは依然未検証。
 > 反復確認後、独立tier非回帰/10k品質へ。5kだけで全goal達成やCOLMAP優越を主張しない。
 > 実ソルバーのpose_indexはfixed pose除外をコード確認。追加観測/固定poseのRSSは未測定。
 > [契約](openloris_fixed_boundary_ba.md)。5k残存singleton1616は二乗誤差2.134%のみ。

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,17 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> PR105 https://github.com/rsasaki0109/visloc-rs/pull/105 はhead `aa3938c`、CI34200559679実行中。
+> 同じbinary `rig-7d99e07` の独立dense ANN2.5k対照を開始。
+> `tier-2500-ann/boundary-control` はexit0・Legacy bytes一致、mapper36.262899秒。
+> boundary-aはexit0、全2500画像、RMSE/p95 0.067853/0.134449m、再投影0.778608pxで改善。
+> 支持/正深度/固定rig正常、track成分1250frame一つ。mapper50.634806秒で対照より遅い。
+> boundary-bもexit0・反復bytes一致。mapper50.635/50.016秒対control36.263秒。
+> 証跡 `m8-openloris-2500-fixed-boundary-v1.json`。次は10k。
+> 容量確保: 5k legacyと完全一致したpolicy-a/b、support-debug、ba-motion-debug、
+> ba-connectivity-debug、anchored-control、boundary-controlの3モデルファイルをhardlink化。
+> パス/bytes不変、入力データ変更なし。これらの既存出力は上書きせず新規run名を使用する。
+> 全goal未達。ディスク空き約327MB（対照開始前）、10k前に再確認する。
+
 > PR104はhead `109705c` のCI9成功後 `1f98c5c` にmerge（成分固定は既定OFF維持）。
 > 現branch `feat/m8-fixed-boundary-ba`、build source `7d99e07dbdbc95bc72d2e28805a75e51dbcd7270`。
 > `--ba-fixed-boundary-observations` を既定OFF追加。窓内usable観測を持つtrackのみ、

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,10 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 10k mapper-only検証を開始: `tier-10000-boundary/boundary-control` session40844実行中。
+> 同じ `rig-7d99e07`/完全10k入力、frame sliceなし、各run上限360秒、単一thread。
+> 入力5000frame/10000画像/64862pairs/7551021 capped matches、初期VmHWM547620KiB。
+> 完走後対照を採点しboundary-a/bへ。native E2Eではなく、登録不足も隠さず記録する。
+
 > PR105 https://github.com/rsasaki0109/visloc-rs/pull/105 はhead `aa3938c`、CI34200559679実行中。
 > 同じbinary `rig-7d99e07` の独立dense ANN2.5k対照を開始。
 > `tier-2500-ann/boundary-control` はexit0・Legacy bytes一致、mapper36.262899秒。

--- a/docs/openloris_fixed_boundary_ba.md
+++ b/docs/openloris_fixed_boundary_ba.md
@@ -1,0 +1,43 @@
+# Fixed boundary observations for native BA — implementation contract
+
+Component anchoring improved 5k RMSE but worsened p95/reprojection. The
+remaining singleton 1616 explains only 2.134% of squared trajectory error;
+do not tune isolated-pose repairs or anchors against GT.
+
+Current `run_rig_bundle_adjustment` discards observations outside the active
+frame set, while updating the selected landmarks globally. The next single
+factor is retaining their outside observations with fixed poses. Keep the
+registration-order window, solver, thresholds, iterations and track policy
+unchanged. Start from Legacy with component anchoring OFF to isolate this
+factor, not a combined parameter sweep.
+
+## Source and limits
+
+COLMAP's [AddPointToProblem](https://raw.githubusercontent.com/colmap/colmap/main/src/colmap/estimators/bundle_adjustment_ceres.cc)
+adds remaining observations of explicitly selected points using constant-pose
+residuals. Its [local mapper](https://raw.githubusercontent.com/colmap/colmap/main/src/colmap/sfm/incremental_mapper.cc)
+also uses covisibility to select local images. We borrow the fixed-boundary
+principle only, not claim identical point selection or change covisibility
+simultaneously. These main-branch sources are design references, not the
+version certificate for the retained COLMAP benchmark.
+
+## Implementation and validation
+
+- Add a default-off explicit option. Select only positioned tracks having
+  usable active-frame observations; never include boundary-only tracks.
+- Keep the existing projectability/reprojection eligibility predicate.
+  Include eligible registered outside observations on those tracks with
+  fixed body poses and unchanged sensor calibration. Do not duplicate rows.
+- Count pose support only for observations actually admitted to BA. Preserve
+  legacy behavior when disabled; do not silently broaden the variable pose set.
+- State must be O(selected observations + selected points + boundary poses).
+  No global pose-pair graph, dense N-by-N state or full model clone. Fixed
+  boundary poses must not enlarge the variable Schur dimension.
+- Tests: one active observation plus fixed-boundary support; no eligible
+  boundary; fully internal tracks; duplicate avoidance; fixed-state and
+  rollback; variable dimension; disabled-path parity; long sparse tracks.
+- Run same-binary control and two 5k candidate repeats. Audit full registration,
+  support, positive depth, fixed rig, raw reprojection, whole-model GT and
+  exact repeatability. Record actual variable/fixed counts and resources.
+- Require evidence of useful quality improvement before larger-tier rollout.
+  No GT-driven threshold or boundary-cap sweep. 10k and native E2E remain open.

--- a/docs/openloris_fixed_boundary_ba.md
+++ b/docs/openloris_fixed_boundary_ba.md
@@ -1,5 +1,18 @@
 # Fixed boundary observations for native BA — implementation contract
 
+## 5k paired result
+
+Both candidate repeats produce identical models with all 5,000 images and
+2,500 frames in one final track-connected component. The same-binary control
+matches historical Legacy. RMSE/p95 improve from 0.477216/0.478983 m to
+0.164335/0.271032 m; raw mean reprojection improves 0.831377 to 0.819133 px.
+Support, positive depth and fixed sensor calibration pass independent audit.
+Mapper time increases from 53.399406 s to 83.156035/91.704508 s; peak RSS
+is 722704 versus 724532/724796 KiB. This is repeatable quality improvement
+on a derived 5k mapper-only slice, not a speedup or native E2E certificate.
+Independent tier nonregression and 10k remain to be checked.
+[Evidence](../benchmarks/electro/m8-openloris-5000-fixed-boundary-v1.json).
+
 Component anchoring improved 5k RMSE but worsened p95/reprojection. The
 remaining singleton 1616 explains only 2.134% of squared trajectory error;
 do not tune isolated-pose repairs or anchors against GT.

--- a/docs/openloris_fixed_boundary_ba.md
+++ b/docs/openloris_fixed_boundary_ba.md
@@ -13,6 +13,15 @@ on a derived 5k mapper-only slice, not a speedup or native E2E certificate.
 Independent tier nonregression and 10k remain to be checked.
 [Evidence](../benchmarks/electro/m8-openloris-5000-fixed-boundary-v1.json).
 
+Independent 1k and 2.5k mapper checks are now complete with exact candidate
+repeatability and full registration. 1k RMSE/p95/reprojection:
+0.022320/0.035799 m / 0.627506 px. 2.5k: 0.067853/0.134449 m /
+0.778608 px, improving the paired control 0.133927/0.237364 m /
+0.788549 px. Both geometry audits pass. 2.5k mapper is 50.635/50.016 s
+versus control 36.263 s: no Legacy speedup. 10k and native E2E remain open.
+[1k evidence](../benchmarks/electro/m8-openloris-1000-fixed-boundary-v1.json),
+[2.5k evidence](../benchmarks/electro/m8-openloris-2500-fixed-boundary-v1.json).
+
 Component anchoring improved 5k RMSE but worsened p95/reprojection. The
 remaining singleton 1616 explains only 2.134% of squared trajectory error;
 do not tune isolated-pose repairs or anchors against GT.

--- a/examples/generalized_rig_sfm.rs
+++ b/examples/generalized_rig_sfm.rs
@@ -125,6 +125,7 @@ struct Args {
     ba_huber_delta: f64,
     ba_backend: RigBaBackend,
     ba_anchor_disconnected_components: bool,
+    ba_fixed_boundary_observations: bool,
     structure_refinement_iterations: usize,
     preview_rig_correspondence_csr: bool,
     preview_pair_confidence_conflicts: bool,
@@ -248,6 +249,7 @@ fn parse_args() -> Result<Args, String> {
     let mut ba_huber_delta = 6.0;
     let mut ba_backend = defaults.ba_backend;
     let mut ba_anchor_disconnected_components = defaults.ba_anchor_disconnected_components;
+    let mut ba_fixed_boundary_observations = defaults.ba_fixed_boundary_observations;
     let mut ba_backend_seen = false;
     let mut structure_refinement_iterations = defaults.structure_refinement_iterations;
     let mut preview_rig_correspondence_csr = false;
@@ -560,6 +562,7 @@ fn parse_args() -> Result<Args, String> {
                 ba_backend = parse_ba_backend(&value()?)?;
             }
             "--ba-anchor-disconnected-components" => ba_anchor_disconnected_components = true,
+            "--ba-fixed-boundary-observations" => ba_fixed_boundary_observations = true,
             "--structure-refinement-iterations" => {
                 structure_refinement_iterations =
                     value()?.parse().map_err(|error| format!("{error}"))?
@@ -620,6 +623,7 @@ fn parse_args() -> Result<Args, String> {
                     "[--local-ba-iterations 8] [--ba-huber-delta 6] ",
                     "[--ba-backend legacy|matrix-free|matrix-free-cluster8|matrix-free-cluster8-restart1|matrix-free-qr|bounded-direct64-qr] ",
                     "[--ba-anchor-disconnected-components] ",
+                    "[--ba-fixed-boundary-observations] ",
                     "[--structure-refinement-iterations 5] ",
                     "[--metric-anchored-cycle-tracks|--metric-temporal-cycle-tracks|",
                     "--metric-sparse-cycle-tracks|",
@@ -912,6 +916,7 @@ fn parse_args() -> Result<Args, String> {
         ba_huber_delta,
         ba_backend,
         ba_anchor_disconnected_components,
+        ba_fixed_boundary_observations,
         structure_refinement_iterations,
         preview_rig_correspondence_csr,
         preview_pair_confidence_conflicts,
@@ -1692,6 +1697,7 @@ fn mapper_config(args: &Args) -> RigSfmConfig {
         final_ba_min_pose_observations: args.final_ba_min_pose_observations,
         ba_backend: args.ba_backend,
         ba_anchor_disconnected_components: args.ba_anchor_disconnected_components,
+        ba_fixed_boundary_observations: args.ba_fixed_boundary_observations,
         structure_refinement_iterations: args.structure_refinement_iterations,
         dynamic_correspondence_tracking: args.dynamic_correspondence_tracking,
         ba_config: visloc_rs::BaConfig {

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -240,6 +240,8 @@ pub struct RigSfmConfig {
     /// Fix the lowest frame ID in each BA observation component lacking a
     /// fixed pose. Removes its rigid gauge, not every possible degeneracy.
     pub ba_anchor_disconnected_components: bool,
+    /// Retain eligible outside observations of active tracks with fixed poses.
+    pub ba_fixed_boundary_observations: bool,
     pub ba_config: BaConfig,
     pub local_ba_every: usize,
     pub local_ba_window_size: usize,
@@ -315,6 +317,7 @@ impl Default for RigSfmConfig {
             final_bundle_adjustment: true,
             ba_backend: RigBaBackend::Legacy,
             ba_anchor_disconnected_components: false,
+            ba_fixed_boundary_observations: false,
             ba_config: BaConfig {
                 linear_solver: LinearSolver::Sparse,
                 robust_kernel: RobustKernel::Huber { delta: 6.0 },
@@ -4801,12 +4804,14 @@ fn run_rig_bundle_adjustment(
             continue;
         };
         let mut observations = Vec::new();
+        let mut has_active_observation = false;
         for &(image, keypoint) in &track.observations {
             let Some(pose) = image_poses[image].as_ref() else {
                 continue;
             };
             let (frame, sensor_index) = image_assignment[image];
-            if !active_frames.contains(&frame) {
+            let active = active_frames.contains(&frame);
+            if !active && (!config.ba_fixed_boundary_observations || frame_poses[frame].is_none()) {
                 continue;
             }
             let sensor = &rig.sensors()[sensor_index];
@@ -4818,7 +4823,11 @@ fn run_rig_bundle_adjustment(
                     (projected - pixel).norm() <= 2.0 * config.max_reprojection_error_px
                 });
             if usable {
-                observations_per_frame[frame] += 1;
+                has_active_observation |= active;
+                // Preserve the historical counter path when disabled.
+                if !config.ba_fixed_boundary_observations {
+                    observations_per_frame[frame] += 1;
+                }
                 observations.push(BaRigObservation {
                     keyframe_id: frame as u64,
                     landmark_id: track_index as u64,
@@ -4828,12 +4837,25 @@ fn run_rig_bundle_adjustment(
                 });
             }
         }
-        if observations.len() < 2 {
+        if observations.len() < 2 || !has_active_observation {
             continue;
         }
         problem.add_landmark(track_index as u64, position);
         visual_observations += observations.len();
         for observation in observations {
+            if config.ba_fixed_boundary_observations {
+                let frame = observation.keyframe_id as usize;
+                observations_per_frame[frame] += 1;
+                if !active_frames.contains(&frame) {
+                    if !problem.poses.contains_key(&observation.keyframe_id) {
+                        problem.add_pose(
+                            observation.keyframe_id,
+                            frame_poses[frame].as_ref().unwrap().clone(),
+                        );
+                    }
+                    problem.fix_pose(observation.keyframe_id);
+                }
+            }
             problem.add_rig_observation(observation);
         }
     }
@@ -9242,17 +9264,27 @@ mod tests {
     }
 
     fn check_fixed_rotation_backend(backend: RigBaBackend) {
-        check_fixed_rotation_backend_with_component_anchors(backend, false);
+        check_fixed_rotation_backend_with_component_anchors(backend, false, false);
     }
 
     #[test]
     fn component_anchoring_native_preserves_fixed_state_and_rollback() {
-        check_fixed_rotation_backend_with_component_anchors(RigBaBackend::BoundedDirect64Qr, true);
+        check_fixed_rotation_backend_with_component_anchors(
+            RigBaBackend::BoundedDirect64Qr,
+            true,
+            false,
+        );
+    }
+
+    #[test]
+    fn fixed_boundary_keeps_single_active_observations_and_external_poses_fixed() {
+        check_fixed_rotation_backend_with_component_anchors(RigBaBackend::Legacy, false, true);
     }
 
     fn check_fixed_rotation_backend_with_component_anchors(
         backend: RigBaBackend,
         component_anchors: bool,
+        boundary_test: bool,
     ) {
         let rig = GeneralizedCameraRig::new(vec![
             RigSensor {
@@ -9386,6 +9418,73 @@ mod tests {
             parallel: false,
             ..BaConfig::default()
         };
+        if boundary_test {
+            let mut outside_only = tracks[0].clone();
+            outside_only.observations.retain(|&(image, _)| image < 2);
+            let outside_position = outside_only.position;
+            // One sensor observation per frame: without the boundary each
+            // track has only one active row and must be excluded.
+            for track in &mut tracks {
+                track.observations.retain(|&(image, _)| image % 2 == 0);
+            }
+            tracks.push(outside_only);
+            let before_poses = frame_poses.clone();
+            let before_images = image_poses.clone();
+            let before_observations: Vec<_> =
+                tracks.iter().map(|t| t.observations.clone()).collect();
+            let active = HashSet::from([1]);
+            assert!(run_rig_bundle_adjustment(
+                &rig,
+                &features,
+                &image_assignment,
+                &config,
+                &active,
+                1,
+                &ba_config,
+                0,
+                &[],
+                false,
+                &mut frame_poses,
+                &mut image_poses,
+                &mut tracks,
+            )
+            .unwrap()
+            .is_none());
+            let boundary_config = RigSfmConfig {
+                ba_fixed_boundary_observations: true,
+                ..config
+            };
+            let stats = run_rig_bundle_adjustment(
+                &rig,
+                &features,
+                &image_assignment,
+                &boundary_config,
+                &active,
+                1,
+                &ba_config,
+                0,
+                &[],
+                false,
+                &mut frame_poses,
+                &mut image_poses,
+                &mut tracks,
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(stats.observations, world_points.len() * 2);
+            assert_eq!(tracks.last().unwrap().position, outside_position);
+            assert!(stats.final_cost <= stats.initial_cost);
+            assert_eq!(frame_poses, before_poses);
+            assert_eq!(image_poses, before_images);
+            assert_eq!(
+                tracks
+                    .iter()
+                    .map(|t| t.observations.clone())
+                    .collect::<Vec<_>>(),
+                before_observations
+            );
+            return;
+        }
         let direct_frame_poses_before = frame_poses.clone();
         let direct_observations_before = tracks
             .iter()


### PR DESCRIPTION
Default-off fixed-boundary observations following the documented COLMAP principle; no covisibility or threshold change. Tests cover single active plus boundary observation, exclusion of boundary-only tracks, fixed pose/observation preservation. Clippy and CLI check pass. Same-binary 1k/5k controls match Legacy; candidate repeats match exactly and pass registration/GT/reprojection quality nonregression with independent geometry audit. Mapper is slower than Legacy; no performance or full-goal claim. Evidence and sources included. 2.5k/10k/native E2E remain open.