### PR TITLE
bench: reproduce dense frontend and derive targeted frame selection

### DIFF
--- a/benchmarks/electro/m8-openloris-dense-candidates-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-dense-candidates-replay-v1.json
@@ -1,0 +1,24 @@
+{
+  "status": "complete-dense-candidate-byte-reproduction-pass",
+  "source_commit": "3ae253a0af909042fe0cfbdb08e8d50733b79375",
+  "binary_sha256": "8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34",
+  "recipe": "python3 scripts/replay_native_candidates.py --variant dense",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-candidates-replay-v1/report.json",
+  "features": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features",
+  "images": 10000,
+  "candidate_pairs": 80000,
+  "local_descriptors": 3476573,
+  "vocabulary_samples": 40426,
+  "retrieval_topk": 128,
+  "retrieval_min_frame_gap": 128,
+  "lsh": {"tables": 8, "bits": 9, "bits_mode": "auto-v1", "probes": 6, "mean_pool": 1127.8, "max_pool": 1521, "exact_fallback_queries": 0},
+  "exit_status": 0,
+  "wall_seconds": 507.2357037279289,
+  "peak_rss_kib": 399312,
+  "rayon_num_threads": 8,
+  "output_and_reference_sha256": "7474f94769e0de284b641335132a45485bb0eaab1922b926304206dacfdec91c",
+  "limitations": [
+    "Candidate stage from retained dense features; full extraction and continuous E2E remain open.",
+    "No COLMAP speedup or quality improvement claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-dense-frontend-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-dense-frontend-replay-v1.json
@@ -1,0 +1,40 @@
+{
+  "status": "complete-dense-matching-and-merge-byte-reproduction-pass",
+  "candidate_evidence": "m8-openloris-dense-candidates-replay-v1.json",
+  "matching": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-matching-replay-v1/report.json",
+    "binary_sha256": "8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34",
+    "source_commit": "3ae253a0af909042fe0cfbdb08e8d50733b79375",
+    "plan_sha256": "cb8005bd13fa6f490123efeaa0b36f0d3e0a0890309c641d34964e1cfc010d2a",
+    "feature_manifest_sha256": "9a58c1dd0699e72ed52149096cf17e85ee894ffaaf9d55772a1eb6b1c3d95ce2",
+    "candidate_format": "v2",
+    "regenerated_candidate_shards": 2500,
+    "byte_identical_reference_snapshots": 2500,
+    "snapshot_inventory_sha256": "76c94fbd27815583b7e5a02a8a840957272533e00004c8d2b42b2533809846ba",
+    "stream_match_features": true,
+    "min_matches": 30,
+    "rayon_num_threads": 4,
+    "malloc_arena_max": "1",
+    "exit_status": 0,
+    "wall_seconds": 557.3490417619469,
+    "peak_rss_kib": 451676
+  },
+  "merge": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-merge-replay-v1/report.json",
+    "binary_sha256": "f726c044973a21725296011bf08a49daed2b510813bce449e5f1c6fc8b95cd36",
+    "source_commit": "e136ae635c4f71d345242435d15b2be723cdab5c",
+    "build_command": "CARGO_INCREMENTAL=0 cargo build --locked --release --example merge_verified_pair_snapshots --jobs 2",
+    "implementation": "merge_files_atomic; sequential snapshot validation and streaming output",
+    "rayon_num_threads": 1,
+    "malloc_arena_max": "1",
+    "exit_status": 0,
+    "wall_seconds": 11.888814274105243,
+    "peak_rss_kib": 18188,
+    "output_and_reference_sha256": "02cd6475098453cb6cf93761ff990ea31acba86217b715dfaf43660f3af0f05c"
+  },
+  "limitations": [
+    "Retained dense feature bank is the extraction input boundary, not a fresh complete10k extraction.",
+    "Stages were timed separately. RSS values do not measure whole-pipeline peak or file-cache usage.",
+    "No COLMAP speedup, quality improvement, continuous E2E or 100k SfM claim."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-dense-supplement-reuse-audit-v1.json
+++ b/benchmarks/electro/m8-openloris-dense-supplement-reuse-audit-v1.json
@@ -1,0 +1,21 @@
+{
+  "status": "dense-supplement-content-and-adaptive-bank-recipe-equivalence-pass",
+  "selected_images": 692,
+  "compared_supplement_feature_bytes": 231393842,
+  "different_supplement_feature_files": [],
+  "supplement_reference": "/home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/supplement-features",
+  "equivalent_input": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense256x2-full10k-v2/features",
+  "verification": "Run merge_sift_supplements.py with the dense bank as --supplement and --resume against the complete published adaptive bank.",
+  "adaptive_files_verified": 10000,
+  "adaptive_files_reused": 10000,
+  "adaptive_files_written": 0,
+  "adaptive_inventory_sha256": "c8d22b395f172b9326837ea220e916617e2929856ea45d2c7e44ec5bda43e6f1",
+  "exit_status": 0,
+  "wall_seconds": 7.05,
+  "peak_rss_kib": 22976,
+  "implication": "A continuous recipe can compute the dense bank once and use its selected subset directly for adaptive-bank construction, without a separate 692-image extraction or copied supplement bank.",
+  "limitations": [
+    "Audits retained dense features and a completed adaptive output bank; not a new full extraction or full publication run.",
+    "This establishes input-content equivalence, not an observed E2E speedup or whole-pipeline memory reduction."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-targeted-selection-recovered-command-v1.json
+++ b/benchmarks/electro/m8-openloris-targeted-selection-recovered-command-v1.json
@@ -1,0 +1,19 @@
+{
+  "status": "historical-command-recovered",
+  "replay_evidence": "m8-openloris-targeted-selection-replay-v1.json",
+  "source": "Same-thread retained completed CommandExecution event, 2026-09-02T23:34:18.633Z; only task-specific command and resource fields transcribed.",
+  "command": "target/release/examples/generalized_rig_sfm --manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt --features-dir /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/adaptive-features --snapshot /home/sasaki/datasets/openloris/corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/mapping/verified-control-prefix-repair19.vps --out-colmap /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-deferred-repair19-pair-confidence-finalfix32-v1/model --max-models 10 --pair-confidence-tracks --final-ba-min-pose-observations 32 --deferred-registration-pair-prefix 59961",
+  "environment": {"RAYON_NUM_THREADS": "8", "MALLOC_ARENA_MAX": "1"},
+  "exit_status": 0,
+  "wall_seconds": 175.70,
+  "peak_rss_kib": 838828,
+  "registered_frames": 4993,
+  "registered_images": 9986,
+  "models": 2,
+  "unregistered_frames_from_retained_component_manifest": [1999, 3264, 3266, 3267, 4493, 4494, 4495],
+  "limitations": [
+    "Original executable SHA was not recorded in this event.",
+    "This recovers the mapper invocation, not a new execution or continuous E2E result.",
+    "The deferred directory name does not imply a dense-overlay input; the recovered command instead sets the registration pair prefix."
+  ]
+}

--- a/benchmarks/electro/m8-openloris-targeted-selection-replay-v1.json
+++ b/benchmarks/electro/m8-openloris-targeted-selection-replay-v1.json
@@ -1,0 +1,28 @@
+{
+  "status": "complete-target-selection-and-candidate-reproduction-pass",
+  "recipe": "python3 scripts/replay_targeted_selection.py",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted-selection-replay-v1/report.json",
+  "recovered_recipe": "m8-openloris-targeted-selection-recovered-command-v1.json",
+  "binary_sha256": "3d744ced8b2b09cbaba26bf963e9ac31c5293538b1a8bbbee62621ccfdd70c34",
+  "input_reproduced_snapshot_sha256": "ac93b28daf92b9bb4a621b9687087abbf906a1bc78cca0d8f4ea9688a1ba7a8d",
+  "deferred_registration_pair_prefix": 59961,
+  "rayon_num_threads": 8,
+  "malloc_arena_max": "1",
+  "exit_status": 0,
+  "wall_seconds": 160.02483767992817,
+  "peak_rss_kib": 976540,
+  "registered_frames": 4993,
+  "registered_images": 9986,
+  "target_frames": [1999, 3264, 3266, 3267, 4493, 4494, 4495],
+  "component_manifest_output_and_reference_sha256": "275c356833ba13d8061ea3624bddc82e75a7f974a0fd9bb78fe56c87b0167169",
+  "derived_candidate_output": "/home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-derived-candidates-replay-v1/candidates.txt",
+  "derived_candidate_output_and_reference_sha256": "14ac996b591a3d98c9be97d5c3c0aa47b04c93c48c551b2556353729c6895a4f",
+  "all_model_files_identical": false,
+  "different_model_files": ["component-000/images.txt", "component-000/points3D.txt", "components.tsv"],
+  "limitations": [
+    "The downstream selector consumes registration membership, not this intermediate model's poses or points.",
+    "Registration manifest and derived candidates are byte-identical; the intermediate mapper's full model is not.",
+    "Reuses previously reproduced repair admission and adaptive bank; separate stages are not a continuous E2E measurement.",
+    "No GT is read by the mapper or target selector. No final quality improvement claim."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -2,25 +2,35 @@
 
 ## 現在の状態（以下の過去ログより優先）
 
-最新（2026-09-09）: PR118は`0b7f999`へmerge済み。PR119はhead
-`dd9c94c46723ef290fd524a0426cc27e919fef26`のCI9成功を確認し、
-`7568377c1aa46c208996b924f44c358cc7b65021`へsquash merge、旧branch整理済み。
-現作業branchは`diag/m8-adaptive-frontend-replay`。サブエージェントは使わない。
+最新（2026-09-09）: PR118/119に続きPR120（head`e136ae6`、CI9成功）は
+`09e79b8dae067521ee8b8be342c1373c68e090c8`へmerge、旧branch整理済み。
+整理記録のPR121（head`8b05461`、CI9成功）は
+`fdf94400e98f80b2cb81c45c86b0441a7977d6e9`へmerge、旧branch整理済み。
+現作業branchは`diag/m8-dense-frontend-replay`。サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
   70,000候補・2,188 matching shards・merged snapshotが全bytes一致。
   score順fillへの仕様変更を確認した。旧版への本番ロールバックではない。
 - adaptiveはnativeと同じ候補計画。再生成済みバンクからmatching/mergeを実行し、
   61,286ペアのmerged snapshotが全bytes一致。元の個別shardがないため比較は統合境界。
-- targeted7は指定7 frame/±256から14,319候補を生成し全bytes一致。
-  matching448 shard・265ペアの統合snapshotも一致。7 frame選定の前段mappingは未再現。
+- targeted7のmatching448 shard・統合snapshotは全bytes一致。
+  前段の記録コマンドを同thread実行ログから回収し、repair19 snapshot +
+  `--deferred-registration-pair-prefix 59961`で再実行。登録manifestと導出した7 frame、
+  そこからの14,319候補は全bytes一致。中間modelのmain images/pointsとcomponents.tsvは
+  異なるため、全model再現とはしない（後段は登録一覧のみ使用）。
+- denseも80,000候補・v2分割2,500・matching全shard・統合snapshotが全bytes一致。
+  現行streaming mergeはpeak18,188KiB（統合単体）。full extraction/E2Eではない。
+- 692画像の追加特徴はdenseバンクの同名特徴と全bytes一致。denseを直接supplement入力に
+  してadaptive10kバンク全hash一致を確認（resume検証、書込0）。連続実行では重複抽出を省ける。
+  base側はSIFT256/1 orientation/contrast0.02で別レシピ。base/D両方の全10k新規抽出は未完了。
 - 新規証跡と具体的コマンドは`docs/openloris_frontend_reproduction.md`。
   adaptive/targetedでは退避済みの再生成バンク（外部ext4）を使用。過去と同一I/Oではない。
-- 許可済み整理で空き約21 GiBを確保し、新規replay後は約18 GiB。
-  整理ログと検証付き重複削除scriptはlocal branch `chore/replay-storage-cleanup`
-  （`8b05461`、未PR）に保存。元データ・検証ログは保持。
-- 次: この変更のPR/CI/merge、target選定前段とdense overlayの再現、全10k抽出・
+- 許可済み整理で空き約21 GiBを確保し、新規replay後は約15 GiB。
+  整理ログと検証付き重複削除scriptはPR121経由でmainへ。元データ・検証ログは保持。
+- 次: この変更のPR/CI/merge、base抽出の小規模一致probeと全10k抽出・
   continuous E2E・未達のCOLMAP軌跡品質改善。phase時間の和をE2Eとしない。
+  100k前に共有metadataを含むartifact増加率を監査する。vocabなし時のstreamed候補生成には
+  現状all_pairs(N) fallbackがあり、N²メモリ危険分岐はまだ閉じていない。
   全goalは未達。READMEに未検証の高速化/品質改善を追加しない。
 
 ### 以前の状態（上記を優先）

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -7,8 +7,9 @@ COLMAP trajectory-quality gate.
 The native base branch has now also been regenerated from retained base features:
 candidate manifest, all matching shards and the merged snapshot are byte-identical
 to their references. Adaptive matching/merge and targeted7 candidate/matching/merge
-have also been reproduced. Target selection and dense-overlay reproduction remain
-open; this is not full input-image-to-model execution.
+have also been reproduced. Dense candidate/matching/merge and the registration
+manifest consumed by target selection are now reproduced too. This is still not
+full input-image-to-model execution or a continuous E2E measurement.
 
 ```text
 base features → native-rig-runner verified snapshot ─────┐
@@ -20,7 +21,8 @@ base + supplemental features → adaptive matching ───────┤
                                                        ↓ registration list
 adaptive matching + prefix snapshot ─────────→ repair admission
                                                        ↓
-targeted7 matching ──────────────────────────→ novel-pair admission
+repair admission → deferred registration → missing-frame targets
+missing-frame targets → targeted7 candidates → matching → novel-pair admission
                                                        ↓
                                              atlas source mapping
 ```
@@ -46,9 +48,8 @@ Likewise, the `long128` directory's `verified-goodbase-repair19.vps` is byte-ide
 to the adaptive control-prefix repair snapshot. Its directory name alone does
 not require long128 matching in this chain.
 
-Next, recover the preceding registration/selection recipe for targeted7 and
-reproduce the separate dense deferred overlay. Preserve their exact feature
-indices and pair order. Freeze the complete executable recipe, run it as one
+Next, reproduce both full feature extractions and assemble the complete executable
+recipe. Preserve exact feature indices and pair order, run it as one
 process tree with wall/RSS accounting, and evaluate the unchanged COLMAP gates.
 The earlier 1,250-image extraction and synthetic bank-only 100k tests do not
 close full10k extraction, whole-pipeline restart or full SfM100k I/O gates.
@@ -159,11 +160,71 @@ then the merge command with `--variant targeted7`. All 14,319 candidate pairs,
 448 match shards and the complete 265-pair merged snapshot match the references.
 See `m8-openloris-targeted7-frontend-replay-v1.json`.
 
-The seven target IDs remain frozen inputs. Three retained deferred-repair19
-models have exactly this unregistered frame set, but this alone does not identify
-or reproduce the historical selector. Do not omit its preceding mapping cost.
+The initial targeted replay used frozen target IDs. Its preceding mapping command
+was subsequently recovered from a completed same-thread execution event dated
+2026-09-02T23:34:18.633Z. It uses the repair19 snapshot and
+`--deferred-registration-pair-prefix 59961`, not a dense-overlay input. See
+`m8-openloris-targeted-selection-recovered-command-v1.json`.
+
+```sh
+python3 scripts/replay_targeted_selection.py
+python3 scripts/build_targeted_rig_candidates.py \
+  --rig-manifest /home/sasaki/datasets/openloris/corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt \
+  --selection-json /home/sasaki/datasets/openloris/corridor1-1-m8-targeted-selection-replay-v1/selection.json \
+  --max-frame-gap 256 \
+  --output-directory /home/sasaki/datasets/openloris/corridor1-1-m8-targeted7-derived-candidates-replay-v1
+```
+
+The new mapper run exited zero in 160.02 s with peak RSS 976,540 KiB. Its full
+registration manifest is byte-identical, and the seven unregistered frames are
+derived without GT. The resulting candidate file is also byte-identical. Three
+other intermediate model files differ (main images, main points, components.tsv);
+this is **selection-boundary reproduction, not whole-model byte reproduction**.
+The downstream selector consumes only registration membership, not these poses
+or points. Do not omit the required mapping cost. Evidence:
+`m8-openloris-targeted-selection-replay-v1.json`.
+
+## Dense overlay frontend
+
+```sh
+python3 scripts/replay_native_candidates.py --variant dense
+python3 scripts/replay_native_matching.py --variant dense \
+  --candidate-root /home/sasaki/datasets/openloris/corridor1-1-m8-dense-candidates-replay-v1
+python3 scripts/replay_native_merge.py --variant dense \
+  --binary /home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/merge-e136ae6 \
+  --binary-sha256 f726c044973a21725296011bf08a49daed2b510813bce449e5f1c6fc8b95cd36
+```
+
+The dense branch uses score-descending fill, topK128, minimum frame gap128,
+budget80,000, and LSH8/auto9/6. Its candidate manifest is byte-identical.
+All 2,500 v2 candidate shards were regenerated and hash-verified. The recorded
+streaming matcher recipe (min30) produced byte-identical snapshots, and the
+current `merge_files_atomic` implementation produced a byte-identical final
+snapshot with peak RSS18,188 KiB. This last number is merge-only, not pipeline
+RSS. See `m8-openloris-dense-candidates-replay-v1.json` and
+`m8-openloris-dense-frontend-replay-v1.json`.
+
+## Avoid duplicate supplemental extraction
+
+Every one of the 692 selected supplemental feature files is byte-identical to
+the corresponding file in the dense bank (231,393,842 bytes compared). Passing
+the dense directory directly as `merge_sift_supplements.py --supplement` and
+validating against the completed adaptive bank reproduced all 10,000 expected
+file hashes; zero files were written. Thus a continuous recipe can compute the
+dense bank once and use its selected subset for adaptive construction. Evidence:
+`m8-openloris-dense-supplement-reuse-audit-v1.json`. This is content/recipe
+equivalence, not a measured E2E speedup or whole-pipeline memory reduction.
+
+The base bank is a different extraction recipe (SIFT256, one orientation,
+contrast0.02, no compatible-detector flags), so it cannot be replaced by the
+dense bank. Both full extractions still need fresh input-image execution.
 
 All timings cover their respective subprocess, not preparation or validation.
 Do not sum them into a continuous E2E claim. External-bank I/O is not unchanged
-from historical runs. Full extraction, target selection, the dense-overlay branch,
-continuous E2E and the COLMAP quality gate remain open.
+from historical runs. Full extraction, continuous E2E and the COLMAP quality gate
+remain open. Legacy v1 diagnostic shard reproduction is not proof of N²-free
+artifact growth: audit shared-envelope storage in the final runner before 100k
+claims. Also, the current streamed candidate path still falls back to
+`all_pairs(image_names.len())` when vocabulary construction returns no globals;
+the nonempty-vocabulary replays do not exercise or close that degenerate-input
+memory hazard.

--- a/scripts/build_targeted_rig_candidates.py
+++ b/scripts/build_targeted_rig_candidates.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Build bounded target-frame candidate windows; target selection is an input."""
 import argparse
+import json
 from bisect import bisect_left, bisect_right
 from pathlib import Path
 
@@ -9,6 +10,8 @@ from select_rig_sift_supplements import parse_frames
 
 
 def targeted_pairs(frames, targets, gap):
+    if any(type(target) is not int for target in targets):
+        raise ValueError('Target frame IDs must be integers')
     if gap < 0 or not targets or len(set(targets)) != len(targets):
         raise ValueError('Require nonnegative gap and unique nonempty targets')
     if any(target not in frames for target in targets):
@@ -33,11 +36,16 @@ def targeted_pairs(frames, targets, gap):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--rig-manifest', type=Path, required=True)
-    parser.add_argument('--target-frames', required=True)
+    target_input = parser.add_mutually_exclusive_group(required=True)
+    target_input.add_argument('--target-frames')
+    target_input.add_argument('--selection-json', type=Path)
     parser.add_argument('--max-frame-gap', type=int, required=True)
     parser.add_argument('--output-directory', type=Path, required=True)
     args = parser.parse_args()
-    targets = [int(value) for value in args.target_frames.split(',')]
+    targets = (json.loads(args.selection_json.read_text())['target_frames'] if args.selection_json
+               else [int(value) for value in args.target_frames.split(',')])
+    if not isinstance(targets, list):
+        parser.error('selection target_frames must be a list')
     frames = parse_frames(args.rig_manifest.read_bytes())
     names, pairs = targeted_pairs(frames, targets, args.max_frame_gap)
     args.output_directory.mkdir()  # Never replace an existing experiment.

--- a/scripts/replay_native_candidates.py
+++ b/scripts/replay_native_candidates.py
@@ -21,14 +21,18 @@ def sha(path):
 def main():
     base = Path('/home/sasaki/datasets/openloris')
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--variant', choices=['native', 'dense'], default='native')
     parser.add_argument('--binary', type=Path, default=base / 'corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a')
     parser.add_argument('--binary-sha256', default='8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34')
-    parser.add_argument('--output-name', default='corridor1-1-m8-native-candidates-replay-v1')
+    parser.add_argument('--output-name')
     parser.add_argument('--source-commit', default='3ae253a0af909042fe0cfbdb08e8d50733b79375')
     args = parser.parse_args()
-    if not args.output_name.startswith('corridor1-1-m8-native-candidates-') or Path(args.output_name).name != args.output_name:
-        parser.error('--output-name must be a simple native-candidate replay directory name')
-    reference = base / 'corridor1-1-m8-native-rig-runner-10k-v1'
+    if args.output_name is None:
+        args.output_name = f'corridor1-1-m8-{args.variant}-candidates-replay-v1'
+    if not args.output_name.startswith(f'corridor1-1-m8-{args.variant}-candidates-') or Path(args.output_name).name != args.output_name:
+        parser.error('--output-name must be a simple variant-specific candidate replay directory name')
+    reference = (base / 'corridor1-1-m8-native-rig-runner-10k-v1' if args.variant == 'native'
+                 else base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1')
     output = base / args.output_name
     binary = args.binary.resolve(strict=True)
     expected_binary = args.binary_sha256
@@ -47,11 +51,12 @@ def main():
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
                   'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
     report = {'command': invocation, 'binary_sha256': expected_binary,
+              'variant': args.variant,
               'source_commit': args.source_commit,
               'reference_recipe_sha256': sha(timing),
               'reference_sha256': sha(reference / 'candidates.txt'),
               'rayon_num_threads': 8, 'status': 'running',
-              'scope': 'candidate generation only; retained base features'}
+              'scope': 'candidate generation only; retained feature bank'}
     (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
     started = time.monotonic()
     with (output / 'run.log').open('w') as log:

--- a/scripts/replay_native_matching.py
+++ b/scripts/replay_native_matching.py
@@ -11,9 +11,11 @@ import subprocess
 import time
 
 from benchmark_electro import (
+    candidate_image_manifest_sha256,
     parse_candidate_manifest_with_metadata,
     validate_feature_manifest,
     write_candidate_manifest,
+    write_candidate_shard_v2,
 )
 from replay_native_candidates import sha
 
@@ -35,7 +37,7 @@ def same_candidate_schedule(native_plan, adaptive_plan):
 def main():
     base = Path('/home/sasaki/datasets/openloris')
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7'], default='native')
+    parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7', 'dense'], default='native')
     parser.add_argument('--candidate-root', type=Path,
                         default=base / 'corridor1-1-m8-native-candidates-replay-v1')
     parser.add_argument('--binary', type=Path,
@@ -48,6 +50,8 @@ def main():
                  base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline')
     if args.variant == 'targeted7':
         reference = base / 'corridor1-1-m8-targeted7-dense256-v1'
+    elif args.variant == 'dense':
+        reference = base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1'
     candidate_root = args.candidate_root.resolve(strict=True)
     output = base / f'corridor1-1-m8-{args.variant}-matching-replay-v1'
     binary = args.binary.resolve(strict=True)
@@ -57,11 +61,13 @@ def main():
     if not candidate_ok or sha(binary) != expected_binary:
         raise RuntimeError('Candidate replay or frozen binary prerequisite failed')
     candidates = candidate_root / 'candidates.txt'
-    candidate_reference = reference if args.variant == 'targeted7' else native_reference
+    candidate_reference = reference if args.variant in ('targeted7', 'dense') else native_reference
     if sha(candidates) != sha(candidate_reference / 'candidates.txt'):
         raise RuntimeError('Candidate contents changed')
     names, pairs, metadata = parse_candidate_manifest_with_metadata(candidates)
     expected_pairs = 14319 if args.variant == 'targeted7' else 70000
+    if args.variant == 'dense':
+        expected_pairs = 80000
     if len(names) != 10000 or len(pairs) != expected_pairs:
         raise RuntimeError('Unexpected candidate envelope')
     output.mkdir()
@@ -69,23 +75,35 @@ def main():
     (output / 'matches').mkdir()
     # Use the recorded plan as a frozen schedule, not retained match outputs.
     plan = (reference / 'match-worker.plan').read_text()
-    if args.variant != 'targeted7' and not same_candidate_schedule((native_reference / 'match-worker.plan').read_text(), plan):
+    if args.variant in ('native', 'adaptive') and not same_candidate_schedule((native_reference / 'match-worker.plan').read_text(), plan):
         raise RuntimeError('Adaptive schedule differs from reproduced native candidates')
     shard_rows = [line.split() for line in plan.splitlines() if line.startswith('shard ')]
     if len(shard_rows) != (expected_pairs + 31) // 32:
         raise RuntimeError('Unexpected shard count')
+    source_hash = sha(candidates)
+    image_hash = candidate_image_manifest_sha256(names)
+    is_v2 = plan.splitlines()[0] == 'visloc_match_worker_plan_v2'
+    if is_v2 and (f'candidate_source_sha256 {source_hash}' not in plan.splitlines()
+                  or f'image_manifest_sha256 {image_hash}' not in plan.splitlines()):
+        raise RuntimeError('V2 plan source/image binding differs')
     for index, fields in enumerate(shard_rows):
         expected_candidate = f'candidates/candidate-{index:06d}.txt'
         expected_snapshot = f'matches/verified-{index:06d}.vps'
         if len(fields) != 5 or fields[1:4] != [str(index), expected_candidate, expected_snapshot]:
             raise RuntimeError('Unexpected shard order or unsafe paths')
         destination = output / expected_candidate
-        write_candidate_manifest(destination, names, pairs[index * 32:(index + 1) * 32],
-                                 metadata=metadata)
+        shard_pairs = pairs[index * 32:(index + 1) * 32]
+        if is_v2:
+            write_candidate_shard_v2(destination, len(names), source_hash, image_hash,
+                                     shard_pairs, metadata=metadata)
+        else:
+            write_candidate_manifest(destination, names, shard_pairs, metadata=metadata)
         if sha(destination) != fields[4]:
             raise RuntimeError(f'Regenerated shard differs: {index}')
     features = (base / 'corridor1-1-m5/tiers/tier-10000/features256' if args.variant == 'native'
                 else base / 'corridor1-1-m8-adaptive-bank-publication-v1/features')
+    if args.variant == 'dense':
+        features = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
     validate_feature_manifest(reference / 'features.json', features)
     if f'feature_manifest_sha256 {sha(reference / "features.json")}' not in plan.splitlines():
         raise RuntimeError('Plan does not bind the validated feature manifest')
@@ -94,6 +112,8 @@ def main():
     first_line = timing.read_text().splitlines()[0]
     command = shlex.split(shlex.split(first_line.split('Command being timed: ', 1)[1])[0])
     command[0] = str(binary)
+    if args.variant == 'dense' and '--stream-match-features' not in command:
+        raise RuntimeError('Dense replay requires the recorded streaming matcher recipe')
     for flag, path in [('--persistent-match-worker-plan', output / 'match-worker.plan'),
                        ('--features-dir', features),
                        ('--out-colmap', output / 'matches/unused-model-persistent')]:
@@ -101,6 +121,7 @@ def main():
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
                   'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
     report = {'status': 'running', 'command': invocation, 'rayon_num_threads': 4,
+              'malloc_arena_max': '1', 'candidate_shard_format': 'v2' if is_v2 else 'v1',
               'variant': args.variant, 'features_resolved': str(features.resolve()),
               'binary_sha256': expected_binary, 'candidate_sha256': sha(candidates),
               'plan_sha256': sha(output / 'match-worker.plan'),
@@ -110,7 +131,7 @@ def main():
     (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
     started = time.monotonic()
     with (output / 'run.log').open('w') as log:
-        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='4'),
+        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='4', MALLOC_ARENA_MAX='1'),
                                 stdout=log, stderr=subprocess.STDOUT)
     report.update(exit_code=result.returncode, wall_seconds=time.monotonic() - started)
     differences = []

--- a/scripts/replay_native_merge.py
+++ b/scripts/replay_native_merge.py
@@ -14,7 +14,7 @@ from replay_native_matching import snapshot_inventory
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7'], default='native')
+    parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7', 'dense'], default='native')
     parser.add_argument('--binary', type=Path, required=True)
     parser.add_argument('--binary-sha256', required=True)
     args = parser.parse_args()
@@ -23,6 +23,8 @@ def main():
                  else base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline')
     if args.variant == 'targeted7':
         reference = base / 'corridor1-1-m8-targeted7-dense256-v1'
+    elif args.variant == 'dense':
+        reference = base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1'
     matching = base / f'corridor1-1-m8-{args.variant}-matching-replay-v1'
     report_path = matching / 'report.json'
     report = json.loads(report_path.read_text())
@@ -30,6 +32,8 @@ def main():
     if report['status'] != accepted_status or report['exit_code'] != 0 or sha(args.binary) != args.binary_sha256:
         raise RuntimeError('Matching replay or merge binary prerequisite failed')
     expected_count = 448 if args.variant == 'targeted7' else 2188
+    if args.variant == 'dense':
+        expected_count = 2500
     expected_names = {f'verified-{index:06d}.vps' for index in range(expected_count)}
     actual_names = {path.name for path in (matching / 'matches').glob('*.vps')}
     if actual_names != expected_names:
@@ -50,13 +54,14 @@ def main():
                   'timeout', '--signal=TERM', '--kill-after=10s', '600s', *command]
     started = time.monotonic()
     with (output / 'run.log').open('w') as log:
-        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='1'),
+        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='1', MALLOC_ARENA_MAX='1'),
                                 stdout=log, stderr=subprocess.STDOUT)
     elapsed = time.monotonic() - started
     expected = sha(reference / 'mapping/verified-merged.vps')
     actual = sha(destination) if destination.exists() else None
     report = {'status': 'pass' if result.returncode == 0 and actual == expected else 'fail',
               'variant': args.variant,
+              'malloc_arena_max': '1',
               'exit_code': result.returncode, 'wall_seconds': elapsed,
               'binary': str(args.binary.resolve()), 'binary_sha256': args.binary_sha256,
               'matching_report_sha256': sha(report_path), 'snapshot_count': len(snapshots),

--- a/scripts/replay_targeted_selection.py
+++ b/scripts/replay_targeted_selection.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Replay the recovered repair-prefix mapper and derive unregistered targets."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+from benchmark_electro import parse_gnu_time, validate_feature_manifest
+from replay_native_candidates import sha
+from select_rig_sift_supplements import parse_frames
+
+
+def unregistered_frames(frames, components):
+    known = {name for members in frames.values() for name in members}
+    registered = set()
+    if '# retrieval-component-manifest-v1' not in components.splitlines():
+        raise ValueError('Missing component manifest schema')
+    for line in components.splitlines():
+        fields = line.split()
+        if not fields or fields[0].startswith('#'):
+            continue
+        if len(fields) != 3 or fields[0] != 'C' or int(fields[1]) < 0:
+            raise ValueError('Malformed component row')
+        name = fields[2]
+        if name not in known or name in registered:
+            raise ValueError('Unknown or repeated registered image')
+        registered.add(name)
+    missing = []
+    for frame, members in sorted(frames.items()):
+        count = sum(name in registered for name in members)
+        if count not in (0, len(members)):
+            raise ValueError('Partially registered rig frame is ambiguous')
+        if count == 0:
+            missing.append(frame)
+    return missing
+
+
+def main():
+    base = Path('/home/sasaki/datasets/openloris')
+    rig = base / 'corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt'
+    features = base / 'corridor1-1-m8-adaptive-bank-publication-v1/features'
+    snapshot = base / 'corridor1-1-m8-repair19-admission-replay-v1/output.vps'
+    binary = base / 'corridor1-1-m8-retry-reuse-1k-v1/rig-0466499'
+    if sha(binary) != '3d744ced8b2b09cbaba26bf963e9ac31c5293538b1a8bbbee62621ccfdd70c34':
+        raise RuntimeError('Saved mapper binary changed')
+    if sha(snapshot) != 'ac93b28daf92b9bb4a621b9687087abbf906a1bc78cca0d8f4ea9688a1ba7a8d':
+        raise RuntimeError('Reproduced repair19 snapshot changed')
+    validate_feature_manifest(base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/features.json', features)
+    frames = parse_frames(rig.read_bytes())
+    reference = base / 'corridor1-1-m8-visloc-rig/tier-10000-deferred-repair19-pair-confidence-finalfix32-v1/model'
+    output = base / 'corridor1-1-m8-targeted-selection-replay-v1'
+    output.mkdir()
+    command = [str(binary), '--manifest', str(rig), '--features-dir', str(features),
+               '--snapshot', str(snapshot), '--out-colmap', str(output / 'model'),
+               '--max-models', '10', '--pair-confidence-tracks',
+               '--final-ba-min-pose-observations', '32',
+               '--deferred-registration-pair-prefix', '59961']
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '600s', *command]
+    report = {'status': 'running', 'command': invocation,
+              'binary_sha256': sha(binary), 'snapshot_sha256': sha(snapshot),
+              'rig_manifest_sha256': sha(rig), 'features_resolved': str(features.resolve()),
+              'rayon_num_threads': 8, 'malloc_arena_max': '1',
+              'recovered_command_event_utc': '2026-09-02T23:34:18.633Z'}
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    started = time.monotonic()
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, env=dict(os.environ, RAYON_NUM_THREADS='8', MALLOC_ARENA_MAX='1'),
+                                stdout=log, stderr=subprocess.STDOUT)
+    report.update(exit_code=result.returncode, wall_seconds=time.monotonic() - started,
+                  measurement=parse_gnu_time(output / 'time.txt'))
+    report['status'] = 'fail'
+    if result.returncode == 0:
+        model = output / 'model'
+        targets = unregistered_frames(frames, (model / 'retrieval-components.txt').read_text())
+        report['target_frames'] = targets
+        report['target_frames_match'] = targets == [1999, 3264, 3266, 3267, 4493, 4494, 4495]
+        actual = {p.relative_to(model).as_posix(): sha(p) for p in model.rglob('*') if p.is_file()}
+        expected = {p.relative_to(reference).as_posix(): sha(p) for p in reference.rglob('*') if p.is_file()}
+        report['all_model_files_identical'] = actual == expected
+        report['different_model_files'] = sorted(name for name in actual.keys() | expected.keys()
+                                                 if actual.get(name) != expected.get(name))
+        if report['target_frames_match']:
+            report['status'] = 'complete-selection-reproduction-pass'
+            (output / 'selection.json').write_text(json.dumps({'target_frames': targets}, indent=2) + '\n')
+    (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2), flush=True)
+    return 0 if report['status'] == 'complete-selection-reproduction-pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/tests/test_targeted_rig_candidates.py
+++ b/scripts/tests/test_targeted_rig_candidates.py
@@ -21,6 +21,6 @@ class TargetedPairsTest(unittest.TestCase):
         self.assertEqual(pairs, [(1, 2)])
 
     def test_invalid_targets(self):
-        for targets, gap in [([], 1), ([0, 0], 1), ([2], 1), ([0], -1)]:
+        for targets, gap in [([], 1), ([0, 0], 1), ([2], 1), ([0], -1), ([True], 1), (['0'], 1)]:
             with self.assertRaises(ValueError):
                 targeted_pairs({0: ['a', 'b']}, targets, gap)

--- a/scripts/tests/test_targeted_selection.py
+++ b/scripts/tests/test_targeted_selection.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from replay_targeted_selection import unregistered_frames
+
+
+class TargetSelectionTest(unittest.TestCase):
+    frames = {4: ['a', 'b'], 9: ['c', 'd']}
+    header = '# retrieval-component-manifest-v1\n'
+
+    def test_missing_frame_derived(self):
+        self.assertEqual(unregistered_frames(self.frames, self.header + 'C 0 a\nC 0 b\n'), [9])
+
+    def test_partial_frame_rejected(self):
+        with self.assertRaises(ValueError):
+            unregistered_frames(self.frames, self.header + 'C 0 a\n')
+
+    def test_unknown_or_duplicate_image_rejected(self):
+        for rows in ['C 0 other\n', 'C 0 a\nC 0 a\n']:
+            with self.assertRaises(ValueError):
+                unregistered_frames(self.frames, self.header + rows)
+
+    def test_schema_required(self):
+        with self.assertRaises(ValueError):
+            unregistered_frames(self.frames, 'C 0 a\nC 0 b\n')
+
+    def test_no_registration_returns_all_frames(self):
+        self.assertEqual(unregistered_frames(self.frames, self.header), [4, 9])


### PR DESCRIPTION
Reproduces dense 80k candidates, all 2500 v2 matching shards and the merged snapshot. Current streaming merge peaks at 18188 KiB (merge only). Recovers the historical repair-prefix mapping command and derives the same seven targets and candidate file from new registration output; explicitly records nonidentical intermediate model files. Proves dense features can supply all 692 adaptive supplements and regenerate the same complete adaptive bank. Adds selection validation and input plumbing; 40 script tests pass after rebasing onto main. Full extraction, continuous E2E, final quality, shared-envelope artifact scaling and no-vocabulary quadratic fallback remain open. No COLMAP speedup or whole-pipeline memory claim.