### PR TITLE
Reproduce OpenLORIS SIFT shard and adaptive feature selection/merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           python3 -m pip install --quiet --disable-pip-version-check pillow numpy pytest opencv-python-headless py7zr
           python3 -m unittest discover -s tests -p 'test_*.py'
+          python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
       - name: Benchmark registry
         run: |

--- a/benchmarks/electro/m8-openloris-adaptive-bank-replay-audit-v1.json
+++ b/benchmarks/electro/m8-openloris-adaptive-bank-replay-audit-v1.json
@@ -1,0 +1,27 @@
+{
+  "status": "all-10000-feature-files-reproduced-in-memory",
+  "implementation_commit": "34fec72",
+  "base": "/home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-10000/features256",
+  "supplement": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/supplement-features",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/adaptive-features",
+  "selection": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/selection.json",
+  "method": "For each selected image, SHA-256 over HEADER followed by merged_rows(base, supplement) compared with the complete retained file hash. For each unselected image, compare complete base/reference file hashes. Compare exact directory-entry membership. Hash reads use 1 MiB chunks; merge retains only one image's base coordinates.",
+  "processed_feature_files": 10000,
+  "selected_images": 692,
+  "unchanged_images": 9308,
+  "missing": [],
+  "extra": [],
+  "hash_mismatches": [],
+  "base_loci_files": 0,
+  "adaptive_loci_files": 0,
+  "policy_disambiguation": {
+    "base_only_distance_reference": {"added_rows": 180924, "mismatching_selected_images": 0},
+    "base_plus_admitted_distance_reference": {"added_rows": 155780, "mismatching_selected_images": 691}
+  },
+  "limitations": [
+    "Retained supplemental descriptors are inputs, not re-extracted in this audit.",
+    "Output bytes were regenerated into streaming hashes, not published as a new bank; atomic output publication and restart remain untested.",
+    "No loci files exist in the base or adaptive reference bank. This does not prove downstream orientation metadata is unnecessary.",
+    "No continuous native E2E or speed-comparison claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-extraction-shard0-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-extraction-shard0-replay-v1.json
@@ -1,0 +1,13 @@
+{
+  "schema": "m8-openloris-extraction-shard0-replay-v1",
+  "status": "running-result-unverified",
+  "command": "set -Ce\nmkdir /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1\nenv RAYON_NUM_THREADS=8 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/extract.time timeout --signal=TERM --kill-after=10s 3600s /home/sasaki/datasets/openloris/corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a --feature-extractor sift --images-dir /home/sasaki/datasets/openloris/corridor1-1-m5/feature-extract/images/shard-0 --input-colmap-calibration /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-10000/calibration --sift-max-keypoints 256 --sift-max-orientations 2 --sift-l1-root --sift-vlfeat-compatible-detector --sift-vlfeat-compatible-descriptor --sift-vlfeat-bilinear-orientations --sift-vlfeat-compatible-output-order --sift-colmap-compatible-grayscale --sift-stream-export --export-features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/features --export-features-only --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/unused-model >/home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/extract.log 2>&1",
+  "binary_sha256": "8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34",
+  "threads": 8,
+  "expected_images": 1250,
+  "acceptance": "Exit zero; compare every feature/loci file and exact file membership to retained dense output; record wall/RSS without claiming whole-pipeline performance.",
+  "limitations": [
+    "One of eight shards, not full10k extraction or native E2E.",
+    "Saved new binary, recorded historical extractor flags, explicitly fixed thread count."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-extraction-shard0-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-extraction-shard0-replay-v1.json
@@ -1,6 +1,25 @@
 {
   "schema": "m8-openloris-extraction-shard0-replay-v1",
-  "status": "running-result-unverified",
+  "status": "completed-output-reproduction-pass",
+  "result": {
+    "exit_status": 0,
+    "wall_seconds": 3060.39,
+    "peak_rss_kib": 283612,
+    "keypoints": 431030,
+    "audit": {
+      "actual_entries": 2500,
+      "expected_files": 2500,
+      "extra": [],
+      "images": 1250,
+      "inventory_sha256": "0bd4ccdd8f71aefaea53ff911924cb816d24dffd5356745a274b6b1f831288e9",
+      "mismatches": [],
+      "missing": [],
+      "missing_reference": [],
+      "passed": true,
+      "replay_bytes": 585615663
+    },
+    "audit_command": "python3 scripts/audit_sift_replay.py --images /home/sasaki/datasets/openloris/corridor1-1-m5/feature-extract/images/shard-0 --reference /home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features --replay /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/features --expected-images 1250"
+  },
   "command": "set -Ce\nmkdir /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1\nenv RAYON_NUM_THREADS=8 /usr/bin/time -v -o /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/extract.time timeout --signal=TERM --kill-after=10s 3600s /home/sasaki/datasets/openloris/corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a --feature-extractor sift --images-dir /home/sasaki/datasets/openloris/corridor1-1-m5/feature-extract/images/shard-0 --input-colmap-calibration /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-10000/calibration --sift-max-keypoints 256 --sift-max-orientations 2 --sift-l1-root --sift-vlfeat-compatible-detector --sift-vlfeat-compatible-descriptor --sift-vlfeat-bilinear-orientations --sift-vlfeat-compatible-output-order --sift-colmap-compatible-grayscale --sift-stream-export --export-features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/features --export-features-only --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/unused-model >/home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1/extract.log 2>&1",
   "binary_sha256": "8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34",
   "threads": 8,

--- a/benchmarks/electro/m8-openloris-extraction-shard0-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-extraction-shard0-replay-v1.json
@@ -8,6 +8,7 @@
   "acceptance": "Exit zero; compare every feature/loci file and exact file membership to retained dense output; record wall/RSS without claiming whole-pipeline performance.",
   "limitations": [
     "One of eight shards, not full10k extraction or native E2E.",
-    "Saved new binary, recorded historical extractor flags, explicitly fixed thread count."
+    "Saved new binary, recorded historical extractor flags, explicitly fixed thread count.",
+    "Concurrent host CPU work observed at 653/1250 images: cc1plus PIDs 3272681 and 3272698 each reported 100% CPU, and python3 PID 3685631 reported 99.8%. Ownership and causal timing impact are unverified; no unrelated process was stopped. Treat this run as output-reproduction evidence, not an isolated speed-comparison sample."
   ]
 }

--- a/benchmarks/electro/m8-openloris-supplement-selection-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-supplement-selection-replay-v1.json
@@ -1,0 +1,17 @@
+{
+  "status": "all-json-fields-equal",
+  "command": "python3 scripts/select_rig_sift_supplements.py --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-10000/features256 --min-sensor-rows-lt 32 --frame-halo 8",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/selection.json",
+  "reference_sha256": "fc0e26c55a75bab87ebf6b15187ea4666876e5de076c6961aa05ed8b4c018b57",
+  "comparison": "json.loads(stdout) == json.loads(reference.read_text()); assertion passed after subprocess exit zero",
+  "base_frames": 221,
+  "selected_frames": 346,
+  "selected_images": 692,
+  "ordered_image_names_newline_terminated_sha256": "372af1119184468698abd6a3e5f4b6a8fb2e9a9bbad159b0fbeb51730bb21f4c",
+  "initial_difference": "Membership and all counts matched, but global lexical sorting differed from retained frame/manifest ordering. Preserve frame/manifest order; a regression test covers interleaved camera names.",
+  "limitations": [
+    "Selection reproduction only, not supplemental extraction, spatial merge, matching or native E2E.",
+    "Uses retained base features; their extraction is not included.",
+    "JSON field equality, not serialized JSON byte equality."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,23 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+## 現在の状態（以下の過去ログより優先）
+
+- branch: `test/m8-extraction-replay-preflight`。サブエージェントは使わない。
+- 抽出session37896は終了コード0で完了。再poll・再起動不要。
+  1,250画像/2,500 feature+loci files/585,615,663 bytesが保存済み出力と完全一致。
+  51:00.39、peak283,612KiB。他CPU負荷を観測したため単独速度比較には使わない。
+- 追加画像選択は692画像の順序を含むJSON全項目が一致。
+  結合は元特徴のみを距離判定対象にして1px以内を除外し、追加特徴同士は除去しない。
+  全10,000 feature filesの生成hashが一致（変更692、元と同一9,308）。
+  base/adaptiveバンクにlociはない。新規バンク書き出し・restartは未実装/未検証。
+- 証跡: extraction-shard0-replay-v1、supplement-selection-replay-v1、
+  adaptive-bank-replay-audit-v1（`benchmarks/electro/m8-openloris-*.json`）。
+- 次: このbranchのPR/最終CI、追加特徴バンクの安全な書き出し、
+  ペア追加の入力・順序・モード再現、continuous native E2E。
+  10k atlas RMSEのCOLMAP基準未達は未解決。M8–M10全goalは未完了。
+
+## 過去の作業ログ（稼働状態は上記で上書き）
+
 > PR115は最終headc09875aのCI9成功確認後、bbaa344d7d94c099ae8bfcbebba6f2668761d93bへmerge済み。
 > 旧branch削除、test/m8-extraction-replay-preflightはmainへrebase済み。
 > 抽出session37896は継続中（直近50/1250）。saved binaryなのでgit更新は実行内容へ影響しない。

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,12 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 稼働中: extraction-shard0-replay-v1、exec session37896。1250画像/8threads/3600秒上限。
+> 出力 `/home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1`、extract.log/time。
+> 直近18/1250画像を出力、同handleをpollして継続確認。観測timeoutで再起動しない。
+> 期待出力585615663bytes、開始free4184961024bytes。抽出binaryは保存extract-3ae253a。
+> 完了後全feature/loci membership/hash比較して証跡JSON更新。1/8shardで全10k/E2E成功ではない。
+> 同時build/追加測定は行わない。PR115はheadc09875a CI8成功/rust稼働を最終確認。
+
 > 最新作業branch `test/m8-extraction-replay-preflight`（PR115の子）。PR115最終headc09875aは
 > CI8件成功、rust1件実行中のため未merge。親へ追加pushしてCIを再起動しない。
 > 容量対応: 再生成可能な`target/debug`約3.3GiBを

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,10 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> PR115は最終headc09875aのCI9成功確認後、bbaa344d7d94c099ae8bfcbebba6f2668761d93bへmerge済み。
+> 旧branch削除、test/m8-extraction-replay-preflightはmainへrebase済み。
+> 抽出session37896は継続中（直近50/1250）。saved binaryなのでgit更新は実行内容へ影響しない。
+> 同handleをpoll、観測timeoutで再実行しない。同時build/測定禁止。全goal未達。
+
 > 稼働中: extraction-shard0-replay-v1、exec session37896。1250画像/8threads/3600秒上限。
 > 出力 `/home/sasaki/datasets/openloris/corridor1-1-m8-extraction-shard0-replay-v1`、extract.log/time。
 > 直近18/1250画像を出力、同handleをpollして継続確認。観測timeoutで再起動しない。

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -1,5 +1,13 @@
 # visloc-rs COLMAP parity — Codex 引き継ぎ資料
 
+> 最新作業branch `test/m8-extraction-replay-preflight`（PR115の子）。PR115最終headc09875aは
+> CI8件成功、rust1件実行中のため未merge。親へ追加pushしてCIを再起動しない。
+> 容量対応: 再生成可能な`target/debug`約3.3GiBを
+> `/dev/shm/visloc-debug-cache.drbnfQ/debug`へ退避。移動完了、disk空き約3.9GiB。
+> 入力/証跡/release/保存binary変更なし。tmpfsは再起動で消えるためcache以外を置かない。
+> ローカルcargo/rustc稼働なしを確認して移動。以降debug buildは再生成が必要、CARGO_INCREMENTAL=0維持。
+> 全特徴4.5GiBの追加保存には依然不足。大規模抽出開始前に容量/出力方針を確定する。全goal未達。
+
 > 最新: `diag/m8-source-command-coverage`。PR114は最終head26f755aのCI9件成功後
 > `da96845c943f5889543b5ba8929079a0d2f2a982`へsquash merge済み。再利用は既定OFF。
 > 親branch整理済み、現branchはmainへrebase。サブエージェントは使わない。

--- a/docs/openloris_atlas_selection_cost_audit.md
+++ b/docs/openloris_atlas_selection_cost_audit.md
@@ -378,3 +378,26 @@ invalid completion sidecar and re-extracts, rather than reporting a resumed
 hit. Feature, loci and repaired sidecar SHA256 all match the untouched original
 pilot. See `m8-openloris-extraction-resume-corrupt-v1.json`. This tests one
 hash-mismatch recovery path, not crash interruption or the full restart gate.
+# Frontend recipe recovery: remaining dependency checks
+
+The retained `corridor1-1-m8-adaptive32-halo8-10k-v1/selection.json`
+records `min_sensor_rows_lt: 32`, `frame_halo: 8`, 221 base frames,
+346 selected frames and 692 image names. Its `merge.json` records
+`base_prefix_preserved: true` and `spatial_novelty_px_exclusive: 1.0`.
+These are recorded policies, not yet a reproduced selection/merge operation.
+A search of tracked Python, Rust and shell sources found neither the selection
+schema `visloc_adaptive_sift_selection_v1` nor `min_sensor_rows_lt`.
+
+The `admit_verified_bridge_snapshot` utility has distinct bridge, registered-frame
+repair, all-new-pair and frozen-track-extension modes. Its writer does not add
+these admission arguments to the snapshot configuration. Consequently, the
+retained snapshot alone does not recover the historical admission invocation;
+do not infer it from the `repair19-targeted7` filename. The generic disjoint-shard
+merge is not a substitute for this operation.
+
+Before a native E2E replay, recover or explicitly define and independently
+validate (1) selection from the base feature counts and rig frame order,
+(2) deterministic prefix-preserving spatial feature merge, and (3) the ordered
+base/repair/targeted admission inputs and modes. Include any intermediate
+registration used by repair selection in E2E time. Existing staged mapper
+reproduction and historical matching-worker timings do not close these steps.

--- a/docs/openloris_atlas_selection_cost_audit.md
+++ b/docs/openloris_atlas_selection_cost_audit.md
@@ -380,6 +380,16 @@ pilot. See `m8-openloris-extraction-resume-corrupt-v1.json`. This tests one
 hash-mismatch recovery path, not crash interruption or the full restart gate.
 # Frontend recipe recovery: remaining dependency checks
 
+Update: `select_rig_sift_supplements.py` now reproduces all fields of the
+retained selection JSON, including frame/manifest image order. The merge
+primitive in `merge_sift_supplements.py` reproduces the complete bytes of all
+692 changed feature files into streaming hashes; the other 9,308 files match
+the base bank. Exact 10,000-entry membership also matches. See
+`m8-openloris-supplement-selection-replay-v1.json` and
+`m8-openloris-adaptive-bank-replay-audit-v1.json`. Neither the base nor the
+adaptive bank contains loci files. New-bank publication, supplemental
+extraction and downstream admission reproduction are still outstanding.
+
 The retained `corridor1-1-m8-adaptive32-halo8-10k-v1/selection.json`
 records `min_sensor_rows_lt: 32`, `frame_halo: 8`, 221 base frames,
 346 selected frames and 692 image names. Its `merge.json` records

--- a/scripts/audit_sift_replay.py
+++ b/scripts/audit_sift_replay.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Read-only, bounded-memory audit of a completed SIFT shard replay.
+
+The reference may contain other shards; the replay must contain exactly this
+shard's feature/loci files. Exit status does not certify extractor completion:
+the caller must independently verify the measured process exited successfully.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def digest(path):
+    hasher = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def audit(images, reference, replay, expected_images):
+    inputs = sorted(path for path in images.iterdir() if path.is_file())
+    stems = [path.stem for path in inputs]
+    if len(inputs) != expected_images or len(set(stems)) != len(stems):
+        raise ValueError("unexpected image count or colliding image stems")
+    expected = {stem + suffix for stem in stems
+                for suffix in ("_features.txt", "_loci.txt")}
+    actual = {path.name for path in replay.iterdir()}
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    mismatches = []
+    missing_reference = []
+    total_bytes = 0
+    inventory = hashlib.sha256()
+    for name in sorted(expected & actual):
+        candidate = replay / name
+        original = reference / name
+        if not original.is_file():
+            missing_reference.append(name)
+            continue
+        if not candidate.is_file():
+            mismatches.append(name)
+            continue
+        size = candidate.stat().st_size
+        candidate_hash = digest(candidate)
+        total_bytes += size
+        inventory.update(f"{name}\t{size}\t{candidate_hash}\n".encode())
+        if size != original.stat().st_size or candidate_hash != digest(original):
+            mismatches.append(name)
+    return {
+        "passed": not (missing or extra or mismatches or missing_reference),
+        "images": len(inputs), "expected_files": len(expected),
+        "actual_entries": len(actual), "replay_bytes": total_bytes,
+        "missing": missing, "extra": extra, "mismatches": mismatches,
+        "missing_reference": missing_reference,
+        "inventory_sha256": inventory.hexdigest(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--images", type=Path, required=True)
+    parser.add_argument("--reference", type=Path, required=True)
+    parser.add_argument("--replay", type=Path, required=True)
+    parser.add_argument("--expected-images", type=int, required=True)
+    args = parser.parse_args()
+    result = audit(args.images, args.reference, args.replay, args.expected_images)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_sift_supplements.py
+++ b/scripts/merge_sift_supplements.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Prefix-preserving, per-image SIFT supplement merge primitives.
+
+Novelty is measured against the original bank only. Supplement orientation
+variants remain distinct. No all-image descriptor bank or pair matrix is built.
+"""
+
+import math
+
+HEADER = b"# visloc adaptive feature bank: legacy prefix + spatially novel compatible supplement\n"
+
+
+def feature_rows(lines):
+    for line in lines:
+        if line.strip() and not line.lstrip().startswith(b"#"):
+            yield line
+
+
+def position(row):
+    fields = row.split()
+    if len(fields) < 2:
+        raise ValueError("feature row lacks coordinates")
+    x, y = map(float, fields[:2])
+    if not math.isfinite(x) or not math.isfinite(y):
+        raise ValueError("nonfinite feature coordinates")
+    return x, y
+
+
+def merged_rows(base_lines, supplement_lines):
+    """Yield original row bytes then novel supplement rows, with a 1px radius.
+
+    Retains only base coordinates for one image; it does not retain descriptors.
+    Callers must finish consuming this generator before publishing output.
+    """
+    grid = {}
+    for row in feature_rows(base_lines):
+        x, y = position(row)
+        grid.setdefault((math.floor(x), math.floor(y)), []).append((x, y))
+        yield row
+    for row in feature_rows(supplement_lines):
+        x, y = position(row)
+        ix, iy = math.floor(x), math.floor(y)
+        if not any((x - a) ** 2 + (y - b) ** 2 <= 1.0
+                   for dx in (-1, 0, 1) for dy in (-1, 0, 1)
+                   for a, b in grid.get((ix + dx, iy + dy), ())):
+            yield row

--- a/scripts/select_rig_sift_supplements.py
+++ b/scripts/select_rig_sift_supplements.py
@@ -38,7 +38,7 @@ def select(frames, counts, threshold, halo):
         "policy": {"frame_halo": halo, "min_sensor_rows_lt": threshold},
         "base_frames": len(seeds), "selected_frames": len(selected),
         "selected_images": sum(len(frames[frame]) for frame in selected),
-        "image_names": sorted(name for frame in selected for name in frames[frame]),
+        "image_names": [name for frame in selected for name in frames[frame]],
     }
 
 

--- a/scripts/select_rig_sift_supplements.py
+++ b/scripts/select_rig_sift_supplements.py
@@ -42,18 +42,22 @@ def select(frames, counts, threshold, halo):
     }
 
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--rig-manifest", type=Path, required=True)
-    parser.add_argument("--features-dir", type=Path, required=True)
-    parser.add_argument("--min-sensor-rows-lt", type=int, required=True)
-    parser.add_argument("--frame-halo", type=int, required=True)
-    args = parser.parse_args()
-    raw = args.rig_manifest.read_bytes()
+def parse_frames(raw):
     frames = {}
     sensors = set()
+    declared = set()
+    names = set()
+    stems = set()
     for line in raw.decode().splitlines():
         fields = line.split()
+        if fields and fields[0] == "S":
+            if len(fields) != 16:
+                raise ValueError("malformed S row")
+            sensor = int(fields[1])
+            if sensor < 0 or sensor in declared:
+                raise ValueError("invalid or duplicate sensor declaration")
+            declared.add(sensor)
+            continue
         if not fields or fields[0] != "F":
             continue
         if len(fields) != 4:
@@ -63,10 +67,33 @@ def main():
             raise ValueError("invalid or duplicate frame/sensor")
         if Path(name).name != name or name in (".", ".."):
             raise ValueError("image names must be basenames")
+        if name in names or Path(name).stem in stems:
+            raise ValueError("duplicate image or colliding feature filename")
+        names.add(name)
+        stems.add(Path(name).stem)
         sensors.add((frame, sensor))
         frames.setdefault(frame, []).append(name)
     if not frames:
         raise ValueError("no rig frames")
+    by_frame = {frame: set() for frame in frames}
+    for frame, sensor in sensors:
+        by_frame[frame].add(sensor)
+    if not declared or any(value != declared for value in by_frame.values()):
+        raise ValueError("each frame must contain exactly the declared sensors")
+    return frames
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rig-manifest", type=Path, required=True)
+    parser.add_argument("--features-dir", type=Path, required=True)
+    parser.add_argument("--min-sensor-rows-lt", type=int, required=True)
+    parser.add_argument("--frame-halo", type=int, required=True)
+    args = parser.parse_args()
+    if args.min_sensor_rows_lt < 0 or args.frame_halo < 0:
+        parser.error("threshold and halo must be nonnegative")
+    raw = args.rig_manifest.read_bytes()
+    frames = parse_frames(raw)
     counts = {}
     for names in frames.values():
         for name in names:

--- a/scripts/select_rig_sift_supplements.py
+++ b/scripts/select_rig_sift_supplements.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Select low-feature rig frames plus a bounded ordinal halo, without GT.
+
+Print a selection manifest; do not modify features or create image links.
+This implements an explicit policy, not a claim of historical reproduction.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def select(frames, counts, threshold, halo):
+    if threshold < 0 or halo < 0:
+        raise ValueError("threshold and halo must be nonnegative")
+    ordered = sorted(frames)
+    names = [name for frame in ordered for name in frames[frame]]
+    if len(set(names)) != len(names) or set(names) != set(counts):
+        raise ValueError("image/count membership must be exact and unique")
+    if any(not frames[frame] for frame in ordered) or any(n < 0 for n in counts.values()):
+        raise ValueError("empty frame or negative feature count")
+    seeds = [i for i, frame in enumerate(ordered)
+             if min(counts[name] for name in frames[frame]) < threshold]
+    # Difference array avoids O(N * halo) work for large halo values.
+    delta = [0] * (len(ordered) + 1)
+    for index in seeds:
+        delta[max(0, index - halo)] += 1
+        delta[min(len(ordered), index + halo + 1)] -= 1
+    selected = []
+    coverage = 0
+    for index, frame in enumerate(ordered):
+        coverage += delta[index]
+        if coverage:
+            selected.append(frame)
+    return {
+        "schema": "visloc_adaptive_sift_selection_v1",
+        "policy": {"frame_halo": halo, "min_sensor_rows_lt": threshold},
+        "base_frames": len(seeds), "selected_frames": len(selected),
+        "selected_images": sum(len(frames[frame]) for frame in selected),
+        "image_names": sorted(name for frame in selected for name in frames[frame]),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rig-manifest", type=Path, required=True)
+    parser.add_argument("--features-dir", type=Path, required=True)
+    parser.add_argument("--min-sensor-rows-lt", type=int, required=True)
+    parser.add_argument("--frame-halo", type=int, required=True)
+    args = parser.parse_args()
+    raw = args.rig_manifest.read_bytes()
+    frames = {}
+    sensors = set()
+    for line in raw.decode().splitlines():
+        fields = line.split()
+        if not fields or fields[0] != "F":
+            continue
+        if len(fields) != 4:
+            raise ValueError("malformed F row")
+        frame, name, sensor = int(fields[1]), fields[2], int(fields[3])
+        if frame < 0 or sensor < 0 or (frame, sensor) in sensors:
+            raise ValueError("invalid or duplicate frame/sensor")
+        if Path(name).name != name or name in (".", ".."):
+            raise ValueError("image names must be basenames")
+        sensors.add((frame, sensor))
+        frames.setdefault(frame, []).append(name)
+    if not frames:
+        raise ValueError("no rig frames")
+    counts = {}
+    for names in frames.values():
+        for name in names:
+            with (args.features_dir / (Path(name).stem + "_features.txt")).open() as stream:
+                counts[name] = sum(1 for line in stream
+                                   if line.strip() and not line.lstrip().startswith("#"))
+    result = select(frames, counts, args.min_sensor_rows_lt, args.frame_halo)
+    result.update(rig_manifest=str(args.rig_manifest),
+                  rig_manifest_sha256=hashlib.sha256(raw).hexdigest())
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_audit_sift_replay.py
+++ b/scripts/tests/test_audit_sift_replay.py
@@ -1,0 +1,66 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "audit_sift_replay", Path(__file__).resolve().parents[1] / "audit_sift_replay.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReplayAuditTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        root = Path(self.temporary.name)
+        self.images, self.reference, self.replay = [root / name for name in
+                                                  ("images", "reference", "replay")]
+        for directory in (self.images, self.reference, self.replay):
+            directory.mkdir()
+        (self.images / "camera.png").write_bytes(b"image")
+        for directory in (self.reference, self.replay):
+            (directory / "camera_features.txt").write_bytes(b"features")
+            (directory / "camera_loci.txt").write_bytes(b"loci")
+
+    def audit(self):
+        return MODULE.audit(self.images, self.reference, self.replay, 1)
+
+    def test_equal_with_reference_superset(self):
+        (self.reference / "other_features.txt").write_bytes(b"other shard")
+        result = self.audit()
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["replay_bytes"], 12)
+
+    def test_same_size_corruption(self):
+        (self.replay / "camera_features.txt").write_bytes(b"Features")
+        self.assertEqual(self.audit()["mismatches"], ["camera_features.txt"])
+
+    def test_missing_and_extra(self):
+        (self.replay / "camera_loci.txt").rename(self.replay / "unexpected.txt")
+        result = self.audit()
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["missing"], ["camera_loci.txt"])
+        self.assertEqual(result["extra"], ["unexpected.txt"])
+
+    def test_missing_reference(self):
+        (self.reference / "camera_loci.txt").unlink()
+        self.assertFalse(self.audit()["passed"])
+
+    def test_directory_not_output_file(self):
+        (self.replay / "camera_loci.txt").unlink()
+        (self.replay / "camera_loci.txt").mkdir()
+        self.assertFalse(self.audit()["passed"])
+
+    def test_count_and_stem_collision(self):
+        with self.assertRaises(ValueError):
+            MODULE.audit(self.images, self.reference, self.replay, 2)
+        (self.images / "camera.jpg").write_bytes(b"image")
+        with self.assertRaises(ValueError):
+            MODULE.audit(self.images, self.reference, self.replay, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_merge_sift_supplements.py
+++ b/scripts/tests/test_merge_sift_supplements.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    "merge_sift_supplements", Path(__file__).resolve().parents[1] / "merge_sift_supplements.py")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MergeTests(unittest.TestCase):
+    def test_preserves_prefix_and_supplement_variants(self):
+        base = [b"# header\n", b"0 0 base\n"]
+        additions = [b"1 0 boundary\n", b"1.01 0 first\n", b"1.01 0 second\n"]
+        self.assertEqual(list(MODULE.merged_rows(base, additions)),
+                         [base[1], additions[1], additions[2]])
+
+    def test_neighbor_cells_and_negative_coordinates(self):
+        self.assertEqual(list(MODULE.merged_rows([b"-0.1 -0.1 base\n"],
+                                                [b"0.1 0.1 near\n"])), [b"-0.1 -0.1 base\n"])
+
+    def test_empty_base_keeps_all_supplements(self):
+        rows = [b"2 3 a\n", b"2 3 b\n"]
+        self.assertEqual(list(MODULE.merged_rows([], rows)), rows)
+
+    def test_bad_coordinates_rejected(self):
+        for row in (b"nan 0\n", b"0 inf\n", b"1\n"):
+            with self.assertRaises(ValueError):
+                list(MODULE.merged_rows([], [row]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_select_rig_sift_supplements.py
+++ b/scripts/tests/test_select_rig_sift_supplements.py
@@ -11,6 +11,21 @@ SPEC.loader.exec_module(MODULE)
 
 
 class SelectionTests(unittest.TestCase):
+    def test_manifest_sensor_membership_and_filename_collisions(self):
+        declarations = "S 0 " + "1 " * 14 + "\nS 1 " + "1 " * 14 + "\n"
+        valid = declarations + "F 0 a.png 0\nF 0 b.png 1\n"
+        self.assertEqual(MODULE.parse_frames(valid.encode()), {0: ["a.png", "b.png"]})
+        for rows in (
+            "F 0 a.png 0\n",  # Missing sensor must not look like sufficient support.
+            "F 0 a.png 0\nF 0 b.png 2\n",
+            "F 0 a.png 0\nF 0 a.jpg 1\n",
+            "F 0 a.png 0\nF 0 ../b.png 1\n",
+            "F 0 a.png 0\nF 0 b.png 0\n",
+        ):
+            with self.subTest(rows=rows):
+                with self.assertRaises(ValueError):
+                    MODULE.parse_frames((declarations + rows).encode())
+
     def test_strict_threshold_and_ordinal_halo(self):
         frames = {10: ["a", "b"], 20: ["c", "d"], 40: ["e", "f"], 90: ["g", "h"]}
         counts = dict.fromkeys("abcdefgh", 32)

--- a/scripts/tests/test_select_rig_sift_supplements.py
+++ b/scripts/tests/test_select_rig_sift_supplements.py
@@ -11,6 +11,11 @@ SPEC.loader.exec_module(MODULE)
 
 
 class SelectionTests(unittest.TestCase):
+    def test_retains_frame_then_manifest_sensor_order(self):
+        result = MODULE.select({1: ["cam1_b", "cam2_b"], 0: ["cam1_a", "cam2_a"]},
+                               dict.fromkeys(["cam1_a", "cam2_a", "cam1_b", "cam2_b"], 0), 32, 0)
+        self.assertEqual(result["image_names"], ["cam1_a", "cam2_a", "cam1_b", "cam2_b"])
+
     def test_manifest_sensor_membership_and_filename_collisions(self):
         declarations = "S 0 " + "1 " * 14 + "\nS 1 " + "1 " * 14 + "\n"
         valid = declarations + "F 0 a.png 0\nF 0 b.png 1\n"

--- a/scripts/tests/test_select_rig_sift_supplements.py
+++ b/scripts/tests/test_select_rig_sift_supplements.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    "select_rig_sift_supplements",
+    Path(__file__).resolve().parents[1] / "select_rig_sift_supplements.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class SelectionTests(unittest.TestCase):
+    def test_strict_threshold_and_ordinal_halo(self):
+        frames = {10: ["a", "b"], 20: ["c", "d"], 40: ["e", "f"], 90: ["g", "h"]}
+        counts = dict.fromkeys("abcdefgh", 32)
+        self.assertEqual(MODULE.select(frames, counts, 32, 1)["selected_images"], 0)
+        counts["c"] = 31
+        result = MODULE.select(frames, counts, 32, 1)
+        self.assertEqual(result["base_frames"], 1)
+        self.assertEqual(result["image_names"], list("abcdef"))
+
+    def test_clipped_overlapping_halos(self):
+        frames = {0: ["a"], 1: ["b"], 2: ["c"]}
+        result = MODULE.select(frames, {"a": 0, "b": 32, "c": 0}, 32, 1000000)
+        self.assertEqual(result["selected_frames"], 3)
+        self.assertEqual(result["selected_images"], 3)
+
+    def test_invalid_inputs(self):
+        for frames, counts, threshold, halo in [
+            ({0: ["a"]}, {}, 32, 8),
+            ({0: ["a"], 1: ["a"]}, {"a": 1}, 32, 8),
+            ({0: ["a"]}, {"a": -1}, 32, 8),
+            ({0: ["a"]}, {"a": 1}, 32, -1),
+            ({0: []}, {}, 32, 8),
+        ]:
+            with self.subTest(frames=frames, counts=counts, halo=halo):
+                with self.assertRaises(ValueError):
+                    MODULE.select(frames, counts, threshold, halo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
- Complete 1,250-image extraction replay: all 2,500 files match retained outputs; concurrent host load explicitly excludes isolated speed claims.
- Reproduce 692-image supplement selection including order and all 10,000 adaptive feature file hashes using bounded per-image merge.
- Add output audit, selection/merge tests, and scripts/tests discovery to CI.
- Refresh handover with terminal process state and remaining E2E/quality work.

## Validation
- 18 scripts/tests unit tests pass.
- Documentation link check and git diff --check pass.
- This does not claim full10k extraction, new-bank publication/restart, native E2E or COLMAP quality/speed completion.