### PR TITLE
bench: reproduce historical OpenLORIS native frontend

### DIFF
--- a/benchmarks/electro/m8-openloris-native-candidates-current-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-native-candidates-current-replay-v1.json
@@ -1,0 +1,25 @@
+{
+  "status": "candidate-byte-reproduction-fail",
+  "source_commit": "3ae253a0af909042fe0cfbdb08e8d50733b79375",
+  "binary_sha256": "8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34",
+  "recipe": "scripts/replay_native_candidates.py (default arguments)",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-candidates-replay-v1/report.json",
+  "exit_status": 0,
+  "wall_seconds": 528.7530037719989,
+  "peak_rss_kib": 361952,
+  "rayon_num_threads": 8,
+  "images": 10000,
+  "reference_pairs": 70000,
+  "output_pairs": 70000,
+  "common_pairs": 66239,
+  "reference_only_pairs": 3761,
+  "output_only_pairs": 3761,
+  "image_order_equal": true,
+  "reference_sha256": "fca2fce1056e08966ed4d3c0a48781cf546ad5c70a6f6f86c39c365205da5716",
+  "output_sha256": "9effd52f35e56f2a765b27466e13f6cfce9c7e99745a9fa961851b15ae068856",
+  "diagnosis": "The saved modern extractor also executes the newer global-score-desc-v1 retrieval fill policy. Historical a7ff5ff preserves producer pair order. Commit 67ead5e introduces score-based filling; this is a policy-version mismatch hypothesis pending historical replay, not mere metadata drift.",
+  "limitations": [
+    "Matching was not launched because candidate equality failed.",
+    "No COLMAP speedup, E2E, or quality claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-native-candidates-legacy-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-native-candidates-legacy-replay-v1.json
@@ -1,0 +1,25 @@
+{
+  "status": "complete-candidate-byte-reproduction-pass",
+  "source_commit": "a7ff5ff47b561556ba20a0afdb40417ec9413120",
+  "binary_sha256": "8eeee5c2f8b39de6575c2308e89cba11b96d38d66d1ae3d51ab6ce0d61d43e79",
+  "build_evidence": "m8-openloris-native-frontend-legacy-build-v1.json",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-candidates-legacy-replay-v1/report.json",
+  "recipe_document": "docs/openloris_frontend_reproduction.md",
+  "exit_status": 0,
+  "wall_seconds": 583.1972788820276,
+  "peak_rss_kib": 354312,
+  "user_seconds": 631.04,
+  "system_seconds": 71.87,
+  "rayon_num_threads": 8,
+  "images": 10000,
+  "candidate_pairs": 70000,
+  "local_descriptors": 1427634,
+  "vocabulary_samples": 40790,
+  "output_and_reference_sha256": "fca2fce1056e08966ed4d3c0a48781cf546ad5c70a6f6f86c39c365205da5716",
+  "lsh": {"tables": 8, "bits": 9, "probes": 9, "mean_pool": 1517.0, "max_pool": 1910, "exact_fallback_queries": 0},
+  "limitations": [
+    "Candidate generation only, from retained base feature files; not native E2E.",
+    "Rebuilt historical source reproduces the saved manifest; original executable identity was not recovered.",
+    "No quality improvement or speedup claim; the modern score-fill candidate policy is different."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-native-frontend-legacy-build-v1.json
+++ b/benchmarks/electro/m8-openloris-native-frontend-legacy-build-v1.json
@@ -1,0 +1,16 @@
+{
+  "status": "build-complete-not-replay-result",
+  "source_commit": "a7ff5ff47b561556ba20a0afdb40417ec9413120",
+  "source_worktree_clean": true,
+  "build_command": "CARGO_INCREMENTAL=0 cargo build --locked --release --example unordered_sfm_demo --jobs 2",
+  "build_exit_status": 0,
+  "cargo_reported_build_duration_seconds": 111,
+  "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)",
+  "cargo_lock_sha256": "a16cf470d271a0dd087ecf5e5d8ab73da91ae11dd18ced08aad42a3525378424",
+  "binary": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/candidates-a7ff5ff",
+  "binary_sha256": "8eeee5c2f8b39de6575c2308e89cba11b96d38d66d1ae3d51ab6ce0d61d43e79",
+  "limitations": [
+    "Rebuilt from retained historical source, not the original historical executable.",
+    "The source date and pre-score-fill policy match the retained candidate recipe, but this build alone proves no output equality."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-native-matching-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-native-matching-replay-v1.json
@@ -1,0 +1,23 @@
+{
+  "status": "complete-matching-shards-byte-reproduction-pass",
+  "source_commit": "a7ff5ff47b561556ba20a0afdb40417ec9413120",
+  "binary_sha256": "8eeee5c2f8b39de6575c2308e89cba11b96d38d66d1ae3d51ab6ce0d61d43e79",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-matching-replay-v1/report.json",
+  "recipe_document": "docs/openloris_frontend_reproduction.md",
+  "candidate_sha256": "fca2fce1056e08966ed4d3c0a48781cf546ad5c70a6f6f86c39c365205da5716",
+  "plan_sha256": "624e8c431cbde31faf8d1ab1590160dc40ad5711a568449df28b378428f47e01",
+  "feature_manifest_sha256": "74c66d3d7641c8d349953bba0b0e89843174699d40e31ee003f56adfef0dcdb8",
+  "regenerated_candidate_shards": 2188,
+  "byte_identical_match_snapshots": 2188,
+  "different_or_missing_snapshots": [],
+  "extra_snapshots": [],
+  "exit_status": 0,
+  "wall_seconds": 209.93730997294188,
+  "peak_rss_kib": 869812,
+  "rayon_num_threads": 4,
+  "limitations": [
+    "Inputs are replayed candidates and hash-validated retained base features; the recorded plan is a frozen schedule.",
+    "Measured wall/RSS covers matching subprocess, not preparation, validation, merge or native E2E.",
+    "No speedup or quality improvement claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-native-merge-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-native-merge-replay-v1.json
@@ -1,0 +1,21 @@
+{
+  "status": "complete-merged-snapshot-byte-reproduction-pass",
+  "source_commit": "a7ff5ff47b561556ba20a0afdb40417ec9413120",
+  "build_command": "CARGO_INCREMENTAL=0 cargo build --locked --release --example merge_verified_pair_snapshots --jobs 2",
+  "binary_sha256": "34840984753c39c23fb30506cc20631b48d69ab4319afdee719f73283b4faa16",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-merge-replay-v1/report.json",
+  "matching_report_sha256": "1759060d43bac930a9d785d354d203326bb68f1c2af50fcd08649a317981ac0f",
+  "snapshot_count": 2188,
+  "pairs": 58530,
+  "accepted_correspondences": 3177460,
+  "output_and_reference_sha256": "ada96b24a29bea87cfe95853959b8915d3265b940d438b849a587dffd1401276",
+  "exit_status": 0,
+  "wall_seconds": 4.586889068013988,
+  "peak_rss_kib": 1843928,
+  "rayon_num_threads": 1,
+  "limitations": [
+    "Merge of independently reproduced matching shards; retained reference snapshots are used only for comparison.",
+    "Native candidate/matching/merge stages were separate timed subprocesses, not a continuous native E2E measurement.",
+    "Adaptive, targeted and dense overlay matching producers and full extraction remain separate upstream work."
+  ]
+}

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -4,6 +4,11 @@ The admission chain is now reproducible **from retained matching inputs**.
 This is not a continuous native E2E result, and it does not fix the remaining
 COLMAP trajectory-quality gate.
 
+The native base branch has now also been regenerated from retained base features:
+candidate manifest, all matching shards and the merged snapshot are byte-identical
+to their references. Adaptive, targeted and dense-overlay frontend reproduction
+remain open; this is not full input-image-to-model execution.
+
 ```text
 base features → native-rig-runner verified snapshot ─────┐
 base + supplemental features → adaptive matching ───────┤
@@ -40,12 +45,78 @@ Likewise, the `long128` directory's `verified-goodbase-repair19.vps` is byte-ide
 to the adaptive control-prefix repair snapshot. Its directory name alone does
 not require long128 matching in this chain.
 
-Next, reproduce candidate generation and matching for native-runner, adaptive,
-targeted7 and the separate dense deferred overlay. Preserve their exact feature
+Next, reproduce candidate generation and matching for adaptive, targeted7 and
+the separate dense deferred overlay. Preserve their exact feature
 indices and pair order. Freeze the complete executable recipe, run it as one
 process tree with wall/RSS accounting, and evaluate the unchanged COLMAP gates.
 The earlier 1,250-image extraction and synthetic bank-only 100k tests do not
 close full10k extraction, whole-pipeline restart or full SfM100k I/O gates.
 
-Storage currently constrains additional large runs. Do not silently move measured
-outputs to memory-backed storage or discard retained evidence to obtain a pass.
+Disk cleanup on 2026-09-09 restored about 21 GiB of root free space before the
+next replay. Do not silently move measured outputs to memory-backed storage or
+discard retained evidence to obtain a pass.
+
+## Native frontend replay commands
+
+The machine-local diagnostic recipes are:
+
+```sh
+python3 scripts/replay_native_candidates.py \
+  --binary /home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/candidates-a7ff5ff \
+  --binary-sha256 8eeee5c2f8b39de6575c2308e89cba11b96d38d66d1ae3d51ab6ce0d61d43e79 \
+  --source-commit a7ff5ff47b561556ba20a0afdb40417ec9413120 \
+  --output-name corridor1-1-m8-native-candidates-legacy-replay-v1
+python3 scripts/replay_native_matching.py \
+  --candidate-root /home/sasaki/datasets/openloris/corridor1-1-m8-native-candidates-legacy-replay-v1 \
+  --binary /home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/candidates-a7ff5ff \
+  --binary-sha256 8eeee5c2f8b39de6575c2308e89cba11b96d38d66d1ae3d51ab6ce0d61d43e79
+python3 scripts/replay_native_merge.py \
+  --binary /home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/merge-a7ff5ff \
+  --binary-sha256 34840984753c39c23fb30506cc20631b48d69ab4319afdee719f73283b4faa16
+```
+
+They refuse existing replay directories. Candidate generation uses the retained
+command-line recipe, a SHA-256-checked executable, CPU8, and
+a 30-minute timeout. Matching requires a successful candidate replay, regenerates
+all 2,188 legacy 32-pair candidate shards and checks their full hashes against the
+recorded schedule, validates the retained feature bank, and uses CPU4. It compares
+every resulting snapshot with the corresponding reference snapshot. These are
+diagnostic stage replays, not a continuous E2E runner or portable demo commands.
+Matching deliberately excludes snapshot merging and downstream reconstruction.
+
+The external replay directories are
+`corridor1-1-m8-native-candidates-legacy-replay-v1` and
+`corridor1-1-m8-native-matching-replay-v1` under the OpenLORIS dataset root.
+Each executed phase writes `report.json`, `run.log` and `time.txt`. A launched
+process or a `running` report is not a pass; require terminal exit zero and
+complete-file equality. Historical candidate thread settings were not recovered
+from the timing file, so new candidate wall time alone is not a speedup claim.
+
+The initial default-argument replay with `extract-3ae253a` completed but failed
+candidate equality: 66,239 shared pairs and 3,761 different pairs on each side.
+It remains in `corridor1-1-m8-native-candidates-replay-v1`; do not feed that run
+into a claimed historical matching reproduction. Commit `67ead5e` introduced
+score-descending retrieval fill, whereas `a7ff5ff` retains producer pair order.
+The historical executable above was rebuilt in a clean detached worktree; its
+build provenance is `m8-openloris-native-frontend-legacy-build-v1.json`.
+
+The historical candidate replay completed successfully: 10,000 images, 70,000
+pairs, full manifest SHA-256 `fca2fce1056e08966ed4d3c0a48781cf546ad5c70a6f6f86c39c365205da5716`
+equal to the retained reference, wall 583.20 s, peak RSS 354,312 KiB.
+Evidence: `m8-openloris-native-candidates-legacy-replay-v1.json`. Thus native
+candidate generation no longer requires a retained candidate output, but still
+requires the retained base feature bank.
+
+Matching then completed in 209.94 s with peak RSS 869,812 KiB. All 2,188
+regenerated candidate shards matched the frozen plan hashes; all 2,188 output
+snapshots were byte-identical, with no missing or extra snapshots. The legacy
+merger rebuilt from the same clean source produced 58,530 pairs / 3,177,460
+accepted correspondences in 4.59 s, peak RSS 1,843,928 KiB. Full output SHA-256:
+`ada96b24a29bea87cfe95853959b8915d3265b940d438b849a587dffd1401276`.
+The output is in `corridor1-1-m8-native-merge-replay-v1`. Evidence is in
+`m8-openloris-native-matching-replay-v1.json` and
+`m8-openloris-native-merge-replay-v1.json`.
+
+All timings cover their respective subprocess, not preparation or validation.
+Do not sum them into a continuous E2E claim. Full extraction, the other frontend
+branches, continuous E2E and the COLMAP quality gate remain open.

--- a/scripts/replay_native_candidates.py
+++ b/scripts/replay_native_candidates.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Replay the retained OpenLORIS native candidate recipe without overwriting it."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import time
+
+
+def sha(path):
+    result = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            result.update(chunk)
+    return result.hexdigest()
+
+
+def main():
+    base = Path('/home/sasaki/datasets/openloris')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=base / 'corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a')
+    parser.add_argument('--binary-sha256', default='8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34')
+    parser.add_argument('--output-name', default='corridor1-1-m8-native-candidates-replay-v1')
+    parser.add_argument('--source-commit', default='3ae253a0af909042fe0cfbdb08e8d50733b79375')
+    args = parser.parse_args()
+    if not args.output_name.startswith('corridor1-1-m8-native-candidates-') or Path(args.output_name).name != args.output_name:
+        parser.error('--output-name must be a simple native-candidate replay directory name')
+    reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
+    output = base / args.output_name
+    binary = args.binary.resolve(strict=True)
+    expected_binary = args.binary_sha256
+    if sha(binary) != expected_binary:
+        raise RuntimeError('Frozen binary changed')
+    timing = reference / 'timing/candidate-generation.time.txt'
+    first_line = timing.read_text().splitlines()[0]
+    recorded = shlex.split(first_line.split('Command being timed: ', 1)[1])[0]
+    command = shlex.split(recorded)
+    command[0] = str(binary)
+    for flag, name in [('--export-candidate-manifest', 'candidates.txt'),
+                       ('--out-colmap', 'unused-model-candidates')]:
+        command[command.index(flag) + 1] = str(output / name)
+    output.mkdir()  # Fail closed on an existing replay directory.
+    env = dict(os.environ, RAYON_NUM_THREADS='8')
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
+    report = {'command': invocation, 'binary_sha256': expected_binary,
+              'source_commit': args.source_commit,
+              'reference_recipe_sha256': sha(timing),
+              'reference_sha256': sha(reference / 'candidates.txt'),
+              'rayon_num_threads': 8, 'status': 'running',
+              'scope': 'candidate generation only; retained base features'}
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    started = time.monotonic()
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, env=env, stdout=log, stderr=subprocess.STDOUT)
+    report.update(exit_code=result.returncode, wall_seconds=time.monotonic() - started)
+    candidate = output / 'candidates.txt'
+    report['output_sha256'] = sha(candidate) if candidate.exists() else None
+    report['byte_identical'] = report['reference_sha256'] == report['output_sha256']
+    report['status'] = 'pass' if result.returncode == 0 and report['byte_identical'] else 'fail'
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2), flush=True)
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/replay_native_matching.py
+++ b/scripts/replay_native_matching.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Reproduce native matching shards from independently replayed candidates."""
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import time
+
+from benchmark_electro import (
+    parse_candidate_manifest_with_metadata,
+    validate_feature_manifest,
+    write_candidate_manifest,
+)
+from replay_native_candidates import sha
+
+
+def main():
+    base = Path('/home/sasaki/datasets/openloris')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--candidate-root', type=Path,
+                        default=base / 'corridor1-1-m8-native-candidates-replay-v1')
+    parser.add_argument('--binary', type=Path,
+                        default=base / 'corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a')
+    parser.add_argument('--binary-sha256',
+                        default='8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34')
+    args = parser.parse_args()
+    reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
+    candidate_root = args.candidate_root.resolve(strict=True)
+    output = base / 'corridor1-1-m8-native-matching-replay-v1'
+    binary = args.binary.resolve(strict=True)
+    expected_binary = args.binary_sha256
+    candidate_report = json.loads((candidate_root / 'report.json').read_text())
+    if candidate_report['status'] != 'pass' or sha(binary) != expected_binary:
+        raise RuntimeError('Candidate replay or frozen binary prerequisite failed')
+    candidates = candidate_root / 'candidates.txt'
+    if sha(candidates) != sha(reference / 'candidates.txt'):
+        raise RuntimeError('Candidate contents changed')
+    names, pairs, metadata = parse_candidate_manifest_with_metadata(candidates)
+    if len(names) != 10000 or len(pairs) != 70000:
+        raise RuntimeError('Unexpected candidate envelope')
+    output.mkdir()
+    (output / 'candidates').mkdir()
+    (output / 'matches').mkdir()
+    # Use the recorded plan as a frozen schedule, not retained match outputs.
+    plan = (reference / 'match-worker.plan').read_text()
+    shard_rows = [line.split() for line in plan.splitlines() if line.startswith('shard ')]
+    if len(shard_rows) != 2188:
+        raise RuntimeError('Unexpected shard count')
+    for index, fields in enumerate(shard_rows):
+        expected_candidate = f'candidates/candidate-{index:06d}.txt'
+        expected_snapshot = f'matches/verified-{index:06d}.vps'
+        if len(fields) != 5 or fields[1:4] != [str(index), expected_candidate, expected_snapshot]:
+            raise RuntimeError('Unexpected shard order or unsafe paths')
+        destination = output / expected_candidate
+        write_candidate_manifest(destination, names, pairs[index * 32:(index + 1) * 32],
+                                 metadata=metadata)
+        if sha(destination) != fields[4]:
+            raise RuntimeError(f'Regenerated shard differs: {index}')
+    features = base / 'corridor1-1-m5/tiers/tier-10000/features256'
+    validate_feature_manifest(reference / 'features.json', features)
+    shutil.copy2(reference / 'match-worker.plan', output / 'match-worker.plan')
+    timing = reference / 'timing/persistent-match.time.txt'
+    first_line = timing.read_text().splitlines()[0]
+    command = shlex.split(shlex.split(first_line.split('Command being timed: ', 1)[1])[0])
+    command[0] = str(binary)
+    for flag, path in [('--persistent-match-worker-plan', output / 'match-worker.plan'),
+                       ('--out-colmap', output / 'matches/unused-model-persistent')]:
+        command[command.index(flag) + 1] = str(path)
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
+    report = {'status': 'running', 'command': invocation, 'rayon_num_threads': 4,
+              'binary_sha256': expected_binary, 'candidate_sha256': sha(candidates),
+              'plan_sha256': sha(output / 'match-worker.plan'),
+              'feature_manifest_sha256': sha(reference / 'features.json'),
+              'regenerated_candidate_shards': len(shard_rows),
+              'scope': 'matching shards only; retained base features and schedule; no merge'}
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    started = time.monotonic()
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='4'),
+                                stdout=log, stderr=subprocess.STDOUT)
+    report.update(exit_code=result.returncode, wall_seconds=time.monotonic() - started)
+    differences = []
+    for fields in shard_rows:
+        relative = fields[3]
+        actual = output / relative
+        if not actual.is_file() or sha(actual) != sha(reference / relative):
+            differences.append(relative)
+    expected_names = {Path(fields[3]).name for fields in shard_rows}
+    actual_names = {path.name for path in (output / 'matches').glob('*.vps')}
+    report['extra_snapshots'] = sorted(actual_names - expected_names)
+    report['different_or_missing_snapshots'] = differences
+    report['status'] = 'pass' if result.returncode == 0 and not differences and not report['extra_snapshots'] else 'fail'
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2), flush=True)
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/replay_native_merge.py
+++ b/scripts/replay_native_merge.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Merge only fully reproduced native match shards and check reference bytes."""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+from benchmark_electro import build_merge_command, parse_gnu_time
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--binary-sha256', required=True)
+    args = parser.parse_args()
+    base = Path('/home/sasaki/datasets/openloris')
+    reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
+    matching = base / 'corridor1-1-m8-native-matching-replay-v1'
+    report_path = matching / 'report.json'
+    report = json.loads(report_path.read_text())
+    if report['status'] != 'pass' or sha(args.binary) != args.binary_sha256:
+        raise RuntimeError('Matching replay or merge binary prerequisite failed')
+    expected_names = {f'verified-{index:06d}.vps' for index in range(2188)}
+    actual_names = {path.name for path in (matching / 'matches').glob('*.vps')}
+    if actual_names != expected_names:
+        raise RuntimeError('Snapshot membership differs')
+    snapshots = []
+    for name in sorted(expected_names):
+        path = matching / 'matches' / name
+        if sha(path) != sha(reference / 'matches' / name):
+            raise RuntimeError(f'Snapshot changed: {name}')
+        snapshots.append(path)
+    output = base / 'corridor1-1-m8-native-merge-replay-v1'
+    output.mkdir()
+    destination = output / 'verified-merged.vps'
+    command = build_merge_command(args.binary.resolve(), destination, snapshots)
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '600s', *command]
+    started = time.monotonic()
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='1'),
+                                stdout=log, stderr=subprocess.STDOUT)
+    elapsed = time.monotonic() - started
+    expected = sha(reference / 'mapping/verified-merged.vps')
+    actual = sha(destination) if destination.exists() else None
+    report = {'status': 'pass' if result.returncode == 0 and actual == expected else 'fail',
+              'exit_code': result.returncode, 'wall_seconds': elapsed,
+              'binary': str(args.binary.resolve()), 'binary_sha256': args.binary_sha256,
+              'matching_report_sha256': sha(report_path), 'snapshot_count': len(snapshots),
+              'output_sha256': actual, 'reference_sha256': expected,
+              'measurement': parse_gnu_time(output / 'time.txt'),
+              'scope': 'merge of reproduced native matching shards only; not E2E'}
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2), flush=True)
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Reproduces the 10k native candidate manifest, all 2188 matching shards, and merged snapshot from retained feature inputs. Diagnoses modern score-fill policy drift and freezes the historical source/binary recipe. All outputs match references byte-for-byte. Adds stage replay commands and evidence; no E2E, quality improvement, or COLMAP speedup claim. Validation: 22 script tests, Python compilation, JSON parsing, diff checks, and completed real-data replays. Adaptive, targeted and dense producers remain open.