### PR TITLE
bench: verify base extraction and audit snapshot metadata scaling

### DIFF
--- a/benchmarks/electro/m8-dense-snapshot-envelope-audit-v1.json
+++ b/benchmarks/electro/m8-dense-snapshot-envelope-audit-v1.json
@@ -1,0 +1,16 @@
+{
+  "scope": "Structural envelope size audit only; pair payload/checksum not validated by this audit. Dense replay content was separately verified.",
+  "recipe": "python3 scripts/audit_snapshot_envelopes.py --snapshots /home/sasaki/datasets/openloris/corridor1-1-m8-dense-matching-replay-v1/matches",
+  "shards": 2500,
+  "images": 10000,
+  "pairs": 64862,
+  "file_bytes": 1294392088,
+  "shared_envelope_bytes_total": 777135000,
+  "unique_envelopes": {
+    "2c9273dbc3f298ed47319243b80560dc38d7f7a0325958984a31ba876f6c52b3": 310854
+  },
+  "duplicate_envelope_bytes": 776824146,
+  "image_dependent_bytes_total": 775000000,
+  "conclusion": "Fixed-size pair shards repeat the entire image envelope. With O(N) shards this metadata is O(N^2); streaming merge does not eliminate storage/I/O growth.",
+  "next": "Share the immutable envelope once, bind pair chunks to its content identity, and validate compatibility and restart before enabling compact output in the runner. Keep legacy v1 import support."
+}

