### PR TITLE
bench: reproduce adaptive and targeted OpenLORIS frontends

### DIFF
--- a/benchmarks/electro/m8-openloris-adaptive-frontend-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-adaptive-frontend-replay-v1.json
@@ -1,0 +1,33 @@
+{
+  "status": "complete-adaptive-merged-snapshot-byte-reproduction-pass",
+  "source_commit": "a7ff5ff47b561556ba20a0afdb40417ec9413120",
+  "candidate_reference": "m8-openloris-native-candidates-legacy-replay-v1.json",
+  "candidate_schedule": "Same as native; only feature_manifest_sha256 differs in frozen worker plans.",
+  "candidate_shards_regenerated_and_hash_verified": 2188,
+  "features": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive-bank-publication-v1/features",
+  "features_resolved": "/media/sasaki/aiueo1/visloc-replay-retired-20260909/corridor1-1-m8-adaptive-bank-publication-v1/features",
+  "feature_manifest_sha256": "406e2e82ea1faa57747465d2adfc95e645ad5e40cd1e301dbb4a70e285be9a0f",
+  "matching": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive-matching-replay-v1/report.json",
+    "exit_status": 0,
+    "wall_seconds": 231.2854480210226,
+    "peak_rss_kib": 977952,
+    "rayon_num_threads": 4,
+    "snapshot_inventory_sha256": "0e994235445415195fe9325132ca93645abed79381b8f90fc87c1c0f42470e92",
+    "individual_reference_comparison": false
+  },
+  "merge": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive-merge-replay-v1/report.json",
+    "exit_status": 0,
+    "wall_seconds": 4.960614662966691,
+    "peak_rss_kib": 1870216,
+    "pairs": 61286,
+    "accepted_correspondences": 3434453,
+    "output_and_reference_sha256": "852c43c3df905ca150e44fbc65c35ed5a451507399019649b3900d06503ccf19"
+  },
+  "limitations": [
+    "Original adaptive individual snapshots are absent; exact comparison is at the complete merged-file boundary.",
+    "Freshly regenerated adaptive bank is on external ext4 storage following authorized cleanup; no unchanged-I/O speedup claim.",
+    "Separate candidate, matching and merge stage runs; no continuous native E2E, extraction or quality improvement claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-targeted7-frontend-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-targeted7-frontend-replay-v1.json
@@ -1,0 +1,36 @@
+{
+  "status": "complete-targeted7-frontend-byte-reproduction-pass-from-frozen-targets",
+  "source_commit": "a7ff5ff47b561556ba20a0afdb40417ec9413120",
+  "target_frames": [1999, 3264, 3266, 3267, 4493, 4494, 4495],
+  "max_frame_gap": 256,
+  "candidate_recipe": "scripts/build_targeted_rig_candidates.py: all sensor combinations incident to a target within inclusive numeric frame gap; canonical pair deduplication and sorting",
+  "candidate_pairs": 14319,
+  "candidate_output_and_reference_sha256": "14ac996b591a3d98c9be97d5c3c0aa47b04c93c48c551b2556353729c6895a4f",
+  "features": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive-bank-publication-v1/features",
+  "feature_manifest_sha256": "406e2e82ea1faa57747465d2adfc95e645ad5e40cd1e301dbb4a70e285be9a0f",
+  "matching": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-matching-replay-v1/report.json",
+    "exit_status": 0,
+    "wall_seconds": 62.94877364998683,
+    "peak_rss_kib": 977232,
+    "rayon_num_threads": 4,
+    "regenerated_candidate_shards": 448,
+    "byte_identical_reference_snapshots": 448,
+    "snapshot_inventory_sha256": "b9af89ee8b9e5e7bd0cfd5d4f8a0d24dee52f0ae8ba72c6724eab6ca50a8567c"
+  },
+  "merge": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-merge-replay-v1/report.json",
+    "exit_status": 0,
+    "wall_seconds": 0.6797075249487534,
+    "peak_rss_kib": 309148,
+    "pairs": 265,
+    "accepted_correspondences": 5336,
+    "output_and_reference_sha256": "5c21537b2d95b85e04739c97ccdf59b2d3837e435f688909114d8ac07e74eba1"
+  },
+  "limitations": [
+    "Seven target IDs are frozen inputs, not yet derived by replaying the preceding registration stage.",
+    "Three retained deferred-repair19 models have exactly these missing frame IDs; set equality alone does not identify the historical selector or mapping command.",
+    "Uses the regenerated adaptive bank on external storage; no unchanged-I/O speed comparison.",
+    "Separate stages, not continuous E2E, extraction closure or quality improvement."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -2,7 +2,30 @@
 
 ## 現在の状態（以下の過去ログより優先）
 
-最新: PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。
+最新（2026-09-09）: PR118は`0b7f999`へmerge済み。PR119はhead
+`dd9c94c46723ef290fd524a0426cc27e919fef26`のCI9成功を確認し、
+`7568377c1aa46c208996b924f44c358cc7b65021`へsquash merge、旧branch整理済み。
+現作業branchは`diag/m8-adaptive-frontend-replay`。サブエージェントは使わない。
+
+- native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
+  70,000候補・2,188 matching shards・merged snapshotが全bytes一致。
+  score順fillへの仕様変更を確認した。旧版への本番ロールバックではない。
+- adaptiveはnativeと同じ候補計画。再生成済みバンクからmatching/mergeを実行し、
+  61,286ペアのmerged snapshotが全bytes一致。元の個別shardがないため比較は統合境界。
+- targeted7は指定7 frame/±256から14,319候補を生成し全bytes一致。
+  matching448 shard・265ペアの統合snapshotも一致。7 frame選定の前段mappingは未再現。
+- 新規証跡と具体的コマンドは`docs/openloris_frontend_reproduction.md`。
+  adaptive/targetedでは退避済みの再生成バンク（外部ext4）を使用。過去と同一I/Oではない。
+- 許可済み整理で空き約21 GiBを確保し、新規replay後は約18 GiB。
+  整理ログと検証付き重複削除scriptはlocal branch `chore/replay-storage-cleanup`
+  （`8b05461`、未PR）に保存。元データ・検証ログは保持。
+- 次: この変更のPR/CI/merge、target選定前段とdense overlayの再現、全10k抽出・
+  continuous E2E・未達のCOLMAP軌跡品質改善。phase時間の和をE2Eとしない。
+  全goalは未達。READMEに未検証の高速化/品質改善を追加しない。
+
+### 以前の状態（上記を優先）
+
+PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。
 現branch `diag/m8-pair-admission-recovery`。targeted7追加とrepair19修復・順序を
 既存ツールで再生成しsnapshot全bytes一致（証跡targeted7-admission-replay-v1、
 repair19-order-replay-v1、repair19-admission-replay-v1）。中間登録結果と修復前snapshotは未再生成。

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -6,8 +6,9 @@ COLMAP trajectory-quality gate.
 
 The native base branch has now also been regenerated from retained base features:
 candidate manifest, all matching shards and the merged snapshot are byte-identical
-to their references. Adaptive, targeted and dense-overlay frontend reproduction
-remain open; this is not full input-image-to-model execution.
+to their references. Adaptive matching/merge and targeted7 candidate/matching/merge
+have also been reproduced. Target selection and dense-overlay reproduction remain
+open; this is not full input-image-to-model execution.
 
 ```text
 base features → native-rig-runner verified snapshot ─────┐
@@ -45,8 +46,8 @@ Likewise, the `long128` directory's `verified-goodbase-repair19.vps` is byte-ide
 to the adaptive control-prefix repair snapshot. Its directory name alone does
 not require long128 matching in this chain.
 
-Next, reproduce candidate generation and matching for adaptive, targeted7 and
-the separate dense deferred overlay. Preserve their exact feature
+Next, recover the preceding registration/selection recipe for targeted7 and
+reproduce the separate dense deferred overlay. Preserve their exact feature
 indices and pair order. Freeze the complete executable recipe, run it as one
 process tree with wall/RSS accounting, and evaluate the unchanged COLMAP gates.
 The earlier 1,250-image extraction and synthetic bank-only 100k tests do not
@@ -117,6 +118,52 @@ The output is in `corridor1-1-m8-native-merge-replay-v1`. Evidence is in
 `m8-openloris-native-matching-replay-v1.json` and
 `m8-openloris-native-merge-replay-v1.json`.
 
+## Adaptive and targeted matching replay
+
+Adaptive and native worker plans differ only in the feature-manifest hash.
+Adaptive therefore consumes the independently reproduced native candidates;
+there is no additional adaptive ANN candidate run in this frozen recipe.
+The replay uses the newly published adaptive bank (full manifest validated),
+now on external ext4 storage after authorized disk cleanup.
+
+```sh
+python3 scripts/replay_native_matching.py --variant adaptive \
+  --candidate-root /home/sasaki/datasets/openloris/corridor1-1-m8-native-candidates-legacy-replay-v1 \
+  --binary /home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/candidates-a7ff5ff \
+  --binary-sha256 8eeee5c2f8b39de6575c2308e89cba11b96d38d66d1ae3d51ab6ce0d61d43e79
+python3 scripts/replay_native_merge.py --variant adaptive \
+  --binary /home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/merge-a7ff5ff \
+  --binary-sha256 34840984753c39c23fb30506cc20631b48d69ab4319afdee719f73283b4faa16
+```
+
+All 2,188 candidate shards were regenerated and hash-checked. Original adaptive
+match shards are no longer present: the matching result remains explicitly
+`complete-awaiting-merge-comparison`, not a per-shard reproduction pass. The
+merger checks new-shard membership and the post-matching content inventory before
+consuming them. Its complete output matches the retained 61,286-pair snapshot
+exactly (SHA-256 `852c43c3df905ca150e44fbc65c35ed5a451507399019649b3900d06503ccf19`).
+See `m8-openloris-adaptive-frontend-replay-v1.json`.
+
+Targeted7 candidates were reproduced with:
+
+```sh
+python3 scripts/build_targeted_rig_candidates.py \
+  --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt \
+  --target-frames 1999,3264,3266,3267,4493,4494,4495 --max-frame-gap 256 \
+  --output-directory /home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-candidates-replay-v1
+```
+
+Use the matching command above with `--variant targeted7` and
+`--candidate-root /home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-candidates-replay-v1`,
+then the merge command with `--variant targeted7`. All 14,319 candidate pairs,
+448 match shards and the complete 265-pair merged snapshot match the references.
+See `m8-openloris-targeted7-frontend-replay-v1.json`.
+
+The seven target IDs remain frozen inputs. Three retained deferred-repair19
+models have exactly this unregistered frame set, but this alone does not identify
+or reproduce the historical selector. Do not omit its preceding mapping cost.
+
 All timings cover their respective subprocess, not preparation or validation.
-Do not sum them into a continuous E2E claim. Full extraction, the other frontend
-branches, continuous E2E and the COLMAP quality gate remain open.
+Do not sum them into a continuous E2E claim. External-bank I/O is not unchanged
+from historical runs. Full extraction, target selection, the dense-overlay branch,
+continuous E2E and the COLMAP quality gate remain open.

--- a/scripts/build_targeted_rig_candidates.py
+++ b/scripts/build_targeted_rig_candidates.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Build bounded target-frame candidate windows; target selection is an input."""
+import argparse
+from bisect import bisect_left, bisect_right
+from pathlib import Path
+
+from benchmark_electro import write_candidate_manifest
+from select_rig_sift_supplements import parse_frames
+
+
+def targeted_pairs(frames, targets, gap):
+    if gap < 0 or not targets or len(set(targets)) != len(targets):
+        raise ValueError('Require nonnegative gap and unique nonempty targets')
+    if any(target not in frames for target in targets):
+        raise ValueError('Unknown target frame')
+    names = sorted(name for members in frames.values() for name in members)
+    if len(set(names)) != len(names):
+        raise ValueError('Duplicate image names')
+    indices = {name: index for index, name in enumerate(names)}
+    ordered = sorted(frames)
+    pairs = set()
+    for target in targets:
+        begin = bisect_left(ordered, target - gap)
+        end = bisect_right(ordered, target + gap)
+        for frame in ordered[begin:end]:
+            for left in frames[target]:
+                for right in frames[frame]:
+                    if left != right:
+                        pairs.add(tuple(sorted((indices[left], indices[right]))))
+    return names, sorted(pairs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--rig-manifest', type=Path, required=True)
+    parser.add_argument('--target-frames', required=True)
+    parser.add_argument('--max-frame-gap', type=int, required=True)
+    parser.add_argument('--output-directory', type=Path, required=True)
+    args = parser.parse_args()
+    targets = [int(value) for value in args.target_frames.split(',')]
+    frames = parse_frames(args.rig_manifest.read_bytes())
+    names, pairs = targeted_pairs(frames, targets, args.max_frame_gap)
+    args.output_directory.mkdir()  # Never replace an existing experiment.
+    output = args.output_directory / 'candidates.txt'
+    write_candidate_manifest(output, names, pairs, metadata={
+        'pair_source': 'targeted-dense-window-v1',
+        'max_frame_gap': str(args.max_frame_gap),
+        'target_frames': ','.join(map(str, sorted(targets))),
+    })
+    print(f'{len(names)} images, {len(pairs)} pairs -> {output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/replay_native_matching.py
+++ b/scripts/replay_native_matching.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Reproduce native matching shards from independently replayed candidates."""
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -17,9 +18,24 @@ from benchmark_electro import (
 from replay_native_candidates import sha
 
 
+def snapshot_inventory(root, names):
+    digest = hashlib.sha256()
+    for name in sorted(names):
+        digest.update(f'{name}\t{sha(root / name)}\n'.encode())
+    return digest.hexdigest()
+
+
+def same_candidate_schedule(native_plan, adaptive_plan):
+    def schedule(plan):
+        return [line for line in plan.splitlines()
+                if not line.startswith('feature_manifest_sha256 ')]
+    return schedule(native_plan) == schedule(adaptive_plan)
+
+
 def main():
     base = Path('/home/sasaki/datasets/openloris')
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7'], default='native')
     parser.add_argument('--candidate-root', type=Path,
                         default=base / 'corridor1-1-m8-native-candidates-replay-v1')
     parser.add_argument('--binary', type=Path,
@@ -27,27 +43,36 @@ def main():
     parser.add_argument('--binary-sha256',
                         default='8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34')
     args = parser.parse_args()
-    reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
+    native_reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
+    reference = (native_reference if args.variant == 'native' else
+                 base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline')
+    if args.variant == 'targeted7':
+        reference = base / 'corridor1-1-m8-targeted7-dense256-v1'
     candidate_root = args.candidate_root.resolve(strict=True)
-    output = base / 'corridor1-1-m8-native-matching-replay-v1'
+    output = base / f'corridor1-1-m8-{args.variant}-matching-replay-v1'
     binary = args.binary.resolve(strict=True)
     expected_binary = args.binary_sha256
-    candidate_report = json.loads((candidate_root / 'report.json').read_text())
-    if candidate_report['status'] != 'pass' or sha(binary) != expected_binary:
+    candidate_ok = (args.variant == 'targeted7' or
+                    json.loads((candidate_root / 'report.json').read_text())['status'] == 'pass')
+    if not candidate_ok or sha(binary) != expected_binary:
         raise RuntimeError('Candidate replay or frozen binary prerequisite failed')
     candidates = candidate_root / 'candidates.txt'
-    if sha(candidates) != sha(reference / 'candidates.txt'):
+    candidate_reference = reference if args.variant == 'targeted7' else native_reference
+    if sha(candidates) != sha(candidate_reference / 'candidates.txt'):
         raise RuntimeError('Candidate contents changed')
     names, pairs, metadata = parse_candidate_manifest_with_metadata(candidates)
-    if len(names) != 10000 or len(pairs) != 70000:
+    expected_pairs = 14319 if args.variant == 'targeted7' else 70000
+    if len(names) != 10000 or len(pairs) != expected_pairs:
         raise RuntimeError('Unexpected candidate envelope')
     output.mkdir()
     (output / 'candidates').mkdir()
     (output / 'matches').mkdir()
     # Use the recorded plan as a frozen schedule, not retained match outputs.
     plan = (reference / 'match-worker.plan').read_text()
+    if args.variant != 'targeted7' and not same_candidate_schedule((native_reference / 'match-worker.plan').read_text(), plan):
+        raise RuntimeError('Adaptive schedule differs from reproduced native candidates')
     shard_rows = [line.split() for line in plan.splitlines() if line.startswith('shard ')]
-    if len(shard_rows) != 2188:
+    if len(shard_rows) != (expected_pairs + 31) // 32:
         raise RuntimeError('Unexpected shard count')
     for index, fields in enumerate(shard_rows):
         expected_candidate = f'candidates/candidate-{index:06d}.txt'
@@ -59,24 +84,29 @@ def main():
                                  metadata=metadata)
         if sha(destination) != fields[4]:
             raise RuntimeError(f'Regenerated shard differs: {index}')
-    features = base / 'corridor1-1-m5/tiers/tier-10000/features256'
+    features = (base / 'corridor1-1-m5/tiers/tier-10000/features256' if args.variant == 'native'
+                else base / 'corridor1-1-m8-adaptive-bank-publication-v1/features')
     validate_feature_manifest(reference / 'features.json', features)
+    if f'feature_manifest_sha256 {sha(reference / "features.json")}' not in plan.splitlines():
+        raise RuntimeError('Plan does not bind the validated feature manifest')
     shutil.copy2(reference / 'match-worker.plan', output / 'match-worker.plan')
     timing = reference / 'timing/persistent-match.time.txt'
     first_line = timing.read_text().splitlines()[0]
     command = shlex.split(shlex.split(first_line.split('Command being timed: ', 1)[1])[0])
     command[0] = str(binary)
     for flag, path in [('--persistent-match-worker-plan', output / 'match-worker.plan'),
+                       ('--features-dir', features),
                        ('--out-colmap', output / 'matches/unused-model-persistent')]:
         command[command.index(flag) + 1] = str(path)
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
                   'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
     report = {'status': 'running', 'command': invocation, 'rayon_num_threads': 4,
+              'variant': args.variant, 'features_resolved': str(features.resolve()),
               'binary_sha256': expected_binary, 'candidate_sha256': sha(candidates),
               'plan_sha256': sha(output / 'match-worker.plan'),
               'feature_manifest_sha256': sha(reference / 'features.json'),
               'regenerated_candidate_shards': len(shard_rows),
-              'scope': 'matching shards only; retained base features and schedule; no merge'}
+              'scope': 'matching shards only; validated feature bank and frozen schedule; no merge'}
     (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
     started = time.monotonic()
     with (output / 'run.log').open('w') as log:
@@ -87,16 +117,21 @@ def main():
     for fields in shard_rows:
         relative = fields[3]
         actual = output / relative
-        if not actual.is_file() or sha(actual) != sha(reference / relative):
+        if not actual.is_file() or (args.variant != 'adaptive' and sha(actual) != sha(reference / relative)):
             differences.append(relative)
     expected_names = {Path(fields[3]).name for fields in shard_rows}
     actual_names = {path.name for path in (output / 'matches').glob('*.vps')}
     report['extra_snapshots'] = sorted(actual_names - expected_names)
     report['different_or_missing_snapshots'] = differences
     report['status'] = 'pass' if result.returncode == 0 and not differences and not report['extra_snapshots'] else 'fail'
+    if report['status'] == 'pass':
+        report['snapshot_inventory_sha256'] = snapshot_inventory(output / 'matches', expected_names)
+        if args.variant == 'adaptive':
+            report['status'] = 'complete-awaiting-merge-comparison'
+    report['individual_reference_comparison'] = args.variant != 'adaptive'
     (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
     print(json.dumps(report, indent=2), flush=True)
-    return 0 if report['status'] == 'pass' else 1
+    return 0 if report['status'] in ('pass', 'complete-awaiting-merge-comparison') else 1
 
 
 if __name__ == '__main__':

--- a/scripts/replay_native_merge.py
+++ b/scripts/replay_native_merge.py
@@ -9,31 +9,40 @@ import time
 
 from benchmark_electro import build_merge_command, parse_gnu_time
 from replay_native_candidates import sha
+from replay_native_matching import snapshot_inventory
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7'], default='native')
     parser.add_argument('--binary', type=Path, required=True)
     parser.add_argument('--binary-sha256', required=True)
     args = parser.parse_args()
     base = Path('/home/sasaki/datasets/openloris')
-    reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
-    matching = base / 'corridor1-1-m8-native-matching-replay-v1'
+    reference = (base / 'corridor1-1-m8-native-rig-runner-10k-v1' if args.variant == 'native'
+                 else base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline')
+    if args.variant == 'targeted7':
+        reference = base / 'corridor1-1-m8-targeted7-dense256-v1'
+    matching = base / f'corridor1-1-m8-{args.variant}-matching-replay-v1'
     report_path = matching / 'report.json'
     report = json.loads(report_path.read_text())
-    if report['status'] != 'pass' or sha(args.binary) != args.binary_sha256:
+    accepted_status = 'complete-awaiting-merge-comparison' if args.variant == 'adaptive' else 'pass'
+    if report['status'] != accepted_status or report['exit_code'] != 0 or sha(args.binary) != args.binary_sha256:
         raise RuntimeError('Matching replay or merge binary prerequisite failed')
-    expected_names = {f'verified-{index:06d}.vps' for index in range(2188)}
+    expected_count = 448 if args.variant == 'targeted7' else 2188
+    expected_names = {f'verified-{index:06d}.vps' for index in range(expected_count)}
     actual_names = {path.name for path in (matching / 'matches').glob('*.vps')}
     if actual_names != expected_names:
         raise RuntimeError('Snapshot membership differs')
+    if args.variant == 'adaptive' and snapshot_inventory(matching / 'matches', expected_names) != report.get('snapshot_inventory_sha256'):
+        raise RuntimeError('Adaptive snapshot bytes changed after matching')
     snapshots = []
     for name in sorted(expected_names):
         path = matching / 'matches' / name
-        if sha(path) != sha(reference / 'matches' / name):
+        if args.variant != 'adaptive' and sha(path) != sha(reference / 'matches' / name):
             raise RuntimeError(f'Snapshot changed: {name}')
         snapshots.append(path)
-    output = base / 'corridor1-1-m8-native-merge-replay-v1'
+    output = base / f'corridor1-1-m8-{args.variant}-merge-replay-v1'
     output.mkdir()
     destination = output / 'verified-merged.vps'
     command = build_merge_command(args.binary.resolve(), destination, snapshots)
@@ -47,12 +56,13 @@ def main():
     expected = sha(reference / 'mapping/verified-merged.vps')
     actual = sha(destination) if destination.exists() else None
     report = {'status': 'pass' if result.returncode == 0 and actual == expected else 'fail',
+              'variant': args.variant,
               'exit_code': result.returncode, 'wall_seconds': elapsed,
               'binary': str(args.binary.resolve()), 'binary_sha256': args.binary_sha256,
               'matching_report_sha256': sha(report_path), 'snapshot_count': len(snapshots),
               'output_sha256': actual, 'reference_sha256': expected,
               'measurement': parse_gnu_time(output / 'time.txt'),
-              'scope': 'merge of reproduced native matching shards only; not E2E'}
+              'scope': 'merge of freshly generated matching shards only; not E2E'}
     (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
     print(json.dumps(report, indent=2), flush=True)
     return 0 if report['status'] == 'pass' else 1

--- a/scripts/tests/test_native_replay_schedule.py
+++ b/scripts/tests/test_native_replay_schedule.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+from replay_native_matching import same_candidate_schedule, snapshot_inventory
+
+
+class ReplayScheduleTest(unittest.TestCase):
+    def test_feature_binding_may_differ(self):
+        self.assertTrue(same_candidate_schedule(
+            'images 2\nfeature_manifest_sha256 aaa\nshard 0 a b c\n',
+            'images 2\nfeature_manifest_sha256 bbb\nshard 0 a b c\n'))
+
+    def test_changed_candidate_rejected(self):
+        self.assertFalse(same_candidate_schedule('shard 0 a b c', 'shard 0 a b d'))
+
+    def test_changed_order_rejected(self):
+        self.assertFalse(same_candidate_schedule('image 0 a\nimage 1 b', 'image 1 b\nimage 0 a'))
+
+    def test_inventory_sorted_and_content_bound(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'a').write_bytes(b'a')
+            (root / 'b').write_bytes(b'b')
+            before = snapshot_inventory(root, ['a', 'b'])
+            self.assertEqual(before, snapshot_inventory(root, ['b', 'a']))
+            (root / 'b').write_bytes(b'c')
+            self.assertNotEqual(before, snapshot_inventory(root, ['a', 'b']))
+
+    def test_inventory_missing_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(FileNotFoundError):
+                snapshot_inventory(Path(directory), ['missing'])

--- a/scripts/tests/test_targeted_rig_candidates.py
+++ b/scripts/tests/test_targeted_rig_candidates.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from build_targeted_rig_candidates import targeted_pairs
+
+
+class TargetedPairsTest(unittest.TestCase):
+    def test_zero_gap_stereo_only(self):
+        names, pairs = targeted_pairs({0: ['a', 'b'], 1: ['c', 'd']}, [0], 0)
+        self.assertEqual(names, ['a', 'b', 'c', 'd'])
+        self.assertEqual(pairs, [(0, 1)])
+
+    def test_overlapping_targets_deduplicated(self):
+        _, pairs = targeted_pairs({0: ['a', 'b'], 1: ['c', 'd']}, [0, 1], 1)
+        self.assertEqual(pairs, [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
+
+    def test_numeric_gap_not_ordinal(self):
+        _, pairs = targeted_pairs({0: ['a'], 10: ['b'], 11: ['c']}, [10], 1)
+        self.assertEqual(pairs, [(1, 2)])
+
+    def test_invalid_targets(self):
+        for targets, gap in [([], 1), ([0, 0], 1), ([2], 1), ([0], -1)]:
+            with self.assertRaises(ValueError):
+                targeted_pairs({0: ['a', 'b']}, targets, gap)


### PR DESCRIPTION
Reuses independently regenerated native candidates for adaptive matching and verifies complete merged snapshot equality. Rebuilds targeted7 candidate windows from frozen target IDs, then reproduces all 448 match shards and the complete merged snapshot. Uses the previously regenerated adaptive bank on external storage; no unchanged-I/O speedup, E2E, or quality claim. Adds content-bound merge checks and 9 focused tests (31 script tests pass). Target selection producer and dense overlay remain open. PR119 has been merged with all 9 CI checks passing.