### PR TITLE
chore: record verified disk cleanup and recovery

### DIFF
--- a/docs/replay_storage_cleanup.md
+++ b/docs/replay_storage_cleanup.md
@@ -1,0 +1,29 @@
+# Replay storage cleanup
+
+User authorized external-disk relocation and disk cleanup. The destination is
+`/media/sasaki/aiueo1/visloc-replay-retired-20260909` (directory identifier).
+
+- `corridor1-1-m8-adaptive-bank-publication-v1`: moved from the OpenLORIS
+  dataset directory; original path now a symlink. All 10,004 files verified
+  against the pre-move aggregate SHA-256 inventory:
+  `7eab135e2d47d8a9fbf72199b13435db234af1f5dbc918d2ecbd6dcdf239459d`.
+- `corridor1-1-m8-extraction-shard0-replay-v1`: same relocation and symlink
+  policy. All 2,502 files verified; inventory:
+  `66de1b1714377cb1796523dd67199ab814b0f9676534aab8f5e127452b72d972`.
+- `synthetic-sift-bank-100k-v1`: archived as
+  `synthetic-sift-bank-100k-v1.tar.gz` at the destination (about 2.8 MiB).
+  All 200,000 file contents and exact membership were compared with the
+  archive before removing the original expanded synthetic fixture.
+
+The first two inventories hash sorted relative paths, a tab, the SHA-256 of
+each file, and a newline. Logs and evidence remain available. Source images,
+original feature banks and original reconstruction outputs were not removed.
+
+Root filesystem free space increased from about 308 MiB at operation start
+to 3.5 GiB. External disk free space is about 1.9 GiB. This is storage cleanup,
+not pipeline memory optimization. Future benchmarks must record the relocated
+input/output filesystem; do not compare new I/O timings as unchanged conditions.
+
+To restore the synthetic fixture, first verify sufficient free space and that
+the original directory is absent, then extract the archive under
+`/home/sasaki/datasets/openloris`. The archive contains its top-level directory.

--- a/docs/replay_storage_cleanup.md
+++ b/docs/replay_storage_cleanup.md
@@ -27,3 +27,45 @@ input/output filesystem; do not compare new I/O timings as unchanged conditions.
 To restore the synthetic fixture, first verify sufficient free space and that
 the original directory is absent, then extract the archive under
 `/home/sasaki/datasets/openloris`. The archive contains its top-level directory.
+
+## Broader cleanup, 2026-09-09
+
+Removed these explicitly inspected, regenerable caches:
+
+- `/home/sasaki/.cache/pip`: approximately 2.8 GiB of download cache.
+- `/home/sasaki/.npm/_cacache`: approximately 2.5 GiB of package cache.
+- `/tmp/visloc-rs-target-camerarig/release/deps`: approximately 332 MiB
+  of Cargo build dependencies; no Cargo/rustc process was observed running.
+
+These caches have no backup; they can be downloaded or built again. Installed
+packages, source code, saved example binaries, datasets and experiment results
+were retained. Root free space increased from 3.5 to 9.0 GiB (rounded `df -h`
+values); external free space remains 1.9 GiB. This does not measure RAM savings.
+
+Larger candidates require a separate retention decision: the approximately
+58 GiB EuRoC experiment directory `/home/sasaki/euroc_mh03_official_20260830`
+and other projects' evidence/output directories. They were inspected for size
+only and were not deleted. `/tmp` contains experiment evidence, not just caches,
+so it must not be cleared wholesale.
+
+### Authorized EuRoC duplicate cleanup
+
+After the user authorized cleanup of the EuRoC directory, removed 187
+`ranges/*.part` download fragments totaling 12,537,235,986 bytes (11.68 GiB).
+Before any removal, `scripts/cleanup_euroc_download_parts.py` verified the
+retained `machine_hall.zip` against its recorded SHA-256
+`5ed7d07903f8d19b6c8808e2ae8a0872b281f6e34ef5497023b8ac58c3de0f6f`
+and compared every fragment byte with its named inclusive byte range in that
+archive. The cleanup exited successfully. All `.part.headers`, download logs,
+archives, original images, rectified images, manifests and run results remain.
+Fragments can be reconstructed by reading the corresponding inclusive byte
+ranges from the retained archive; the header filenames retain the range names.
+
+The approximately 30 GiB `features_sp2048_cpu_2700` directory was retained:
+`docs/nonregression_20260830.md` identifies it as the authoritative frozen
+feature bank used for baseline/current comparison. Its exact contents should
+not be discarded merely because feature extraction can be run again.
+
+Four focused tests pass: audit-only preservation, verified removal, corrupt
+fragment rejection and corrupt archive rejection. The script defaults to
+audit-only and requires `--remove-verified-parts` for removal.

