### PR TITLE
feat: add experimental bounded covisibility selector with rejection evidence

### DIFF
--- a/benchmarks/electro/m8-openloris-1000-covisibility-v1.json
+++ b/benchmarks/electro/m8-openloris-1000-covisibility-v1.json
@@ -1,0 +1,296 @@
+{
+  "schema": "m8-openloris-1000-covisibility-v1",
+  "status": "repeated-quality-regression-not-promoted",
+  "build_commit": "9d7868bf44b19cccbcaa6503c1018cf9867956f0",
+  "binary_sha256": "3dc9d3f9302c73bc58a218cd3ca0239450e877fad0bb9a4998ca596bc2dfcc79",
+  "commands": {
+    "control": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-9d7868b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control.log 2>&1",
+    "candidate-a": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-9d7868b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --local-ba-covisibility --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a.log 2>&1",
+    "candidate-b": "set -Ce\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b\ntest ! -e /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b.time\nenv -u VISLOC_SFM_DEBUG_QR_SHARED_STATE -u VISLOC_SFM_DEBUG_BA -u VISLOC_SFM_DEBUG_BA_STEPS -u VISLOC_SFM_DEBUG_BA_SCHUR_SLOT -u VISLOC_SFM_DEBUG_BA_LM_QUALITY RAYON_NUM_THREADS=1 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b.time timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-9d7868b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --local-ba-covisibility --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b/model > /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b.log 2>&1"
+  },
+  "audit_command": "python3 - <<'PY'\nimport json\np=json.load(open('benchmarks/electro/m8-openloris-1000-fixed-boundary-v1.json'))['audit_program'].replace('boundary-1k','covisibility-1k')\nexec(p)\nPY",
+  "runs": {
+    "control": {
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "937098610a0ec29c37bbc9c649e9385050d9ce6782f3154fcc2c02613281b8ee",
+        "points3D.txt": "11eb71b6a45f248770429a91a8841e64e028089350515f3f87366c468ae399af"
+      },
+      "mapper_seconds": 3.333572,
+      "peak_rss_kib": 81860,
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62380 KiB\nrig-replay BA: observations=120217 cost=267541.992667814->121458.389207945 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2658 observations=27716 mean_reprojection_px=0.671637382 seed_frame=26 mapper_seconds=3.333572 total_seconds=3.776279 VmHWM_KiB=82228 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=39217 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=29751 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2607 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-9d7868b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/control/model\"\n\tUser time (seconds): 3.69\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:03.78\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 81860\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23493\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 29\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7288\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+    },
+    "candidate-a": {
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "cfbaa266a18ac69411c9ef45c60b5bd17850c583606bf18e0d74bd5c0b55faf9",
+        "points3D.txt": "32564480f3c3c6d5611ea452452f557e51730d89b627851f13ec9de2949110cd"
+      },
+      "mapper_seconds": 4.018558,
+      "peak_rss_kib": 82552,
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62460 KiB\nrig-replay BA: observations=124533 cost=247973.930922620->129079.547193989 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2763 observations=28898 mean_reprojection_px=0.703792384 seed_frame=26 mapper_seconds=4.018558 total_seconds=4.527399 VmHWM_KiB=82748 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=37978 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=30342 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2730 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-9d7868b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --local-ba-covisibility --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model\"\n\tUser time (seconds): 4.44\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:04.53\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82552\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23629\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 21\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7320\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+    },
+    "candidate-b": {
+      "model_sha256": {
+        "cameras.txt": "65e29cd8cdc5029404f2877ff5db846f61909635527634e03ca7b1ea0bc91c6e",
+        "images.txt": "cfbaa266a18ac69411c9ef45c60b5bd17850c583606bf18e0d74bd5c0b55faf9",
+        "points3D.txt": "32564480f3c3c6d5611ea452452f557e51730d89b627851f13ec9de2949110cd"
+      },
+      "mapper_seconds": 3.881393,
+      "peak_rss_kib": 82440,
+      "log": "rig-replay input: frames=500 images=1000 pairs=6869 matches=661428 keypoints=256000 VmHWM=62432 KiB\nrig-replay BA: observations=124533 cost=247973.930922620->129079.547193989 iterations=288 converged=false\nrig-replay result: registered_frames=500/500 registered_images=1000/1000 tracks=2763 observations=28898 mean_reprojection_px=0.703792384 seed_frame=26 mapper_seconds=3.881393 total_seconds=4.361079 VmHWM_KiB=82848 track_components=11211 conflicting_track_edges=1123 retained_track_observations=57088 triangulation_attempts=37978 robust_triangulation_tracks=0 robust_triangulation_pruned_observations=0 robust_triangulation_majority_rejections=0 cache_insertions=30342 pnp_attempts=499 pnp_insufficient_sensors=0 pnp_estimation_failures=0 pnp_inlier_rejections=0 pnp_registrations=499 dynamic_activated_rows=0 dynamic_activated_edges=0 dynamic_track_creates=0 dynamic_track_continues=0 dynamic_owner_conflicts=0 dynamic_same_image_conflicts=0 dynamic_geometry_rejections=0 dynamic_observation_lookup_entries=0 dynamic_pnp_graph_insertions=0 dynamic_bootstrap_legacy_tracks=0 dynamic_bootstrap_candidates=0 dynamic_bootstrap_seed_support=0 dynamic_bootstrap_seed_pairs=0 dynamic_bootstrap_seed_landmarks=0 dynamic_bootstrap_direct_fallbacks=0 direct_bridge_pair_visits=0 direct_bridge_correspondences=0 direct_bridge_registrations=0 motion_bridge_pair_visits=0 motion_bridge_estimation_failures=0 motion_bridge_rotation_rejections=0 motion_bridge_registrations=0 deferred_pair_visits=0 deferred_correspondences=0 deferred_pnp_attempts=0 deferred_pnp_estimation_failures=0 deferred_pnp_inlier_rejections=0 deferred_registrations=0 deferred_interpolation_registrations=0 deferred_observations_attached=0 deferred_retriangulated_tracks=0 deferred_retriangulated_observations=0 unregistered_zero_support=0 unregistered_below_pnp_support=0 unregistered_eligible_pnp=0 unregistered_below_sensors=0 max_unregistered_support=0 local_ba_runs=50 ba_retriangulated_tracks=0 ba_requeued_frames=0 structure_refined_tracks=2730 geometry_recovered_tracks=0 geometry_recovered_observations=0 track_completion_passes=0 track_completion_pair_visits=0 track_completion_observations=0 track_completion_reprojection_rejections=0 final_filter_refinement_passes=0 final_filter_refinement_pruned_observations=0 isolated_pose_repair_passes=0 isolated_pose_repairs=0 paired_pose_jump_repairs=0 paired_pose_jump_repaired_frames=0 out=/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b/model\n",
+      "time_output": "\tCommand being timed: \"timeout --signal=TERM --kill-after=10s 180s /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/rig-9d7868b --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-1000/features256 --snapshot /home/sasaki/datasets/openloris/corridor1-1-m6/tier-1000-lsh6t8/mapping/verified-merged.vps --local-ba-covisibility --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-b/model\"\n\tUser time (seconds): 4.26\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 99%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:04.37\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 82440\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 23628\n\tVoluntary context switches: 4\n\tInvoluntary context switches: 41\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 7320\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n"
+    }
+  },
+  "score_command": "python3 scripts/score_openloris_model.py --model-images /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model/images.txt --manifest /home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json --ground-truth /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt --transform-matrix /home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+  "score": {
+    "component_weighted_max_m": 0.07202738615835552,
+    "component_weighted_median_m": 0.023250711940511225,
+    "component_weighted_p95_m": 0.037302368282162233,
+    "component_weighted_rmse_m": 0.02521553018080179,
+    "components": [
+      {
+        "gt_scored": 308,
+        "images_txt": "/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model/images.txt",
+        "images_txt_sha256": "cfbaa266a18ac69411c9ef45c60b5bd17850c583606bf18e0d74bd5c0b55faf9",
+        "max_m": 0.07202738615835552,
+        "median_m": 0.023250711940511225,
+        "p95_m": 0.037302368282162233,
+        "reference_extent_m": 1.9718678959594034,
+        "registered": 1000,
+        "relative_rmse": 0.012787636652775509,
+        "rmse_m": 0.02521553018080179,
+        "sim3_scale": 1.3608132814221663,
+        "trajectory_segments": [
+          {
+            "images": 32,
+            "max_m": 0.029312244736700674,
+            "median_m": 0.02564245943086249,
+            "p95_m": 0.027651455311632996,
+            "rmse_m": 0.025520428769782187,
+            "segment": 0,
+            "timestamp_end": 1560000015.556828,
+            "timestamp_start": 1560000015.056853
+          },
+          {
+            "images": 30,
+            "max_m": 0.030612054376478515,
+            "median_m": 0.02540451226706118,
+            "p95_m": 0.029989181745311504,
+            "rmse_m": 0.0250812828354952,
+            "segment": 1,
+            "timestamp_end": 1560000016.056906,
+            "timestamp_start": 1560000015.590162
+          },
+          {
+            "images": 32,
+            "max_m": 0.02786563814138815,
+            "median_m": 0.016624024800202895,
+            "p95_m": 0.02333559592574333,
+            "rmse_m": 0.0175535450943242,
+            "segment": 2,
+            "timestamp_end": 1560000016.590147,
+            "timestamp_start": 1560000016.09024
+          },
+          {
+            "images": 30,
+            "max_m": 0.032961111621066165,
+            "median_m": 0.02412102918951664,
+            "p95_m": 0.028867875236901045,
+            "rmse_m": 0.023829465232525673,
+            "segment": 3,
+            "timestamp_end": 1560000017.09023,
+            "timestamp_start": 1560000016.623481
+          },
+          {
+            "images": 30,
+            "max_m": 0.03682308976705602,
+            "median_m": 0.031861192014089296,
+            "p95_m": 0.03599227647379792,
+            "rmse_m": 0.031269418206462125,
+            "segment": 4,
+            "timestamp_end": 1560000017.590167,
+            "timestamp_start": 1560000017.123563
+          },
+          {
+            "images": 32,
+            "max_m": 0.03756044132875792,
+            "median_m": 0.022145257566943015,
+            "p95_m": 0.03453045553238497,
+            "rmse_m": 0.024795132576776704,
+            "segment": 5,
+            "timestamp_end": 1560000018.123552,
+            "timestamp_start": 1560000017.623501
+          },
+          {
+            "images": 30,
+            "max_m": 0.025955219931424526,
+            "median_m": 0.015519327696614897,
+            "p95_m": 0.024517522394394052,
+            "rmse_m": 0.015880007416959396,
+            "segment": 6,
+            "timestamp_end": 1560000018.623534,
+            "timestamp_start": 1560000018.156885
+          },
+          {
+            "images": 30,
+            "max_m": 0.04416287552195437,
+            "median_m": 0.019257148362300695,
+            "p95_m": 0.03915929680337226,
+            "rmse_m": 0.024393993751903383,
+            "segment": 7,
+            "timestamp_end": 1560000019.123582,
+            "timestamp_start": 1560000018.656868
+          },
+          {
+            "images": 32,
+            "max_m": 0.07202738615835552,
+            "median_m": 0.027112074396820562,
+            "p95_m": 0.06448414462134418,
+            "rmse_m": 0.03683323666987334,
+            "segment": 8,
+            "timestamp_end": 1560000019.666914,
+            "timestamp_start": 1560000019.156915
+          },
+          {
+            "images": 30,
+            "max_m": 0.03184295817453498,
+            "median_m": 0.01817512301375976,
+            "p95_m": 0.029496736913539077,
+            "rmse_m": 0.01948207738849432,
+            "segment": 9,
+            "timestamp_end": 1560000020.166894,
+            "timestamp_start": 1560000019.700247
+          }
+        ]
+      }
+    ],
+    "ground_truth": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/groundtruth.txt",
+    "ground_truth_sha256": "8bac84df6e0ec2ab1d08f0e3d5c47b1da067911ee9a814471b96ef13637a8e2d",
+    "ground_truth_used_only_for_post_mapping_score": true,
+    "gt_interpolated_images": 308,
+    "gt_scored_images": 308,
+    "image_aliases": null,
+    "image_aliases_sha256": null,
+    "manifest": "/home/sasaki/datasets/openloris/corridor1-1-m5/manifests/tier-1000.json",
+    "manifest_images": 1000,
+    "manifest_sha256": "f1ed9292c806103c1d129340f429bc74e5ba4842c6092b836d541cd518256baa",
+    "max_interpolation_gap_seconds": 0.1,
+    "models": 1,
+    "registered_images": 1000,
+    "schema": "visloc_openloris_model_score_v1",
+    "score_convention": "per-component Sim(3), image-weighted aggregate",
+    "scorer_sha256": "c0196be50b4b7ee385bd8db437a8fa6cae508fb0d4a9ecc4038981c94455d5d0",
+    "trajectory_segments": [
+      {
+        "images": 32,
+        "max_m": 0.029312244736700674,
+        "median_m": 0.02564245943086249,
+        "p95_m": 0.027651455311632996,
+        "rmse_m": 0.025520428769782187,
+        "segment": 0,
+        "timestamp_end": 1560000015.556828,
+        "timestamp_start": 1560000015.056853
+      },
+      {
+        "images": 30,
+        "max_m": 0.030612054376478515,
+        "median_m": 0.02540451226706118,
+        "p95_m": 0.029989181745311504,
+        "rmse_m": 0.0250812828354952,
+        "segment": 1,
+        "timestamp_end": 1560000016.056906,
+        "timestamp_start": 1560000015.590162
+      },
+      {
+        "images": 32,
+        "max_m": 0.02786563814138815,
+        "median_m": 0.016624024800202895,
+        "p95_m": 0.02333559592574333,
+        "rmse_m": 0.0175535450943242,
+        "segment": 2,
+        "timestamp_end": 1560000016.590147,
+        "timestamp_start": 1560000016.09024
+      },
+      {
+        "images": 30,
+        "max_m": 0.032961111621066165,
+        "median_m": 0.02412102918951664,
+        "p95_m": 0.028867875236901045,
+        "rmse_m": 0.023829465232525673,
+        "segment": 3,
+        "timestamp_end": 1560000017.09023,
+        "timestamp_start": 1560000016.623481
+      },
+      {
+        "images": 30,
+        "max_m": 0.03682308976705602,
+        "median_m": 0.031861192014089296,
+        "p95_m": 0.03599227647379792,
+        "rmse_m": 0.031269418206462125,
+        "segment": 4,
+        "timestamp_end": 1560000017.590167,
+        "timestamp_start": 1560000017.123563
+      },
+      {
+        "images": 32,
+        "max_m": 0.03756044132875792,
+        "median_m": 0.022145257566943015,
+        "p95_m": 0.03453045553238497,
+        "rmse_m": 0.024795132576776704,
+        "segment": 5,
+        "timestamp_end": 1560000018.123552,
+        "timestamp_start": 1560000017.623501
+      },
+      {
+        "images": 30,
+        "max_m": 0.025955219931424526,
+        "median_m": 0.015519327696614897,
+        "p95_m": 0.024517522394394052,
+        "rmse_m": 0.015880007416959396,
+        "segment": 6,
+        "timestamp_end": 1560000018.623534,
+        "timestamp_start": 1560000018.156885
+      },
+      {
+        "images": 30,
+        "max_m": 0.04416287552195437,
+        "median_m": 0.019257148362300695,
+        "p95_m": 0.03915929680337226,
+        "rmse_m": 0.024393993751903383,
+        "segment": 7,
+        "timestamp_end": 1560000019.123582,
+        "timestamp_start": 1560000018.656868
+      },
+      {
+        "images": 32,
+        "max_m": 0.07202738615835552,
+        "median_m": 0.027112074396820562,
+        "p95_m": 0.06448414462134418,
+        "rmse_m": 0.03683323666987334,
+        "segment": 8,
+        "timestamp_end": 1560000019.666914,
+        "timestamp_start": 1560000019.156915
+      },
+      {
+        "images": 30,
+        "max_m": 0.03184295817453498,
+        "median_m": 0.01817512301375976,
+        "p95_m": 0.029496736913539077,
+        "rmse_m": 0.01948207738849432,
+        "segment": 9,
+        "timestamp_end": 1560000020.166894,
+        "timestamp_start": 1560000019.700247
+      }
+    ],
+    "transform_matrix": "/home/sasaki/datasets/openloris/official-groundtruth/calibration/corridor1-1/trans_matrix.yaml",
+    "transform_matrix_sha256": "aa133ada81e6c168acb2233b9f93d145bf8216c83d54b34db92e4944bafd3e69"
+  },
+  "limits": [
+    "Mapper-only1k; not native E2E or10k proof.",
+    "RMSE0.02521553018080179 exceeds frozen0.02269532080131782; reprojection0.703792384 exceeds0.6716373819326764. Reject unchanged policy; no larger-tier promotion.",
+    "Default-off control exactly matches retained legacy model; candidate repeats match all three model files."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-1000-covisibility-v1.json
+++ b/benchmarks/electro/m8-openloris-1000-covisibility-v1.json
@@ -1,6 +1,8 @@
 {
   "schema": "m8-openloris-1000-covisibility-v1",
   "status": "repeated-quality-regression-not-promoted",
+  "geometry_command": "python3 scripts/audit_colmap_pinhole_model.py /home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt",
+  "geometry": [{"model":"/home/sasaki/datasets/openloris/corridor1-1-m8-bounded-native-v1/covisibility-1k/candidate-a/model","image_poses":1000,"supported_images":1000,"unsupported_image_ids":[],"landmarks":2763,"observations":28898,"mean_reprojection_px":0.7037923837204834,"observation_weighted_mean_reprojection_px":0.7037923837204834,"point_weighted_mean_reprojection_px":0.7173899673965904,"max_track_mean_reprojection_px":3.4075767045554626,"max_reprojection_px":3.9951611319315514,"max_stored_mean_difference_px":3.4075767045554626,"nonpositive_depth_observations":0,"tracks_with_multiple_keypoints_in_one_image":0,"excess_same_image_track_observations":0,"bidirectional_references_valid":true,"rig":{"rig_manifest":"/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-1000/rig-manifest.txt","rig_frames":500,"supported_rig_frames":500,"unsupported_rig_frame_ids":[],"max_inferred_rig_center_disagreement_m":3.2625801586147356e-12,"max_inferred_rig_rotation_disagreement_deg":0.0000012074182697257333,"fixed_sensor_extrinsics_valid":true,"track_connected_components":1,"track_connected_component_sizes":[500],"track_connected_component_frame_ranges":[[0,499]]}}],
   "build_commit": "9d7868bf44b19cccbcaa6503c1018cf9867956f0",
   "binary_sha256": "3dc9d3f9302c73bc58a218cd3ca0239450e877fad0bb9a4998ca596bc2dfcc79",
   "commands": {

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,18 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 最新: `feat/m8-covisibility-local-ba`。PR107は最終head6914606のCI9件成功後
+> `f7ab2ca`へmerge。共視選択を既定OFFの`--local-ba-covisibility`として追加。
+> rig_sfm39テスト、CLI check、lib clippy通過。release source9d7868b、57.05秒。
+> 保存binary `corridor1-1-m8-bounded-native-v1/rig-9d7868b` SHA256
+> `3dc9d3f9302c73bc58a218cd3ca0239450e877fad0bb9a4998ca596bc2dfcc79`。
+> `covisibility-1k/control`はLegacy全3ファイル一致。candidate-a/bも全3ファイル一致。
+> 1000画像/500frameすべて支持あり、正深度/固定rig/双方向参照正常、連結成分1。
+> ただしRMSE0.025216mと再投影0.703792pxは既存gateを超えるため不採用。
+> 証跡 `m8-openloris-1000-covisibility-v1.json`。このまま上位tierへ進めない。
+> 全goal未達。支持欠落やrig破損が今回の品質低下を説明する証拠はない。
+> strong-boundary候補bをaへ全6ファイルcmp後hardlink化済み、パス/bytes保持。
+> 空き約119MiB。新規run名を使い、既存hardlinkモデルは上書き禁止。
+
 > 現branch `test/m8-strong-boundary-10k`。旧strong30/deferred8/direct2/s1/rot5条件をtimeログから復元。
 > manifest/snapshot/visloc pose-prior2ファイルSHA確認済み。契約 `m8-openloris-strong-boundary-contract-v1.json`。
 > 同binary `rig-7d99e07` の `strong-boundary-10k/control` はexit0、過去9998画像モデル全成分bytes一致。

--- a/docs/openloris_atlas_selection_cost_audit.md
+++ b/docs/openloris_atlas_selection_cost_audit.md
@@ -1,0 +1,43 @@
+# Atlas selection cost audit (2026-09-08)
+
+This is a source/log audit, not a performance measurement or quality pass.
+The closest retained scaled atlas still fails COLMAP RMSE and its1k gate.
+Do not revive it as a promoted end-to-end pipeline.
+
+## Observed work
+
+`selected_landmarks_for_frames` in `integrate_rig_atlas_landmarks.rs` visits
+every landmark per window and checks its observations for an active frame.
+The filtering runner calls this once per window. Saved accepted-window logs
+from `corridor1-1-m8-atlas-landmarks-v1/connected-filtered-ba-v1` contain:
+
+| Component | Accepted windows | Selected landmark events | Selected observation events |
+|---|---:|---:|---:|
+| main | 150 | 846728 | 5504692 |
+| tail | 17 | 82904 | 392637 |
+
+These are events, not unique points. Final retained landmark counts are318222
+and34615. Since this filtering pass only removes landmarks, selection inspects
+at least47733300 and588455 landmark entries respectively. These bounds exclude
+observation visits, validation, connectivity and solver work. They do not prove
+that selection dominates wall time; there is no phase timer in this runner.
+
+## Safe next optimization boundary
+
+Before replacing selection, measure its elapsed time separately from solving,
+validation/connectivity and application/compaction on an unchanged replay.
+An index must preserve exactly the ascending current landmark-index selection,
+not select only the top covisible tracks. Every active observation remains in
+scope. Persistent IDs must survive accepted-window landmark compaction and
+observation deletion; stale-index reuse could silently omit constraints.
+
+Potential state is frame-to-track incidence O(observations), not frame-pair
+adjacency O(N²). Its additional RSS must be measured. Updating/rebuilding it
+after every compaction may erase the speed benefit. Retain the full-scan oracle
+for differential tests, including deleted tracks, multi-camera duplicate frame
+incidence and repeated windows. Do not remove the independent selection or
+connectivity validation just to improve a timing number.
+
+This work can reduce unchanged-objective overhead. It cannot itself fix the
+remaining trajectory error or establish native end-to-end parity. Those gates
+remain explicit in the M8–M10 plan.

--- a/docs/openloris_covisibility_local_ba.md
+++ b/docs/openloris_covisibility_local_ba.md
@@ -1,0 +1,79 @@
+# Bounded covisibility local BA experiment
+
+Status: design frozen before measurement, not implemented or promoted.
+
+## Evidence and hypothesis
+
+The repeated strong/deferred boundary arm regresses trajectory and mapper time
+despite retaining9998 image poses; see
+[result](../benchmarks/electro/m8-openloris-strong-boundary-result-v1.json).
+Do not combine that rejected arm with this experiment.
+
+Both native registration paths currently choose the last40 registrations for
+local BA. Registration order need not express useful geometric overlap.
+Hypothesis: selecting already registered neighbors with shared usable landmarks
+can improve the constraints in the same bounded pose budget. This does not
+establish that selection explains the remaining10k trajectory error.
+
+[COLMAP AdjustLocalBundle](https://github.com/colmap/colmap/blob/main/src/colmap/sfm/incremental_mapper.cc)
+selects images using shared3D points, includes their rig frames, and separately
+controls gauges and variable landmarks. This is design evidence inspected on
+2026-09-08, not a pinned version of the benchmark executable. The policy below
+is our proposed adaptation, not an exact reproduction of COLMAP.
+
+## Single-factor contract
+
+- Add an opt-in selector; default registration-order selection remains exact.
+- Keep window cap40, BA frequency, iterations, solver, calibration, feature and
+  pair inputs, registration thresholds and final BA unchanged.
+- Boundary observations and disconnected-component anchoring stay disabled.
+- Select the newest registered frame plus at most39 registered neighbors.
+- Count distinct shared positioned tracks, not camera observations: stereo
+  observations cannot give two votes for the same track/frame.
+- Require a usable observation in the newest frame and in each counted neighbor:
+  positive projection and the existing BA gate of2×max_reprojection_error_px.
+  Honor the existing metric-only filter when that option is enabled.
+- Rank by descending shared-track count, then ascending frame ID. Do not pad
+  with zero-overlap frames. With no neighbor, skip local BA explicitly.
+- Anchor the earliest registered selected frame. This preserves the existing
+  oldest-in-window gauge rule, but its identity may change with selection.
+  Do not fix the newest PnP pose or choose anchors using GT errors.
+- Both legacy and dynamic paths call the same selector. Final BA is unchanged.
+
+## Resource and ownership contract
+
+Reuse `image_tracks` from each registration path to enumerate only tracks
+incident to the newest frame. Deduplicate track IDs before visiting their
+observations. Maintain temporary neighbor counts and a per-track frame set;
+do not retain a global frame-pair graph or scan every track to find neighbors.
+Use a bounded top-K heap with deterministic ties, not a full candidate sort.
+Temporary storage is O(incident tracks + distinct neighbors + longest incident
+track + K); neighbor count can be O(N), but no N² state is introduced.
+Selection time depends on incident observations, not just K: long tracks must
+be represented in synthetic tests and measured, not described as constant cost.
+Existing BA still scans tracks when assembling its problem; this proposal does
+not claim to remove that independent cost.
+
+## Verification order and rejection gates
+
+1. Unit tests: recent-vs-shared selection, duplicate stereo votes, unusable and
+   unpositioned tracks, unregistered neighbors, deterministic ties and reversed
+   input order, cap0/1/40, no-neighbor skip, oldest selected anchor, metric-only
+   filter and long-track/100k-frame sparse state. Check both call sites.
+2. Same-binary default-off1k control must match retained model files exactly.
+   Run candidate1k twice; audit registration, support, fixed rig, positive depth,
+   reprojection and GT with frozen scorer. Reject quality regression; do not
+   tune on individual GT frame IDs or relax gates to rescue it.
+3. If1k passes, run independent2.5k, derived5k with its scope disclosed, then
+   the complete10k control/candidate repeats. Record selection cost, mapper wall
+   and peak RSS, not merely BA iterations. Recheck unsupported rig frames.
+4.10k must meet the frozen COLMAP registration, support, RMSE, p95 and
+   reprojection gates, plus RSS≤2097152KiB. A small-tier win is not promotion.
+5. Only an eligible candidate proceeds to independent final-tier validation,
+   native end-to-end accounting including saved-prior generation, restart and
+   100k I/O stress. No README superiority claim before those gates pass.
+
+Disk preflight is mandatory before build and each run: current filesystem has
+under100MiB available. Preserve input datasets and prior evidence. Reclaim only
+verified duplicate experiment output storage or obtain additional capacity;
+never overwrite existing hardlinked model outputs.

--- a/docs/openloris_covisibility_local_ba.md
+++ b/docs/openloris_covisibility_local_ba.md
@@ -1,6 +1,11 @@
 # Bounded covisibility local BA experiment
 
-Status: design frozen before measurement, not implemented or promoted.
+Status: opt-in implementation added, not benchmarked or promoted.
+`--local-ba-covisibility` selects the same helper in legacy and dynamic paths.
+Initial selector tests cover stereo deduplication, ties, input order, caps,
+unusable/unpositioned tracks and a100k-frame long track. CLI check passes.
+Remaining tests include native fixed-state behavior, oldest selected anchor and
+metric-only integration; all model parity and performance gates remain open.
 
 ## Evidence and hypothesis
 
@@ -77,3 +82,5 @@ Disk preflight is mandatory before build and each run: current filesystem has
 under100MiB available. Preserve input datasets and prior evidence. Reclaim only
 verified duplicate experiment output storage or obtain additional capacity;
 never overwrite existing hardlinked model outputs.
+The strong-boundary candidate-b six model files were rechecked with `cmp` and
+hardlinked to candidate-a, recovering about100MiB while preserving paths/bytes.

--- a/docs/openloris_covisibility_local_ba.md
+++ b/docs/openloris_covisibility_local_ba.md
@@ -1,11 +1,19 @@
 # Bounded covisibility local BA experiment
 
-Status: opt-in implementation added, not benchmarked or promoted.
+Status: opt-in implementation fails1k quality gates; not promoted.
+Same-binary default-off control matches Legacy exactly. Two candidate runs
+produce identical model files and register1000 images, but RMSE0.025216m
+exceeds0.022695m and reprojection0.703792px exceeds0.671637px.
+See [repeat evidence](../benchmarks/electro/m8-openloris-1000-covisibility-v1.json).
+Do not advance this unchanged policy to larger tiers or tune thresholds on GT.
 `--local-ba-covisibility` selects the same helper in legacy and dynamic paths.
 Initial selector tests cover stereo deduplication, ties, input order, caps,
 unusable/unpositioned tracks and a100k-frame long track. CLI check passes.
-Remaining tests include native fixed-state behavior, oldest selected anchor and
-metric-only integration; all model parity and performance gates remain open.
+The native fixed-state fixtures now obtain their active set through the selector
+and check oldest selected anchor, unregistered observations, metric-only filtering
+and default-off selection. All39 rig_sfm tests pass, including fixed-state and
+rollback tests. Default parity and repeatability pass; quality fails. Larger-tier
+and native E2E gates remain open, not implied by these tests.
 
 ## Evidence and hypothesis
 

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -11,6 +11,14 @@ BA changes are possible means, not milestone success by themselves.
 
 ## Latest checkpoint (2026-09-08)
 
+Bounded covisibility local-window selection is opt-in and fails the frozen1k
+quality gate: repeated RMSE0.025216m and reprojection0.703792px. All1000 images
+and500 rig frames are supported, with positive depths, valid fixed rig and one
+connected track component. Default-off output matches Legacy exactly. Do not
+promote this policy or run larger tiers unchanged. See
+[contract](openloris_covisibility_local_ba.md) and
+[evidence](../benchmarks/electro/m8-openloris-1000-covisibility-v1.json).
+
 Fixed-boundary observations are implemented default-off (PR105 merged) and
 tested on same-binary controls. 1k/independent2.5k/derived5k pass registration,
 trajectory and reprojection nonregression with exact two-run model equality.

--- a/examples/generalized_rig_sfm.rs
+++ b/examples/generalized_rig_sfm.rs
@@ -126,6 +126,7 @@ struct Args {
     ba_backend: RigBaBackend,
     ba_anchor_disconnected_components: bool,
     ba_fixed_boundary_observations: bool,
+    local_ba_covisibility: bool,
     structure_refinement_iterations: usize,
     preview_rig_correspondence_csr: bool,
     preview_pair_confidence_conflicts: bool,
@@ -250,6 +251,7 @@ fn parse_args() -> Result<Args, String> {
     let mut ba_backend = defaults.ba_backend;
     let mut ba_anchor_disconnected_components = defaults.ba_anchor_disconnected_components;
     let mut ba_fixed_boundary_observations = defaults.ba_fixed_boundary_observations;
+    let mut local_ba_covisibility = defaults.local_ba_covisibility;
     let mut ba_backend_seen = false;
     let mut structure_refinement_iterations = defaults.structure_refinement_iterations;
     let mut preview_rig_correspondence_csr = false;
@@ -563,6 +565,7 @@ fn parse_args() -> Result<Args, String> {
             }
             "--ba-anchor-disconnected-components" => ba_anchor_disconnected_components = true,
             "--ba-fixed-boundary-observations" => ba_fixed_boundary_observations = true,
+            "--local-ba-covisibility" => local_ba_covisibility = true,
             "--structure-refinement-iterations" => {
                 structure_refinement_iterations =
                     value()?.parse().map_err(|error| format!("{error}"))?
@@ -623,7 +626,7 @@ fn parse_args() -> Result<Args, String> {
                     "[--local-ba-iterations 8] [--ba-huber-delta 6] ",
                     "[--ba-backend legacy|matrix-free|matrix-free-cluster8|matrix-free-cluster8-restart1|matrix-free-qr|bounded-direct64-qr] ",
                     "[--ba-anchor-disconnected-components] ",
-                    "[--ba-fixed-boundary-observations] ",
+                    "[--ba-fixed-boundary-observations] [--local-ba-covisibility] ",
                     "[--structure-refinement-iterations 5] ",
                     "[--metric-anchored-cycle-tracks|--metric-temporal-cycle-tracks|",
                     "--metric-sparse-cycle-tracks|",
@@ -917,6 +920,7 @@ fn parse_args() -> Result<Args, String> {
         ba_backend,
         ba_anchor_disconnected_components,
         ba_fixed_boundary_observations,
+        local_ba_covisibility,
         structure_refinement_iterations,
         preview_rig_correspondence_csr,
         preview_pair_confidence_conflicts,
@@ -1698,6 +1702,7 @@ fn mapper_config(args: &Args) -> RigSfmConfig {
         ba_backend: args.ba_backend,
         ba_anchor_disconnected_components: args.ba_anchor_disconnected_components,
         ba_fixed_boundary_observations: args.ba_fixed_boundary_observations,
+        local_ba_covisibility: args.local_ba_covisibility,
         structure_refinement_iterations: args.structure_refinement_iterations,
         dynamic_correspondence_tracking: args.dynamic_correspondence_tracking,
         ba_config: visloc_rs::BaConfig {

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -245,6 +245,8 @@ pub struct RigSfmConfig {
     pub ba_config: BaConfig,
     pub local_ba_every: usize,
     pub local_ba_window_size: usize,
+    /// Select bounded neighbors sharing usable landmarks instead of recent frames.
+    pub local_ba_covisibility: bool,
     pub local_ba_iterations: usize,
     pub final_ba_passes: usize,
     pub final_ba_window_size: usize,
@@ -326,6 +328,7 @@ impl Default for RigSfmConfig {
             },
             local_ba_every: 10,
             local_ba_window_size: 40,
+            local_ba_covisibility: false,
             local_ba_iterations: 8,
             final_ba_passes: 2,
             final_ba_window_size: 60,
@@ -595,6 +598,119 @@ struct WorkingTrack {
     observations: Vec<(usize, usize)>,
     position: Option<Point3<f64>>,
     metric_anchored: bool,
+}
+
+/// Visit only indexed incident tracks; never materialize a frame-pair graph.
+fn covisible_local_frames(
+    newest: usize,
+    cap: usize,
+    incident_tracks: impl IntoIterator<Item = usize>,
+    tracks: &[WorkingTrack],
+    image_assignment: &[(usize, usize)],
+    mut usable: impl FnMut(usize, usize, &WorkingTrack) -> bool,
+) -> HashSet<usize> {
+    if cap < 2 {
+        return HashSet::new();
+    }
+    let mut seen_tracks = HashSet::new();
+    let mut counts = HashMap::<usize, usize>::new();
+    let mut frames = HashSet::new();
+    for id in incident_tracks {
+        if !seen_tracks.insert(id) {
+            continue;
+        }
+        let track = &tracks[id];
+        if track.position.is_none() {
+            continue;
+        }
+        frames.clear();
+        for &(image, keypoint) in &track.observations {
+            if usable(image, keypoint, track) {
+                frames.insert(image_assignment[image].0);
+            }
+        }
+        if !frames.remove(&newest) {
+            continue;
+        }
+        for &frame in &frames {
+            *counts.entry(frame).or_default() += 1;
+        }
+    }
+    // The heap root is the worst retained candidate: low count, then high ID.
+    let mut best = BinaryHeap::new();
+    for (frame, count) in counts {
+        best.push(Reverse((count, Reverse(frame))));
+        if best.len() > cap - 1 {
+            best.pop();
+        }
+    }
+    if best.is_empty() {
+        return HashSet::new();
+    }
+    let mut selected = best
+        .into_iter()
+        .map(|Reverse((_, Reverse(frame)))| frame)
+        .collect::<HashSet<_>>();
+    selected.insert(newest);
+    selected
+}
+
+#[allow(clippy::too_many_arguments)]
+fn select_local_ba_frames(
+    rig: &GeneralizedCameraRig,
+    frames: &[RigFrame],
+    features: &[FeatureSet],
+    image_assignment: &[(usize, usize)],
+    image_tracks: &[Vec<(usize, usize)>],
+    image_poses: &[Option<Pose>],
+    tracks: &[WorkingTrack],
+    registration_order: &[usize],
+    config: &RigSfmConfig,
+) -> (HashSet<usize>, usize) {
+    let start = registration_order
+        .len()
+        .saturating_sub(config.local_ba_window_size);
+    if !config.local_ba_covisibility {
+        return (
+            registration_order[start..].iter().copied().collect(),
+            registration_order[start],
+        );
+    }
+    let newest = *registration_order
+        .last()
+        .expect("local BA requires registration");
+    let active = covisible_local_frames(
+        newest,
+        config.local_ba_window_size,
+        frames[newest]
+            .images
+            .iter()
+            .flat_map(|image| image_tracks[image.image_index].iter().map(|&(_, id)| id)),
+        tracks,
+        image_assignment,
+        |image, keypoint, track| {
+            if config.ba_metric_tracks_only && !track.metric_anchored {
+                return false;
+            }
+            let Some(pose) = &image_poses[image] else {
+                return false;
+            };
+            let sensor = &rig.sensors()[image_assignment[image].1];
+            sensor
+                .camera
+                .project(&pose.transform_world_point(&track.position.unwrap()))
+                .is_some_and(|pixel| {
+                    (pixel - features[image].keypoints[keypoint]).norm()
+                        <= 2.0 * config.max_reprojection_error_px
+                })
+        },
+    );
+    let anchor = registration_order
+        .iter()
+        .copied()
+        .find(|frame| active.contains(frame))
+        .unwrap_or(newest);
+    (active, anchor)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1092,34 +1208,38 @@ pub fn incremental_rig_sfm(
                 && config.local_ba_window_size >= 2
                 && registration_order.len() % config.local_ba_every == 0
             {
-                let start = registration_order
-                    .len()
-                    .saturating_sub(config.local_ba_window_size);
-                let active_frames = registration_order[start..]
-                    .iter()
-                    .copied()
-                    .collect::<HashSet<_>>();
-                let anchor = registration_order[start];
+                let (active_frames, anchor) = select_local_ba_frames(
+                    rig,
+                    frames,
+                    features,
+                    &image_assignment,
+                    &image_tracks,
+                    &image_poses,
+                    &tracks,
+                    &registration_order,
+                    config,
+                );
                 let local_ba_config = BaConfig {
                     max_iterations: config.local_ba_iterations,
                     ..config.ba_config
                 };
-                if run_rig_bundle_adjustment(
-                    rig,
-                    features,
-                    &image_assignment,
-                    config,
-                    &active_frames,
-                    anchor,
-                    &local_ba_config,
-                    0,
-                    &[],
-                    false,
-                    &mut frame_poses,
-                    &mut image_poses,
-                    &mut tracks,
-                )?
-                .is_some()
+                if !active_frames.is_empty()
+                    && run_rig_bundle_adjustment(
+                        rig,
+                        features,
+                        &image_assignment,
+                        config,
+                        &active_frames,
+                        anchor,
+                        &local_ba_config,
+                        0,
+                        &[],
+                        false,
+                        &mut frame_poses,
+                        &mut image_poses,
+                        &mut tracks,
+                    )?
+                    .is_some()
                 {
                     work.local_ba_runs += 1;
                     if config.ba_metric_tracks_only {
@@ -2765,34 +2885,38 @@ fn dynamic_grow_from_seed(
             && config.local_ba_window_size >= 2
             && registration_order.len() % config.local_ba_every == 0
         {
-            let start = registration_order
-                .len()
-                .saturating_sub(config.local_ba_window_size);
-            let active_frames = registration_order[start..]
-                .iter()
-                .copied()
-                .collect::<HashSet<_>>();
-            let anchor = registration_order[start];
+            let (active_frames, anchor) = select_local_ba_frames(
+                rig,
+                frames,
+                features,
+                image_assignment,
+                &image_tracks,
+                &image_poses,
+                &tracks,
+                &registration_order,
+                config,
+            );
             let local_ba_config = BaConfig {
                 max_iterations: config.local_ba_iterations,
                 ..config.ba_config
             };
-            if run_rig_bundle_adjustment(
-                rig,
-                features,
-                image_assignment,
-                config,
-                &active_frames,
-                anchor,
-                &local_ba_config,
-                0,
-                &[],
-                false,
-                &mut frame_poses,
-                &mut image_poses,
-                &mut tracks,
-            )?
-            .is_some()
+            if !active_frames.is_empty()
+                && run_rig_bundle_adjustment(
+                    rig,
+                    features,
+                    image_assignment,
+                    config,
+                    &active_frames,
+                    anchor,
+                    &local_ba_config,
+                    0,
+                    &[],
+                    false,
+                    &mut frame_poses,
+                    &mut image_poses,
+                    &mut tracks,
+                )?
+                .is_some()
             {
                 work.local_ba_runs += 1;
                 let affected_tracks = active_frames
@@ -7347,6 +7471,59 @@ mod tests {
     use visloc_vision::pnp::RigSensor;
 
     use super::*;
+
+    #[test]
+    fn covisibility_deduplicates_stereo_votes_and_selects_deterministically() {
+        let assignments = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (3, 0)];
+        let track = |images: &[usize]| WorkingTrack {
+            observations: images.iter().map(|&image| (image, 0)).collect(),
+            position: Some(Point3::new(0.0, 0.0, 1.0)),
+            metric_anchored: true,
+        };
+        let tracks = vec![track(&[0, 1, 2, 3, 4]), track(&[0, 4]), track(&[5])];
+        let selected =
+            covisible_local_frames(0, 2, [0, 0, 1, 2], &tracks, &assignments, |_, _, _| true);
+        assert_eq!(selected, HashSet::from([0, 2]));
+        assert_eq!(
+            selected,
+            covisible_local_frames(0, 2, [2, 1, 0], &tracks, &assignments, |_, _, _| true)
+        );
+        assert_eq!(
+            covisible_local_frames(0, 2, [0], &tracks, &assignments, |_, _, _| true),
+            HashSet::from([0, 1])
+        );
+        assert!(
+            covisible_local_frames(0, 40, [0, 1], &tracks, &assignments, |image, _, _| image
+                > 1)
+            .is_empty()
+        );
+        for cap in [0, 1] {
+            assert!(
+                covisible_local_frames(0, cap, [0, 1], &tracks, &assignments, |_, _, _| true)
+                    .is_empty()
+            );
+        }
+    }
+
+    #[test]
+    fn covisibility_long_track_keeps_bounded_window() {
+        let assignments = (0..100_000).map(|frame| (frame, 0)).collect::<Vec<_>>();
+        let mut tracks = vec![WorkingTrack {
+            observations: (0..100_000).map(|image| (image, 0)).collect(),
+            position: Some(Point3::new(0.0, 0.0, 1.0)),
+            metric_anchored: true,
+        }];
+        let selected =
+            covisible_local_frames(99_999, 40, [0], &tracks, &assignments, |_, _, _| true);
+        assert_eq!(selected.len(), 40);
+        assert!(selected.contains(&99_999));
+        assert!((0..39).all(|frame| selected.contains(&frame)));
+        tracks[0].position = None;
+        assert!(
+            covisible_local_frames(99_999, 40, [0], &tracks, &assignments, |_, _, _| true)
+                .is_empty()
+        );
+    }
 
     #[test]
     fn registration_trace_line_formats_camera_center_precisely() {

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -9589,7 +9589,7 @@ mod tests {
         };
         let selection_config = RigSfmConfig {
             local_ba_covisibility: true,
-            ..config.clone()
+            ..config
         };
         let index = image_track_index(features.len(), &tracks);
         let select = |order: &[usize],
@@ -9627,7 +9627,7 @@ mod tests {
         }
         let metric_config = RigSfmConfig {
             ba_metric_tracks_only: true,
-            ..selection_config.clone()
+            ..selection_config
         };
         assert!(select(&[0, 1], &image_poses, &nonmetric, &metric_config)
             .0

--- a/pipelines/slam/src/rig_sfm.rs
+++ b/pipelines/slam/src/rig_sfm.rs
@@ -9581,13 +9581,61 @@ mod tests {
             .map(|(track, point)| (track.position.unwrap() - point).norm())
             .sum::<f64>()
             / world_points.len() as f64;
-        let active_frames = HashSet::from([0, 1]);
         let config = RigSfmConfig {
             ba_anchor_disconnected_components: component_anchors,
             final_bundle_adjustment: false,
             structure_refinement_iterations: 0,
             ..RigSfmConfig::default()
         };
+        let selection_config = RigSfmConfig {
+            local_ba_covisibility: true,
+            ..config.clone()
+        };
+        let index = image_track_index(features.len(), &tracks);
+        let select = |order: &[usize],
+                      poses: &[Option<Pose>],
+                      tracks: &[WorkingTrack],
+                      cfg: &RigSfmConfig| {
+            select_local_ba_frames(
+                &rig,
+                &frames,
+                &features,
+                &image_assignment,
+                &index,
+                poses,
+                tracks,
+                order,
+                cfg,
+            )
+        };
+        let (active_frames, anchor) = select(&[0, 1], &image_poses, &tracks, &selection_config);
+        assert_eq!(active_frames, HashSet::from([0, 1]));
+        assert_eq!(anchor, 0);
+        assert_eq!(
+            select(&[1, 0], &image_poses, &tracks, &selection_config).1,
+            1
+        );
+        let mut unsupported = image_poses.clone();
+        unsupported[0] = None;
+        unsupported[1] = None;
+        assert!(select(&[1], &unsupported, &tracks, &selection_config)
+            .0
+            .is_empty());
+        let mut nonmetric = tracks.clone();
+        for track in &mut nonmetric {
+            track.metric_anchored = false;
+        }
+        let metric_config = RigSfmConfig {
+            ba_metric_tracks_only: true,
+            ..selection_config.clone()
+        };
+        assert!(select(&[0, 1], &image_poses, &nonmetric, &metric_config)
+            .0
+            .is_empty());
+        assert_eq!(
+            select(&[0, 1], &image_poses, &tracks, &config).0,
+            active_frames
+        );
         let ba_config = BaConfig {
             max_iterations: 40,
             linear_solver: LinearSolver::Sparse,


### PR DESCRIPTION
Adds a default-off local BA selector using indexed incident tracks and bounded top-K neighbors, shared by both native registration paths. No global frame-pair graph.

Validation: 39 rig_sfm tests pass, including native fixed-state/rollback fixtures; CLI check and lib clippy pass. Same-binary 1k default-off control exactly matches retained Legacy models. Two candidates match all model files and support all 1000 images/500 rig frames with valid geometry. However RMSE 0.025216 m and reprojection 0.703792 px fail frozen quality gates. This experimental policy is NOT promoted and larger-tier benchmarking is stopped. Evidence, commands, hashes, scoring and geometry audit are retained. No README superiority claims or default changes.