--- a/benchmarks/electro/m8-openloris-base-extraction-probe-v1.json
+++ b/benchmarks/electro/m8-openloris-base-extraction-probe-v1.json
@@ -1,0 +1,21 @@
+{
+  "status": "four-image-byte-parity-pass",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-base-extraction-probe-v1/report.json",
+  "recipe": "python3 scripts/probe_openloris_base_extraction.py --output NEW_PROBE_DIRECTORY",
+  "binary_sha256": "8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34",
+  "reference_recipe_sha256": "d4d6097f92f0c9ac19dee0795b9418af824c36889a5f3dac5e967f6df34f3dc2",
+  "images": ["cam1_000000.png", "cam1_006666.png", "cam2_003333.png", "cam2_009999.png"],
+  "feature_sha256": {
+    "cam1_000000_features.txt": "eb7d3e54c46e09f56b7cb35607786492542517a990a8a0902bc09d146f0fdc76",
+    "cam1_006666_features.txt": "a06b9b6f753721bb1e0fde3bdbaa90fa583342e9af6ef0fecc3a6ec9a4565754",
+    "cam2_003333_features.txt": "dcb734f19ce780fb445d6f907be383d4fc1394c96d62e93814d31920f06dd507",
+    "cam2_009999_features.txt": "247508ff145a570592b777ebf279cedfb1c669c96a3aec813d8a38cf705bf5c4"
+  },
+  "keypoints": 584,
+  "exit_code": 0,
+  "peak_rss_kib": 271872,
+  "rayon_num_threads": 8,
+  "malloc_arena_max": "1",
+  "time_report_sha256": "484fd15f69fa7c8d830431c4bee3ca6341b95f095967a6989f492007c69a3646",
+  "scope": "Four raw images only, not full10k extraction, a speed comparison, or continuous native E2E. Base recipe is distinct from dense extraction."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -7,7 +7,8 @@
 整理記録のPR121（head`8b05461`、CI9成功）は
 `fdf94400e98f80b2cb81c45c86b0441a7977d6e9`へmerge、旧branch整理済み。
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
-へmerge、旧branch整理済み。現作業branchは`fix/streamed-retrieval-empty-vocabulary`。
+へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI8成功/rust実行中。
+現作業branchはその子`test/m8-base-extraction-parity-probe`。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -36,6 +37,12 @@ PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac
   2GiB仮想メモリ制限下でexit1・期待診断・出力なし、1.00s/102,892KiB。
   通常の100k SfM/共有metadataの容量保証ではない。64 example tests通過。
   全goalは未達。READMEに未検証の高速化/品質改善を追加しない。
+
+更新: base抽出の4画像probeは完了。両カメラの時系列に散らした4画像・584特徴が
+保存済みbaseと全bytes一致。scriptは`probe_openloris_base_extraction.py`、
+証跡は`m8-openloris-base-extraction-probe-v1.json`。実行session64673はexit0完了。
+全10k抽出/E2Eではない。Python40 tests/py_compile通過。大規模抽出前に容量を確認し、
+base/Dを別レシピで処理する。PR123の最終CI確認後merge、親branch整理が次。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -7,8 +7,9 @@
 整理記録のPR121（head`8b05461`、CI9成功）は
 `fdf94400e98f80b2cb81c45c86b0441a7977d6e9`へmerge、旧branch整理済み。
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
-へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI8成功/rust実行中。
-現作業branchはその子`test/m8-base-extraction-parity-probe`。
+へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
+`d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
+現作業branchは`test/m8-base-extraction-parity-probe`。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -42,7 +43,14 @@ PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac
 保存済みbaseと全bytes一致。scriptは`probe_openloris_base_extraction.py`、
 証跡は`m8-openloris-base-extraction-probe-v1.json`。実行session64673はexit0完了。
 全10k抽出/E2Eではない。Python40 tests/py_compile通過。大規模抽出前に容量を確認し、
-base/Dを別レシピで処理する。PR123の最終CI確認後merge、親branch整理が次。
+base/Dを別レシピで処理する。
+
+更新: dense snapshot全2500の構造監査完了。総1,294,392,088 bytes中
+共通envelope777,135,000 bytes、重複分776,824,146 bytes。全envelope SHA一致。
+固定ペア数shardに全画像metadataを反復するため、O(N) shardでO(N²)保存/I/Oになる。
+次は共有envelope+内容IDに結びつくpair chunkの設計・実装、v1互換/restart検証。
+証跡`m8-dense-snapshot-envelope-audit-v1.json`。監査script自身はpayload checksumを検証しない。
+Python43 tests通過。全goal未達。PR123旧branch整理と現branchのPRが次。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -226,7 +226,22 @@ remain open. Legacy v1 diagnostic shard reproduction is not proof of N²-free
 artifact growth: audit shared-envelope storage in the final runner before 100k
 claims.
 
-## Base extraction preflight
+## Extraction and storage preflights
+
+### Snapshot storage audit
+
+`scripts/audit_snapshot_envelopes.py` measured the 2,500 dense matching snapshots:
+1,294,392,088 total bytes, of which 777,135,000 are shared envelope bytes.
+All envelopes have the same SHA-256; 776,824,146 bytes are duplicate copies.
+The image-dependent portion alone is 775,000,000 bytes. Fixed-pair-count shards
+therefore retain quadratic image metadata when shard count grows with image
+count. Streaming merge bounds merge memory, not this storage/I/O cost.
+Evidence: `m8-dense-snapshot-envelope-audit-v1.json`. This structural audit does
+not validate pair payload checksums; full dense replay parity is separate.
+Next: shared immutable envelope plus identity-bound pair chunks, legacy v1 read
+compatibility, and restart/round-trip tests before runner adoption.
+
+### Raw image probe
 
 The base extraction preflight also passed on four raw images spread across both
 cameras and the sequence (`cam1_000000`, `cam1_006666`, `cam2_003333`,

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -226,6 +226,16 @@ remain open. Legacy v1 diagnostic shard reproduction is not proof of N²-free
 artifact growth: audit shared-envelope storage in the final runner before 100k
 claims.
 
+## Base extraction preflight
+
+The base extraction preflight also passed on four raw images spread across both
+cameras and the sequence (`cam1_000000`, `cam1_006666`, `cam2_003333`,
+`cam2_009999`). `scripts/probe_openloris_base_extraction.py` replays the recorded
+base SIFT recipe with the frozen image-capable extractor; all four feature files
+(584 keypoints) match the retained base bank byte-for-byte. Evidence:
+`m8-openloris-base-extraction-probe-v1.json`. This does not establish full10k
+extraction parity or E2E performance.
+
 ## Empty vocabulary safety
 
 Streamed candidate export now rejects a missing/empty appearance vocabulary

--- a/scripts/audit_snapshot_envelopes.py
+++ b/scripts/audit_snapshot_envelopes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Measure repeated v1 snapshot envelopes, without claiming payload validation."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import struct
+
+MAGIC = b'VISLOC-VERIFIED-PAIR-SNAPSHOT\0'
+
+
+def inspect(path):
+    size = path.stat().st_size
+    with path.open('rb') as stream:
+        def read(count):
+            if count < 0 or count > size - stream.tell():
+                raise ValueError('Truncated snapshot')
+            value = stream.read(count)
+            if len(value) != count:
+                raise ValueError('Truncated snapshot')
+            return value
+
+        def integer(fmt):
+            return struct.unpack(fmt, read(struct.calcsize(fmt)))[0]
+
+        if read(len(MAGIC)) != MAGIC or integer('<I') != 1:
+            raise ValueError('Unsupported snapshot header')
+        payload_size = integer('<Q')
+        start = stream.tell()
+        if start + payload_size + 8 != size:
+            raise ValueError('Snapshot length mismatch')
+        if integer('<I') != 1:
+            raise ValueError('Unsupported payload schema')
+        count = integer('<Q')
+        if count > payload_size // 8:
+            raise ValueError('Invalid image count')
+        name_bytes = 0
+        for _ in range(count):
+            length = integer('<Q')
+            read(length)
+            name_bytes += 8 + length
+        read(16)  # image and feature manifest hashes
+        features = integer('<Q')
+        if features != count:
+            raise ValueError('Image/feature count mismatch')
+        read(8 * features)
+        read(48)  # width, height, intrinsics
+        for _ in range(2):
+            read(8)  # configuration hash
+            read(integer('<Q'))
+        end = stream.tell()
+        read(24)  # shard-specific pair/edge hashes and match count
+        pairs = integer('<Q')
+        if stream.tell() > start + payload_size:
+            raise ValueError('Envelope exceeds payload')
+        stream.seek(start)
+        digest = hashlib.sha256(read(end - start)).hexdigest()
+    return {'images': count, 'pairs': pairs, 'file_bytes': size,
+            'shared_envelope_bytes': end - start,
+            'image_dependent_bytes': name_bytes + 8 * features,
+            'envelope_sha256': digest}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--snapshots', type=Path, required=True)
+    args = parser.parse_args()
+    paths = sorted(args.snapshots.glob('*.vps'))
+    if not paths:
+        parser.error('No snapshot files')
+    rows = [inspect(path) for path in paths]
+    unique = {}
+    for row in rows:
+        unique[row['envelope_sha256']] = row['shared_envelope_bytes']
+    total = sum(row['shared_envelope_bytes'] for row in rows)
+    print(json.dumps({
+        'scope': 'Structural envelope size audit only; pair payload/checksum not validated.',
+        'snapshots': str(args.snapshots.resolve()), 'shards': len(rows),
+        'image_counts': sorted({row['images'] for row in rows}),
+        'pairs': sum(row['pairs'] for row in rows),
+        'file_bytes': sum(row['file_bytes'] for row in rows),
+        'shared_envelope_bytes_total': total,
+        'unique_envelopes': unique,
+        'duplicate_envelope_bytes': total - sum(unique.values()),
+        'image_dependent_bytes_total': sum(row['image_dependent_bytes'] for row in rows),
+        'scaling': 'With O(N) fixed-pair-count shards and full N-image envelopes, serialized image metadata is O(N^2). A streaming merger alone does not change this.'
+    }, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/probe_openloris_base_extraction.py
+++ b/scripts/probe_openloris_base_extraction.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Probe the recorded base SIFT recipe on four spread-out raw images."""
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+
+from benchmark_electro import parse_gnu_time
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    base = Path('/home/sasaki/datasets/openloris')
+    source = base / 'corridor1-1-m5'
+    binary = base / 'corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a'
+    binary_sha = sha(binary)
+    if binary_sha != '8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34':
+        raise RuntimeError('Frozen extractor changed')
+    recipe = source / 'feature-extract/timing/shard-0.time.txt'
+    command = shlex.split(shlex.split(recipe.read_text().splitlines()[0].split(
+        'Command being timed: ', 1)[1])[0])
+    images = sorted((source / 'images').glob('*.png'))
+    if len(images) < 4:
+        raise RuntimeError('Raw image bank missing')
+    selected = [images[index * (len(images) - 1) // 3] for index in range(4)]
+    reference = source / 'tiers/tier-10000/features256'
+    expected = {image.stem + '_features.txt': sha(reference / (image.stem + '_features.txt'))
+                for image in selected}
+    output = args.output.resolve()
+    output.mkdir()  # Never overwrite an existing probe.
+    inputs = output / 'images'
+    inputs.mkdir()
+    for image in selected:
+        (inputs / image.name).symlink_to(image.resolve(strict=True))
+    command[0] = str(binary)
+    for flag, path in [('--images-dir', inputs),
+                       ('--export-features-dir', output / 'features'),
+                       ('--out-colmap', output / 'unused-model')]:
+        command[command.index(flag) + 1] = str(path)
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '300s', *command]
+    report = {'status': 'running', 'command': invocation, 'binary_sha256': binary_sha,
+              'recipe_sha256': sha(recipe), 'reference_feature_sha256': expected,
+              'image_sha256': {image.name: sha(image) for image in selected},
+              'rayon_num_threads': 8, 'malloc_arena_max': '1',
+              'scope': 'Four-image base extraction parity only; not full10k or E2E.'}
+    report_path = output / 'report.json'
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, stdout=log, stderr=subprocess.STDOUT,
+                                env=dict(os.environ, RAYON_NUM_THREADS='8', MALLOC_ARENA_MAX='1'))
+    actual = {path.name: sha(path) for path in (output / 'features').glob('*_features.txt')}
+    report.update(exit_code=result.returncode, output_feature_sha256=actual,
+                  measurement=parse_gnu_time(output / 'time.txt'),
+                  status='pass' if result.returncode == 0 and actual == expected else 'fail')
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/tests/test_snapshot_envelope_audit.py
+++ b/scripts/tests/test_snapshot_envelope_audit.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+import struct
+import tempfile
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    'audit', Path(__file__).resolve().parents[1] / 'audit_snapshot_envelopes.py')
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+def fixture(images=2):
+    payload = struct.pack('<IQ', 1, images)
+    for index in range(images):
+        name = f'{index}.png'.encode()
+        payload += struct.pack('<Q', len(name)) + name
+    payload += struct.pack('<QQQ', 0, 0, images) + bytes(images * 8 + 48)
+    payload += bytes(32)  # Two empty configuration strings with hashes.
+    payload += bytes(32)  # Pair/edge hashes, accepted count, pair count.
+    return audit.MAGIC + struct.pack('<IQ', 1, len(payload)) + payload + bytes(8)
+
+
+class EnvelopeTests(unittest.TestCase):
+    def inspect(self, data):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'test.vps'
+            path.write_bytes(data)
+            return audit.inspect(path)
+
+    def test_sizes(self):
+        row = self.inspect(fixture())
+        self.assertEqual(row['images'], 2)
+        self.assertEqual(row['pairs'], 0)
+        self.assertEqual(row['image_dependent_bytes'], 42)
+        self.assertEqual(row['shared_envelope_bytes'], 158)
+        self.assertEqual(row['file_bytes'], len(fixture()))
+
+    def test_image_metadata_grows_linearly_per_shard(self):
+        first = self.inspect(fixture(2))
+        second = self.inspect(fixture(4))
+        self.assertEqual(second['image_dependent_bytes'], 2 * first['image_dependent_bytes'])
+        self.assertNotEqual(first['envelope_sha256'], second['envelope_sha256'])
+
+    def test_rejects_bad_header_and_lengths(self):
+        for data in [b'', fixture()[:-1], fixture() + b'x', b'X' + fixture()[1:]]:
+            with self.subTest(length=len(data)), self.assertRaises(ValueError):
+                self.inspect(data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reproduce the recorded base extraction recipe on four raw images from both cameras; all 584 features match retained files byte-for-byte.
- Audit all 2500 dense snapshots: 776824146 bytes of duplicate shared envelopes, exposing quadratic metadata storage with fixed-size pair shards.
- Add reproducible scripts, three structural parser tests, evidence, and handover notes.

## Validation
- Python suite: 43 tests passed
- Actual four-image extraction: exit 0 and full feature file SHA parity
- Actual dense snapshot audit: all shared envelopes have identical SHA
- git diff --check

## Limits and next step
This is not full10k extraction or continuous E2E. Structural auditing does not validate pair payload checksums. Implement shared immutable envelopes with identity-bound pair chunks and restart/legacy compatibility before claiming N-squared-free storage.