--- a/scripts/cleanup_euroc_download_parts.py
+++ b/scripts/cleanup_euroc_download_parts.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Verify EuRoC download parts against the retained archive before removal."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, required=True)
+    parser.add_argument('--remove-verified-parts', action='store_true')
+    args = parser.parse_args()
+    root = args.root.resolve(strict=True)
+    archive = root / 'machine_hall.zip'
+    expected = (root / 'machine_hall.zip.sha256').read_text().split()[0]
+    digest = hashlib.sha256()
+    with archive.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    if digest.hexdigest() != expected:
+        raise RuntimeError('Retained archive SHA-256 mismatch')
+    parts = []
+    with archive.open('rb') as stream:
+        for part in sorted((root / 'ranges').glob('*.part')):
+            match = re.fullmatch(r'(\d+)-(\d+)\.part', part.name)
+            if part.is_symlink() or not part.is_file() or not match:
+                raise RuntimeError(f'Unexpected part: {part}')
+            start, end = map(int, match.groups())
+            if end < start or part.stat().st_size != end - start + 1:
+                raise RuntimeError(f'Invalid range size: {part}')
+            stream.seek(start)
+            part_digest = hashlib.sha256()
+            with part.open('rb') as incoming:
+                for chunk in iter(lambda: incoming.read(1024 * 1024), b''):
+                    if stream.read(len(chunk)) != chunk:
+                        raise RuntimeError(f'Content mismatch: {part}')
+                    part_digest.update(chunk)
+            parts.append((part, part.stat(), part_digest.hexdigest()))
+    # Complete all validation before any deletion. Headers and logs are retained.
+    for part, original, _ in parts:
+        current = part.stat()
+        if (current.st_ino, current.st_size, current.st_mtime_ns) != (
+                original.st_ino, original.st_size, original.st_mtime_ns):
+            raise RuntimeError(f'Part changed during verification: {part}')
+    report = {
+        'archive': str(archive), 'archive_sha256': expected,
+        'part_count': len(parts), 'bytes': sum(s.st_size for _, s, _ in parts),
+        'action': 'remove' if args.remove_verified_parts else 'audit_only',
+        'parts': [{'name': p.name, 'bytes': s.st_size, 'sha256': h}
+                  for p, s, h in parts],
+    }
+    print(json.dumps(report), flush=True)
+    if args.remove_verified_parts:
+        for part, _, _ in parts:
+            part.unlink()
+        print('Removed verified duplicate parts; retained archive and headers.', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_cleanup_euroc_download_parts.py
+++ b/scripts/tests/test_cleanup_euroc_download_parts.py
@@ -1,0 +1,45 @@
+import hashlib
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'cleanup_euroc_download_parts.py'
+
+
+class CleanupPartsTest(unittest.TestCase):
+    def run_case(self, *, corrupt=False, remove=False, archive_corrupt=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'ranges').mkdir()
+            content = b'0123456789'
+            (root / 'machine_hall.zip').write_bytes(content)
+            digest = hashlib.sha256(content).hexdigest()
+            (root / 'machine_hall.zip.sha256').write_text(
+                ('0' * 64 if archive_corrupt else digest) + '  machine_hall.zip\n')
+            part = root / 'ranges' / '2-5.part'
+            part.write_bytes(b'xxxx' if corrupt else content[2:6])
+            header = root / 'ranges' / '2-5.part.headers'
+            header.write_text('retained')
+            command = [sys.executable, str(SCRIPT), '--root', str(root)]
+            if remove:
+                command.append('--remove-verified-parts')
+            result = subprocess.run(command, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode == 0, not (corrupt or archive_corrupt))
+            self.assertEqual(part.exists(), not (remove and not corrupt and not archive_corrupt))
+            self.assertTrue(header.exists())
+            self.assertEqual((root / 'machine_hall.zip').read_bytes(), content)
+
+    def test_audit_retains(self):
+        self.run_case()
+
+    def test_remove_verified(self):
+        self.run_case(remove=True)
+
+    def test_bad_part_retained(self):
+        self.run_case(corrupt=True, remove=True)
+
+    def test_bad_archive_retained(self):
+        self.run_case(archive_corrupt=True, remove=True)


### PR DESCRIPTION
Documents authorized relocation, verified synthetic fixture archiving, cache removal, and deletion of 187 duplicate EuRoC download fragments. The fragment cleanup script checks the retained archive SHA and every fragment byte before any deletion; source archives, images, features, headers and experiment logs remain. Includes 4 fail-closed tests. This is disk cleanup, not pipeline RSS optimization. No benchmark or quality claims.