### PR TITLE
fix: reject empty streamed vocabulary before exhaustive pairing

### DIFF
--- a/benchmarks/electro/m8-empty-streamed-candidates-100k-v1.json
+++ b/benchmarks/electro/m8-empty-streamed-candidates-100k-v1.json
@@ -1,0 +1,27 @@
+{
+  "status": "empty-vocabulary-cli-rejection-pass",
+  "binary": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-frontend-binaries-v1/streamed-candidate-guard-v2",
+  "binary_sha256": "4d8e5aa5385efe39af8c45f8dfc4a6b5e08854bef7d05ab8b6aa720bb36ce2b4",
+  "build_recipe": "CARGO_INCREMENTAL=0 cargo build --locked --release --example unordered_sfm_demo --jobs 2",
+  "stress_recipe": "python3 scripts/stress_empty_streamed_candidates.py --binary SAVED_BINARY --root NEW_FIXTURE_ROOT --images 100000",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-empty-streamed-candidates-100k-v2/report.json",
+  "images": 100000,
+  "feature_files": 100000,
+  "local_descriptors": 0,
+  "candidate_budget": 700000,
+  "address_space_limit_bytes": 2147483648,
+  "core_dumps_disabled": true,
+  "expected_exit_status": 1,
+  "actual_exit_status": 1,
+  "required_diagnostic": "refusing exhaustive fallback",
+  "candidate_manifest_exists": false,
+  "wall_seconds": 1.0025213829940185,
+  "peak_rss_kib": 102892,
+  "rayon_num_threads": 8,
+  "malloc_arena_max": "1",
+  "limits": [
+    "Measures only the empty-feature candidate CLI subprocess, not fixture generation or full100k SfM.",
+    "An address-space cap is a safety backstop; passing requires the explicit vocabulary diagnostic and ordinary exit1, not timeout, allocation failure or signal termination.",
+    "Shared-envelope artifact scaling and full native E2E remain separate requirements."
+  ]
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -6,7 +6,9 @@
 `09e79b8dae067521ee8b8be342c1373c68e090c8`へmerge、旧branch整理済み。
 整理記録のPR121（head`8b05461`、CI9成功）は
 `fdf94400e98f80b2cb81c45c86b0441a7977d6e9`へmerge、旧branch整理済み。
-現作業branchは`diag/m8-dense-frontend-replay`。サブエージェントは使わない。
+PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
+へmerge、旧branch整理済み。現作業branchは`fix/streamed-retrieval-empty-vocabulary`。
+サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
   70,000候補・2,188 matching shards・merged snapshotが全bytes一致。
@@ -29,8 +31,10 @@
   整理ログと検証付き重複削除scriptはPR121経由でmainへ。元データ・検証ログは保持。
 - 次: この変更のPR/CI/merge、base抽出の小規模一致probeと全10k抽出・
   continuous E2E・未達のCOLMAP軌跡品質改善。phase時間の和をE2Eとしない。
-  100k前に共有metadataを含むartifact増加率を監査する。vocabなし時のstreamed候補生成には
-  現状all_pairs(N) fallbackがあり、N²メモリ危険分岐はまだ閉じていない。
+  100k前に共有metadataを含むartifact増加率を監査する。vocabなし時のstreamed候補生成の
+  all_pairs(N) fallbackを削除し、明示エラーで停止するよう変更。100k空特徴の実CLIは
+  2GiB仮想メモリ制限下でexit1・期待診断・出力なし、1.00s/102,892KiB。
+  通常の100k SfM/共有metadataの容量保証ではない。64 example tests通過。
   全goalは未達。READMEに未検証の高速化/品質改善を追加しない。
 
 ### 以前の状態（上記を優先）

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -224,7 +224,21 @@ Do not sum them into a continuous E2E claim. External-bank I/O is not unchanged
 from historical runs. Full extraction, continuous E2E and the COLMAP quality gate
 remain open. Legacy v1 diagnostic shard reproduction is not proof of N²-free
 artifact growth: audit shared-envelope storage in the final runner before 100k
-claims. Also, the current streamed candidate path still falls back to
-`all_pairs(image_names.len())` when vocabulary construction returns no globals;
-the nonempty-vocabulary replays do not exercise or close that degenerate-input
-memory hazard.
+claims.
+
+## Empty vocabulary safety
+
+Streamed candidate export now rejects a missing/empty appearance vocabulary
+before candidate construction. It no longer calls `all_pairs(N)` in that case:
+the candidate budget would only have been applied after the quadratic allocation.
+The error explicitly says `refusing exhaustive fallback`; no candidate manifest
+is published. Nonempty descriptor data keeps the same retrieval functions and
+borrowed global descriptors, with the batch/streamed equality test preserved.
+
+`scripts/stress_empty_streamed_candidates.py` exercised the real CLI with 100,000
+empty feature files and calibrated image entries under a 2 GiB address-space cap
+and a timeout. It rejected normally (exit 1 and the required diagnostic), emitted
+no candidate manifest, took 1.00 s and peaked at 102,892 KiB RSS. Evidence:
+`m8-empty-streamed-candidates-100k-v1.json`. This is an invalid-input safety gate,
+not a 100k reconstruction, nonempty 100k retrieval benchmark, whole-pipeline
+memory bound or quality result.

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -9865,6 +9865,15 @@ struct StreamedVladGlobals {
     sampled_descriptors: usize,
 }
 
+impl StreamedVladGlobals {
+    fn appearance_globals(&self) -> Result<&[Vec<f32>], &'static str> {
+        self.globals
+            .as_deref()
+            .filter(|globals| !globals.is_empty())
+            .ok_or("streamed candidate export requires a nonempty appearance vocabulary; refusing exhaustive fallback")
+    }
+}
+
 fn count_feature_rows(path: &Path) -> Result<usize, Box<dyn std::error::Error>> {
     Ok(std::fs::read_to_string(path)?
         .lines()
@@ -16294,34 +16303,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             args.vocab_size,
         )?;
         log_process_memory("example-after-streamed-vlad-globals");
-        let retrieval = if let Some(globals) = streamed.globals.as_deref() {
-            match args.retrieval_backend {
-                RetrievalBackend::Exact => {
-                    candidate_pairs_vlad_scored_from_globals(globals, args.retrieval_topk, false)
-                }
-                RetrievalBackend::Lsh => {
-                    let bits = effective_ann_bits(args.ann_bits, globals.len());
-                    if args.ann_probes > bits {
-                        return Err(format!(
-                            "--ann-probes {} exceeds effective --ann-bits {bits}",
-                            args.ann_probes
-                        )
-                        .into());
-                    }
-                    candidate_pairs_vlad_lsh_scored(
-                        globals,
-                        args.retrieval_topk,
-                        args.ann_tables,
-                        bits,
-                        args.ann_probes,
-                    )
-                }
+        // A missing vocabulary must not allocate N*(N-1)/2 pairs before the
+        // temporal-pyramid budget is applied. Fail closed instead.
+        let globals = streamed.appearance_globals()?;
+        let retrieval = match args.retrieval_backend {
+            RetrievalBackend::Exact => {
+                candidate_pairs_vlad_scored_from_globals(globals, args.retrieval_topk, false)
             }
-        } else {
-            all_pairs(image_names.len())
-                .into_iter()
-                .map(|pair| (pair, 0.0))
-                .collect()
+            RetrievalBackend::Lsh => {
+                let bits = effective_ann_bits(args.ann_bits, globals.len());
+                if args.ann_probes > bits {
+                    return Err(format!(
+                        "--ann-probes {} exceeds effective --ann-bits {bits}",
+                        args.ann_probes
+                    )
+                    .into());
+                }
+                candidate_pairs_vlad_lsh_scored(
+                    globals,
+                    args.retrieval_topk,
+                    args.ann_tables,
+                    bits,
+                    args.ann_probes,
+                )
+            }
         };
         let generated = candidate_pairs_temporal_pyramid_from_retrieval(
             &image_names,
@@ -18723,6 +18728,42 @@ mod diagnose_cli_tests {
     }
 
     #[test]
+    fn streamed_vlad_missing_vocabulary_refuses_exhaustive_fallback() {
+        for globals in [None, Some(Vec::new())] {
+            let streamed = super::StreamedVladGlobals {
+                globals,
+                total_descriptors: 0,
+                sampled_descriptors: 0,
+            };
+            assert!(streamed
+                .appearance_globals()
+                .unwrap_err()
+                .contains("refusing exhaustive fallback"));
+        }
+    }
+
+    #[test]
+    fn streamed_vlad_empty_feature_files_refuse_exhaustive_fallback() {
+        let root =
+            std::env::temp_dir().join(format!("visloc_empty_streamed_vlad_{}", std::process::id()));
+        std::fs::create_dir(&root).unwrap();
+        let files = vec!["a_features.txt".to_owned(), "b_features.txt".to_owned()];
+        for file in &files {
+            std::fs::write(root.join(file), b"").unwrap();
+        }
+        let rig = PerImageCameras::new(
+            (0..files.len())
+                .map(|image| Camera::pinhole(image as u64, 100, 100, 50.0, 50.0, 50.0, 50.0))
+                .collect(),
+        )
+        .unwrap();
+        let streamed = stream_vlad_globals_from_feature_files(&root, &files, &rig, 3).unwrap();
+        assert_eq!(streamed.total_descriptors, 0);
+        assert!(streamed.appearance_globals().is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn streamed_vlad_globals_preserve_batch_candidate_pairs() {
         let root = std::env::temp_dir().join(format!(
             "visloc_streamed_vlad_candidates_{}",
@@ -18759,7 +18800,7 @@ mod diagnose_cli_tests {
         assert_eq!(streamed.total_descriptors, 20);
         assert_eq!(streamed.sampled_descriptors, 20);
         let streamed_pairs = candidate_pairs_vlad_scored_from_globals(
-            streamed.globals.as_deref().unwrap(),
+            streamed.appearance_globals().unwrap(),
             2,
             false,
         );

--- a/scripts/stress_empty_streamed_candidates.py
+++ b/scripts/stress_empty_streamed_candidates.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Linux CLI stress: empty feature banks must reject before exhaustive pairing."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+from benchmark_electro import parse_gnu_time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--root', type=Path, required=True)
+    parser.add_argument('--images', type=int, default=100000)
+    args = parser.parse_args()
+    if not sys.platform.startswith('linux'):
+        parser.error('This resource-limited fixture requires Linux')
+    if not 2 <= args.images <= 100000:
+        parser.error('--images must be between 2 and 100000')
+    import resource
+
+    def limit_address_space():
+        ceiling = 2 * 1024**3
+        resource.setrlimit(resource.RLIMIT_AS, (ceiling, ceiling))
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+
+    binary = args.binary.resolve(strict=True)
+    with binary.open('rb') as stream:
+        binary_sha = hashlib.file_digest(stream, 'sha256').hexdigest()
+    root = args.root.resolve()
+    root.mkdir()  # No reuse or replacement of an existing fixture.
+    features = root / 'features'
+    calibration = root / 'calibration'
+    features.mkdir()
+    calibration.mkdir()
+    (calibration / 'cameras.txt').write_text('1 PINHOLE 100 100 50 50 50 50\n')
+    with (calibration / 'images.txt').open('w') as images:
+        for index in range(args.images):
+            stem = f'image_{index:06d}'
+            (features / f'{stem}_features.txt').touch(exist_ok=False)
+            images.write(f'{index + 1} 1 0 0 0 0 0 0 1 {stem}.png\n\n')
+    destination = root / 'candidates.txt'
+    command = [str(binary), '--feature-extractor', 'files', '--features-dir', str(features),
+               '--feature-suffix', '_features.txt', '--image-suffix', '.png',
+               '--input-colmap-calibration', str(calibration),
+               '--pair-source', 'temporal-pyramid', '--retrieval-topk', '32',
+               '--candidate-budget', str(args.images * 7), '--stream-candidate-features',
+               '--retrieval-backend', 'lsh', '--ann-tables', '8', '--ann-bits', '9',
+               '--ann-probes', '6', '--export-candidate-manifest', str(destination),
+               '--out-colmap', str(root / 'unused-model')]
+    invocation = ['/usr/bin/time', '-v', '-o', str(root / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=5s', '120s', *command]
+    started = time.monotonic()
+    with (root / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, stdout=log, stderr=subprocess.STDOUT,
+                                env=dict(os.environ, RAYON_NUM_THREADS='8', MALLOC_ARENA_MAX='1'),
+                                preexec_fn=limit_address_space)
+    elapsed = time.monotonic() - started
+    diagnostic = (root / 'run.log').read_text()
+    report = {'status': 'pass' if result.returncode == 1
+              and 'refusing exhaustive fallback' in diagnostic and not destination.exists() else 'fail',
+              'images': args.images, 'candidate_budget': args.images * 7,
+              'command': invocation, 'binary_sha256': binary_sha,
+              'expected_exit_status': 1, 'actual_exit_status': result.returncode,
+              'address_space_limit_bytes': 2 * 1024**3, 'wall_seconds': elapsed,
+              'candidate_manifest_exists': destination.exists(),
+              'measurement': parse_gnu_time(root / 'time.txt'),
+              'scope': 'empty-feature candidate rejection only; not full100k SfM or quality'}
+    (root / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2), flush=True)
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Reject missing or empty appearance vocabulary before streamed candidate generation can allocate all pairs.
- Preserve normal Exact/LSH retrieval and batch/streamed parity coverage.
- Add a resource-limited real CLI stress harness and 100k empty-feature evidence; this is not a full100k SfM or E2E claim.

## Validation
- Release example tests: 64 passed
- Python tests: 40 passed
- Release example Clippy with warnings denied: passed
- Final release binary: 100k empty-feature CLI rejected explicitly, exit 1, no manifest, 1.003 seconds, peak 102892 KiB under 2 GiB address-space cap
- git diff --check: passed

## Remaining goal
Shared-envelope artifact growth, full extraction/native E2E, and COLMAP trajectory parity remain open.