### PR TITLE
Recover OpenLORIS adaptive pair admission reproduction chain

### DIFF
--- a/benchmarks/electro/m8-openloris-native-prefix-supplement-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-native-prefix-supplement-replay-v1.json
@@ -1,0 +1,22 @@
+{
+  "status": "complete-snapshot-byte-reproduction-pass",
+  "binary_sha256": "883a6ad7b21e34de9309cb71e35fe7750547df34d3ffe8c92b59921625247af5",
+  "command": "target/release/examples/admit_verified_bridge_snapshot --base-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-runner-10k-v1/mapping/verified-merged.vps --augmented-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-merged.vps --base-features-dir /home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-10000/features256 --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt --include-prefix-supplements --output /home/sasaki/datasets/openloris/corridor1-1-m8-native-prefix-supplement-replay-v1/output.vps",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-bridges-prefix-supplements.vps",
+  "output_and_reference_sha256": "fbcd111cd193fd59a3311c99208de6fe30c2c334f0b088ba7798aeff69dffe6f",
+  "exit_status": 0,
+  "wall_seconds": 3.23,
+  "peak_rss_kib": 665020,
+  "base_pairs": 58530,
+  "admitted_pairs": 1431,
+  "admitted_matches": 89150,
+  "supplemented_pairs": 764,
+  "supplemented_matches": 70910,
+  "output_pairs": 59961,
+  "output_matches": 3337520,
+  "limitations": [
+    "New reproduction command, not a recovered historical invocation.",
+    "Retained native-runner and adaptive matching snapshots are inputs; their producers remain upstream dependencies.",
+    "Individual stage reproduction, not a continuous E2E measurement or quality improvement."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-prefix-base-candidate-v1.json
+++ b/benchmarks/electro/m8-openloris-prefix-base-candidate-v1.json
@@ -1,0 +1,18 @@
+{
+  "status": "ordered-edge-prefix-candidate-found",
+  "candidate": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-rig-runner-10k-v1/mapping/verified-merged.vps",
+  "candidate_pairs": 58530,
+  "candidate_accepted_correspondences": 3177460,
+  "candidate_pair_order_hash": "cfc2174c1ae0881f",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-bridges-prefix-supplements.vps",
+  "reference_pairs": 59961,
+  "all_candidate_edge_keys_equal_reference_prefix": true,
+  "missing_candidate_edges": 0,
+  "rejected_alternatives_missing_edges": {
+    "component-ann-k128-match32-10k-v1": 50,
+    "native-rig-balanced-retrieval-match32-10k-v2": 1557,
+    "native-rig-long128-10k-v1": 581
+  },
+  "next_action": "Replay bridge admission with prefix supplements from native-rig-runner base and adaptive verified snapshot; compare complete output SHA-256.",
+  "limitations": ["Ordered image-index edge keys alone do not establish feature-envelope, correspondence or complete-file equality."]
+}

--- a/benchmarks/electro/m8-openloris-prefix-supplement-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-prefix-supplement-replay-v1.json
@@ -1,0 +1,18 @@
+{
+  "status": "rejected-reproduction-hypothesis",
+  "base": "/home/sasaki/datasets/openloris/corridor1-1-m5/tiers/tier-10000/pipeline-sparse7n/mapping/verified-merged.vps",
+  "augmented": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-merged.vps",
+  "operation": "admit_verified_bridge_snapshot --include-prefix-supplements; base-features-dir=m5/tiers/tier-10000/features256; rig-manifest=m8-visloc-rig/tier-10000-champion/rig-manifest.txt",
+  "output": "/home/sasaki/datasets/openloris/corridor1-1-m8-prefix-supplement-replay-v1/output.vps",
+  "recorded_command_and_time": "/home/sasaki/datasets/openloris/corridor1-1-m8-prefix-supplement-replay-v1/time.txt",
+  "exit_status": 0,
+  "wall_seconds": 2.99,
+  "peak_rss_kib": 690056,
+  "output_pairs": 60310,
+  "output_matches": 3601143,
+  "reference_pairs": 59961,
+  "reference_matches": 3337520,
+  "output_sha256": "734ca4ce6da282d85e1bab7100f5f0708f805bd783402965021f5b3db94f2dde",
+  "reference_sha256": "fbcd111cd193fd59a3311c99208de6fe30c2c334f0b088ba7798aeff69dffe6f",
+  "next_action": "Identify the actual pre-admission base selection; do not use raw sparse7n as an established producer or repeat this unchanged hypothesis."
+}

--- a/benchmarks/electro/m8-openloris-repair-registration-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-repair-registration-replay-v1.json
@@ -1,0 +1,10 @@
+{
+  "status": "running-unverified",
+  "session": 78386,
+  "recorded_command_source": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-adaptive32-halo8-bridges-supp-pair-confidence-finalfix32-v1/mapper.time.txt",
+  "binary": "/home/sasaki/datasets/openloris/corridor1-1-m8-retry-reuse-1k-v1/rig-0466499",
+  "output_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-repair-registration-replay-v1",
+  "replay_changes": ["saved newer binary", "fresh output root", "RAYON_NUM_THREADS=1", "600-second timeout with TERM and 10-second kill grace"],
+  "acceptance": "Exit zero, compare model component membership and every cameras/images/points3D file; separately compare retrieval-components used by repair selection.",
+  "limitations": ["Not historical binary identity or continuous native E2E."]
+}

--- a/benchmarks/electro/m8-openloris-repair-registration-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-repair-registration-replay-v1.json
@@ -1,5 +1,14 @@
 {
-  "status": "running-unverified",
+  "status": "completed-model-and-registration-byte-parity",
+  "result": {
+    "exit_status": 0,
+    "wall_seconds": 169.82,
+    "peak_rss_kib": 974884,
+    "comparison": "Compare exact membership and SHA-256 of every component cameras.txt/images.txt/points3D.txt and root retrieval-components.txt against recorded-command model directory.",
+    "model_files": 6,
+    "retrieval_component_files": 1,
+    "missing": [], "extra": [], "hash_mismatches": []
+  },
   "session": 78386,
   "recorded_command_source": "/home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-adaptive32-halo8-bridges-supp-pair-confidence-finalfix32-v1/mapper.time.txt",
   "binary": "/home/sasaki/datasets/openloris/corridor1-1-m8-retry-reuse-1k-v1/rig-0466499",

--- a/benchmarks/electro/m8-openloris-repair19-admission-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-repair19-admission-replay-v1.json
@@ -1,0 +1,20 @@
+{
+  "status": "complete-snapshot-byte-reproduction-pass",
+  "binary_sha256": "883a6ad7b21e34de9309cb71e35fe7750547df34d3ffe8c92b59921625247af5",
+  "command": "target/release/examples/admit_verified_bridge_snapshot --base-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-bridges-prefix-supplements.vps --augmented-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-merged.vps --base-features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/adaptive-features --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt --repair-registered-components /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-adaptive32-halo8-bridges-supp-pair-confidence-finalfix32-v1/model/retrieval-components.txt --output /home/sasaki/datasets/openloris/corridor1-1-m8-repair19-admission-replay-v1/output.vps",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-control-prefix-repair19.vps",
+  "output_and_reference_sha256": "ac93b28daf92b9bb4a621b9687087abbf906a1bc78cca0d8f4ea9688a1ba7a8d",
+  "exit_status": 0,
+  "wall_seconds": 2.95,
+  "peak_rss_kib": 680056,
+  "base_pairs": 59961,
+  "admitted_repair_pairs": 173,
+  "admitted_repair_matches": 11027,
+  "output_pairs": 60134,
+  "output_matches": 3348547,
+  "limitations": [
+    "New reproduction invocation; the historical invocation is not recovered.",
+    "Uses retained intermediate registered-component manifest, pre-repair snapshot and adaptive verified snapshot. Their producers must be included in E2E.",
+    "No repaired snapshot is an input, unlike the earlier order-only reproduction."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-repair19-input-alias-v1.json
+++ b/benchmarks/electro/m8-openloris-repair19-input-alias-v1.json
@@ -1,0 +1,27 @@
+{
+  "status": "complete-file-alias-verified",
+  "paths": [
+    "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-control-prefix-repair19.vps",
+    "/home/sasaki/datasets/openloris/corridor1-1-m8-long128-component-ann80k-v1/mapping/verified-goodbase-repair19.vps"
+  ],
+  "sha256_both": "ac93b28daf92b9bb4a621b9687087abbf906a1bc78cca0d8f4ea9688a1ba7a8d",
+  "pairs": 60134,
+  "accepted_correspondences": 3348547,
+  "pair_order_hash": "4dad0aafb0da8cdb",
+  "related_adaptive_snapshots": {
+    "verified-bridges-prefix-supplements-repair19.vps": {
+      "pairs": 60134, "accepted_correspondences": 3348547,
+      "pair_order_hash": "155eee41f04e2fcb",
+      "unordered_edge_hash": "abcc1542232c857d"
+    },
+    "verified-bridges-prefix-supplements.vps": {
+      "pairs": 59961, "accepted_correspondences": 3337520,
+      "pair_order_hash": "59770e42e7e8d68b"
+    }
+  },
+  "next_action": "Recover adaptive repair admission and control-prefix ordering; the long128 directory name alone does not imply its retrieval/matching is a required producer of these identical bytes.",
+  "limitations": [
+    "Related repair snapshot shares counts and unordered-edge hash, but correspondence content and exact reordering have not been verified.",
+    "Alias equality does not establish the historical copy operation or upstream repair recipe."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-repair19-order-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-repair19-order-replay-v1.json
@@ -1,0 +1,20 @@
+{
+  "status": "complete-snapshot-byte-reproduction-pass",
+  "binary_sha256": "883a6ad7b21e34de9309cb71e35fe7750547df34d3ffe8c92b59921625247af5",
+  "command": "target/release/examples/admit_verified_bridge_snapshot --base-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-bridges-prefix-supplements.vps --augmented-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-bridges-prefix-supplements-repair19.vps --base-features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/adaptive-features --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt --include-all-new-pairs --output /home/sasaki/datasets/openloris/corridor1-1-m8-repair19-order-replay-v1/output.vps",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-control-prefix-repair19.vps",
+  "output_and_reference_sha256": "ac93b28daf92b9bb4a621b9687087abbf906a1bc78cca0d8f4ea9688a1ba7a8d",
+  "exit_status": 0,
+  "wall_seconds": 2.98,
+  "peak_rss_kib": 671736,
+  "base_pairs": 59961,
+  "admitted_pairs": 173,
+  "admitted_matches": 11027,
+  "output_pairs": 60134,
+  "output_matches": 3348547,
+  "limitations": [
+    "Reproduces control-prefix ordering using the retained repaired snapshot; does not reproduce selection of repair pairs.",
+    "New reproduction command, not recovered historical invocation.",
+    "Phase-only measurement; upstream base, repaired snapshot and features remain retained inputs."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-targeted7-admission-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-targeted7-admission-replay-v1.json
@@ -1,0 +1,21 @@
+{
+  "status": "complete-snapshot-byte-reproduction-pass",
+  "source_commit": "916be88",
+  "binary_sha256": "883a6ad7b21e34de9309cb71e35fe7750547df34d3ffe8c92b59921625247af5",
+  "command": "target/release/examples/admit_verified_bridge_snapshot --base-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-long128-component-ann80k-v1/mapping/verified-goodbase-repair19.vps --augmented-snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-dense256-v1/mapping/verified-merged.vps --base-features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/adaptive-features --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt --include-all-new-pairs --output /home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-admission-replay-v1/output.vps",
+  "reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-dense256-v1/mapping/verified-base-repair19-targeted7.vps",
+  "output_and_reference_sha256": "c9b30f7f7c29257e79dda6fe9b479924917b1e875d351085768b19af1e476857",
+  "exit_status": 0,
+  "wall_seconds": 2.53,
+  "peak_rss_kib": 376444,
+  "base_pairs": 60134,
+  "admitted_pairs": 213,
+  "admitted_matches": 4158,
+  "output_pairs": 60347,
+  "output_matches": 3352705,
+  "limitations": [
+    "Newly specified reproduction command, not a recovered historical invocation.",
+    "Retained base repair19 and targeted7 matching snapshot are inputs; upstream generation is not included.",
+    "Single phase, not native E2E performance or quality improvement."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-targeted7-admission-structure-v1.json
+++ b/benchmarks/electro/m8-openloris-targeted7-admission-structure-v1.json
@@ -1,0 +1,21 @@
+{
+  "status": "pair-summary-order-reproduced-not-full-snapshot",
+  "base": "/home/sasaki/datasets/openloris/corridor1-1-m8-long128-component-ann80k-v1/mapping/verified-goodbase-repair19.vps",
+  "addition": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-dense256-v1/mapping/verified-merged.vps",
+  "output": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-dense256-v1/mapping/verified-base-repair19-targeted7.vps",
+  "inspection": "inspect_verified_pair_snapshot --snapshot PATH --pairs-tsv TSV; compare ordered TSV rows including all reported match/inlier counts",
+  "base_pairs": 60134,
+  "addition_pairs": 265,
+  "output_pairs": 60347,
+  "base_prefix_rows_equal": true,
+  "addition_overlap_with_base": 52,
+  "novel_addition_count": 213,
+  "output_tail_equals_novel_addition_order": true,
+  "missing_base_edges": 0,
+  "novel_accepted_sum": 4158,
+  "limitations": [
+    "TSV summary equality does not verify individual correspondence indices, poses or snapshot envelope bytes.",
+    "This supports append-only novel-pair admission as a reconstruction hypothesis, not recovery of the historical invocation.",
+    "Base repair19 generation remains an upstream dependency."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -2,6 +2,16 @@
 
 ## 現在の状態（以下の過去ログより優先）
 
+最新: PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。
+現branch `diag/m8-pair-admission-recovery`。targeted7追加とrepair19修復・順序を
+既存ツールで再生成しsnapshot全bytes一致（証跡targeted7-admission-replay-v1、
+repair19-order-replay-v1、repair19-admission-replay-v1）。中間登録結果と修復前snapshotは未再生成。
+disk空き89MiBまで低下したため、cargo/rustc稼働なしを確認し、再生成可能な
+`target/release/deps`と`target/doc`を `/dev/shm/visloc-regenerable-cache.D87DLG/`へ退避。
+移動後空き576MiB。実行バイナリ・入力・計測出力は移動/削除していない。
+tmpfsは再起動で消える。次のbuildは依存cache再生成が必要なので容量を再確認する。
+全10k再抽出や新バンク一式の追加保存容量は依然不足。全goal未達。
+
 更新: PR116はhead`bef08e15b40e1e020584fc3fd83fc56447964ed6`のCI9件成功後、
 `75fea9aba77507862e503fb090395cd5e602bf3d`へsquash merge、旧branch整理済み。
 現branchは`feat/m8-adaptive-bank-publication`。

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -1,0 +1,51 @@
+# OpenLORIS frontend reproduction boundary
+
+The admission chain is now reproducible **from retained matching inputs**.
+This is not a continuous native E2E result, and it does not fix the remaining
+COLMAP trajectory-quality gate.
+
+```text
+base features → native-rig-runner verified snapshot ─────┐
+base + supplemental features → adaptive matching ───────┤
+                                                       ↓
+                                             prefix supplement admission
+                                                       ↓
+                                             intermediate rig mapping
+                                                       ↓ registration list
+adaptive matching + prefix snapshot ─────────→ repair admission
+                                                       ↓
+targeted7 matching ──────────────────────────→ novel-pair admission
+                                                       ↓
+                                             atlas source mapping
+```
+
+The verified stages are:
+
+| Stage | Complete reproduced output | Evidence JSON under benchmarks/electro |
+| --- | --- | --- |
+| Prefix supplements | 59,961-pair snapshot, SHA-256 `fbcd111c…` | m8-openloris-native-prefix-supplement-replay-v1.json |
+| Intermediate registration | Both models' six files and retrieval-components.txt | m8-openloris-repair-registration-replay-v1.json |
+| Repair admission | 173 new pairs; 60,134-pair snapshot, SHA-256 `ac93b28d…` | m8-openloris-repair19-admission-replay-v1.json |
+| Targeted admission | 213 new pairs; 60,347-pair snapshot, SHA-256 `c9b30f7f…` | m8-openloris-targeted7-admission-replay-v1.json |
+
+These stages were run separately with retained upstream inputs. File equality
+supports assembling this dependency chain; it does not establish that a single
+run executed it or that summed phase times equal E2E time. Intermediate mapping
+is a required cost because repair selection consumes its registration result.
+
+The raw M5 sparse7n snapshot is **not** the prefix-admission input: that hypothesis
+produced 60,310 pairs and failed complete-file equality. The actual reproduced
+input is `corridor1-1-m8-native-rig-runner-10k-v1/mapping/verified-merged.vps`.
+Likewise, the `long128` directory's `verified-goodbase-repair19.vps` is byte-identical
+to the adaptive control-prefix repair snapshot. Its directory name alone does
+not require long128 matching in this chain.
+
+Next, reproduce candidate generation and matching for native-runner, adaptive,
+targeted7 and the separate dense deferred overlay. Preserve their exact feature
+indices and pair order. Freeze the complete executable recipe, run it as one
+process tree with wall/RSS accounting, and evaluate the unchanged COLMAP gates.
+The earlier 1,250-image extraction and synthetic bank-only 100k tests do not
+close full10k extraction, whole-pipeline restart or full SfM100k I/O gates.
+
+Storage currently constrains additional large runs. Do not silently move measured
+outputs to memory-backed storage or discard retained evidence to obtain a pass.


### PR DESCRIPTION
Records complete-file reproduction of adaptive prefix supplements, intermediate rig mapping, repair19 admission and targeted7 admission. Preserves the rejected raw sparse7n hypothesis and distinguishes newly specified commands from recovered historical invocations. Documents retained-input dependencies and remaining continuous E2E, quality and storage requirements. Documentation links and diff checks pass. Evidence-only change; no performance or quality promotion.