### PR TITLE
feat: add opt-in content-addressed snapshot envelopes

### DIFF
--- a/benchmarks/electro/m8-dense-shared-snapshot-parity-v1.json
+++ b/benchmarks/electro/m8-dense-shared-snapshot-parity-v1.json
@@ -1,0 +1,17 @@
+{
+  "status": "all-shard-record-parity-pass",
+  "source": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-matching-replay-v1/matches",
+  "output": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-shared-snapshots-v1",
+  "recipe": "target/release/examples/compact_verified_pair_snapshots SOURCE NEW_OUTPUT",
+  "binary_sha256": "1686226789dffe4c41e8961ad88e920ca7fc87ade1e3dab7048492d1635fa64f",
+  "shards": 2500,
+  "pairs": 64862,
+  "shared_envelopes": 1,
+  "legacy_bytes": 1294392088,
+  "shared_directory_bytes": 517615442,
+  "wall_seconds": 16.90,
+  "peak_rss_kib": 7820,
+  "exit_code": 0,
+  "validation": "Each source and output was checksum-decoded by Rust and compared with full Snapshot equality, preserving all pair records and floating-point bits.",
+  "scope": "Conversion plus verification only, not a matching/E2E speed comparison. Reader/writer envelope caching, forced restart, concurrent publication, and 100k stress remain open."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`test/m8-base-extraction-parity-probe`。
+現作業branchは`feat/shared-snapshot-envelope`。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -51,6 +51,16 @@ base/Dを別レシピで処理する。
 次は共有envelope+内容IDに結びつくpair chunkの設計・実装、v1互換/restart検証。
 証跡`m8-dense-snapshot-envelope-audit-v1.json`。監査script自身はpayload checksumを検証しない。
 Python43 tests通過。全goal未達。PR123旧branch整理と現branchのPRが次。
+
+更新: PR123旧branch整理済み、probe/監査PR124は最終head`9e4f0d4`でCI9成功後
+`e5ec9d6b29c625937e79e507ac3374318f4e1d8b`へmerge済み。
+共有snapshot形式を実装。明示flag `--shared-snapshot-envelope`のみ、既定v1は変更なし。
+実dense2500 shard/64862 pairsを変換し全Snapshotレコード一致。
+保存量1,294,392,088→517,615,442 bytes（envelope1個）。変換検証16.90s/7820KiB。
+証跡`m8-dense-shared-snapshot-parity-v1.json`、設計/制約`docs/shared_snapshot_envelopes.md`。
+lib15/example64 testsとClippy通過。現形式は読書きごとにenvelopeを再検証するため
+I/O/CPUのN²解消は未達。次はbounded cache、強制中断/同時publication、worker実出力と
+100k stress。変換session79247はexit0完了。全goal未達。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -1,0 +1,41 @@
+# Shared snapshot envelopes
+
+`unordered_sfm_demo --shared-snapshot-envelope` opts snapshot exports (including
+persistent worker shards) into a compact, lossless representation. Default
+exports remain legacy v1. Snapshot readers and the streaming merger accept both.
+
+Each directory stores immutable `envelope-<sha256>.vpe` files and pair chunks.
+The envelope is the exact v1 payload prefix through verifier configuration;
+the chunk contains the four shard-specific counters/hashes and encoded pairs.
+The chunk header binds the envelope SHA-256, and the existing FNV checksum covers
+that binding and the chunk payload. FNV is accidental-corruption detection, not
+an adversarial authentication mechanism. No matches or floating-point bits are
+changed. Readers concatenate the validated envelope and chunk payload logically
+and reuse the existing decoder, including compact/capped mapper validation.
+
+Publication writes and syncs owned temporary files. A hard link publishes an
+envelope only if absent; existing content must match exactly. A same-directory
+rename publishes the completed chunk after its envelope. A retry may leave an
+unreferenced envelope or interrupted temporary file; neither is a completed
+chunk. This is process-interruption safety, not a tested power-loss guarantee.
+Copy the whole directory, including `.vpe` files. A chunk alone is incomplete.
+
+To convert retained shards into a fresh directory with full record equality
+checked for every output:
+
+```sh
+cargo run --locked --release --example compact_verified_pair_snapshots -- INPUT_DIRECTORY NEW_OUTPUT_DIRECTORY
+```
+
+The converter retains one input/output shard at a time. It does not replace or
+delete inputs and refuses an existing destination. The writer supports retry;
+the batch converter itself does not yet resume partially completed conversions.
+
+## Remaining work
+
+This format removes repeated envelope storage, but currently reads and validates
+the shared envelope for every chunk. Add a bounded, explicit reader/writer
+envelope cache before claiming linear metadata I/O/CPU. Verify concurrent
+publication, forced-interruption restart, real persistent-worker output parity,
+and 100k scaling before switching the native runner default. Full E2E, trajectory
+quality and whole-pipeline memory gates remain separate.

--- a/examples/compact_verified_pair_snapshots.rs
+++ b/examples/compact_verified_pair_snapshots.rs
@@ -1,0 +1,43 @@
+//! Convert a v1 shard directory to shared-envelope chunks and verify every record.
+use std::path::PathBuf;
+use visloc_rs::verified_pair_snapshot::{read, write_shared_atomic};
+
+fn main() -> Result<(), String> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        return Err(
+            "usage: compact_verified_pair_snapshots INPUT_DIRECTORY NEW_OUTPUT_DIRECTORY".into(),
+        );
+    }
+    let source = PathBuf::from(&args[0]);
+    let destination = PathBuf::from(&args[1]);
+    let mut paths = std::fs::read_dir(&source)
+        .map_err(|error| error.to_string())?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    paths.retain(|path| path.extension().is_some_and(|extension| extension == "vps"));
+    paths.sort();
+    if paths.is_empty() {
+        return Err("no snapshot shards".into());
+    }
+    std::fs::create_dir(&destination).map_err(|error| error.to_string())?;
+    let mut pairs = 0usize;
+    for (index, path) in paths.iter().enumerate() {
+        let snapshot = read(path)?;
+        let output = destination.join(path.file_name().ok_or("missing filename")?);
+        write_shared_atomic(&output, &snapshot)?;
+        if read(&output)? != snapshot {
+            return Err(format!("round-trip mismatch: {}", path.display()));
+        }
+        pairs += snapshot.pairs.len();
+        if (index + 1) % 250 == 0 {
+            eprintln!("verified {}/{} shards", index + 1, paths.len());
+        }
+    }
+    println!(
+        "verified {} shards, {pairs} pairs; shared-envelope record parity passed",
+        paths.len()
+    );
+    Ok(())
+}

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -243,6 +243,9 @@
 //! default and is forced for snapshot replay unless a policy is explicitly
 //! requested.
 //!
+//! `--shared-snapshot-envelope` opts exported snapshots into compact pair chunks
+//! with a content-addressed `.vpe` envelope in the same directory. Copy both
+//! chunks and envelopes together; legacy snapshot import remains supported.
 //! `--export-verified-pairs-snapshot PATH` writes a lossless, versioned
 //! snapshot of the accepted pair/match stream after verification and all
 //! configured stream-order transforms.  `--import-verified-pairs-snapshot
@@ -2087,6 +2090,8 @@ struct Args {
     /// Export the exact post-verification pair/match stream to a checksummed
     /// versioned snapshot.  Default None; does not alter reconstruction.
     export_verified_pairs_snapshot: Option<PathBuf>,
+    /// Store one content-addressed envelope alongside compact pair chunks.
+    shared_snapshot_envelope: bool,
     /// Import a checksummed verified-pair snapshot and bypass matching and
     /// verification.  The loaded image/feature manifest and camera must match.
     import_verified_pairs_snapshot: Option<PathBuf>,
@@ -4815,6 +4820,7 @@ where
     let mut sift_stream_resume = false;
     let mut import_verified_pairs_file: Option<PathBuf> = None;
     let mut export_verified_pairs_snapshot: Option<PathBuf> = None;
+    let mut shared_snapshot_envelope = false;
     let mut import_verified_pairs_snapshot: Option<PathBuf> = None;
     let mut snapshot_keypoints_only = false;
     let mut export_verified_pairs_only = false;
@@ -5593,6 +5599,7 @@ where
                 a.remove(i + 1);
                 import_verified_pairs_snapshot = Some(PathBuf::from(raw));
             }
+            "--shared-snapshot-envelope" => shared_snapshot_envelope = true,
             "--snapshot-keypoints-only" => snapshot_keypoints_only = true,
             "--export-verified-pairs-only" => export_verified_pairs_only = true,
             "--persistent-match-worker-plan" => {
@@ -6528,6 +6535,7 @@ where
         sift_stream_resume,
         import_verified_pairs_file,
         export_verified_pairs_snapshot,
+        shared_snapshot_envelope,
         import_verified_pairs_snapshot,
         snapshot_keypoints_only,
         export_verified_pairs_only,
@@ -8760,7 +8768,9 @@ fn write_verified_pair_snapshot_with_validation(
             .sum::<usize>() as u64,
         pairs: records,
     };
-    if atomic {
+    if args.shared_snapshot_envelope {
+        verified_pair_snapshot::write_shared_atomic(path, &snapshot)
+    } else if atomic {
         verified_pair_snapshot::write_atomic(path, &snapshot)
     } else {
         verified_pair_snapshot::write(path, &snapshot)

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -13,6 +13,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 pub const SCHEMA_VERSION: u32 = 1;
 
+mod shared;
+pub use shared::write_shared_atomic;
+
 const MAGIC: &[u8] = b"VISLOC-VERIFIED-PAIR-SNAPSHOT\0";
 const MAX_VECTOR_ITEMS: usize = 50_000_000;
 
@@ -1507,6 +1510,9 @@ fn read_with_retention(
     let mut magic = vec![0; MAGIC.len()];
     file.read_exact(&mut magic)
         .map_err(|error| format!("read {} header: {error}", path.display()))?;
+    if magic.starts_with(shared::MAGIC) {
+        return shared::read(path, retain_audit_streams, mapper_match_limit);
+    }
     if magic != MAGIC {
         return Err(format!(
             "{} is not a verified-pair snapshot (bad magic or truncated header)",
@@ -1667,6 +1673,75 @@ mod tests {
             "visloc_verified_pair_snapshot_{tag}_{}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn shared_chunks_round_trip_reuse_envelope_and_merge() {
+        let root = temp_path("shared_roundtrip");
+        std::fs::create_dir(&root).unwrap();
+        let snapshot = sample();
+        let first = root.join("first.vps");
+        let second = root.join("second.vps");
+        super::write_shared_atomic(&first, &snapshot).unwrap();
+        super::write_shared_atomic(&second, &snapshot).unwrap();
+        assert_eq!(read(&first).unwrap(), snapshot);
+        assert_eq!(
+            std::fs::read(&first).unwrap(),
+            std::fs::read(&second).unwrap()
+        );
+        assert_eq!(std::fs::read_dir(&root).unwrap().count(), 3);
+        let legacy = root.join("legacy.vps");
+        write(&legacy, &snapshot).unwrap();
+        assert_eq!(
+            read_mapper_compact(&first).unwrap(),
+            read_mapper_compact(&legacy).unwrap()
+        );
+        assert_eq!(
+            read_mapper_compact_capped(&first, 1).unwrap(),
+            read_mapper_compact_capped(&legacy, 1).unwrap()
+        );
+        let merged_shared = root.join("merged_shared.vps");
+        let merged_legacy = root.join("merged_legacy.vps");
+        merge_files_atomic(&merged_shared, &[first.clone()]).unwrap();
+        merge_files_atomic(&merged_legacy, &[legacy]).unwrap();
+        assert_eq!(
+            std::fs::read(merged_shared).unwrap(),
+            std::fs::read(merged_legacy).unwrap()
+        );
+        // Retry publication produces exactly the same complete bytes.
+        super::write_shared_atomic(&first, &snapshot).unwrap();
+        assert_eq!(read(&first).unwrap(), snapshot);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn shared_chunks_reject_corruption_and_missing_envelope() {
+        let root = temp_path("shared_corruption");
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("chunk.vps");
+        super::write_shared_atomic(&path, &sample()).unwrap();
+        let envelope = std::fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| path.extension().is_some_and(|extension| extension == "vpe"))
+            .unwrap();
+        let original = std::fs::read(&envelope).unwrap();
+        std::fs::write(&envelope, b"corrupt").unwrap();
+        assert!(read(&path).unwrap_err().contains("SHA-256"));
+        assert!(super::write_shared_atomic(&path, &sample())
+            .unwrap_err()
+            .contains("mismatch"));
+        std::fs::remove_file(&envelope).unwrap();
+        assert!(read(&path).unwrap_err().contains("read shared envelope"));
+        std::fs::write(&envelope, original).unwrap();
+        let mut bytes = std::fs::read(&path).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 1;
+        std::fs::write(&path, &bytes).unwrap();
+        assert!(read(&path).unwrap_err().contains("checksum"));
+        std::fs::write(&path, &bytes[..last]).unwrap();
+        assert!(read(&path).unwrap_err().contains("length"));
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -1702,7 +1702,7 @@ mod tests {
         );
         let merged_shared = root.join("merged_shared.vps");
         let merged_legacy = root.join("merged_legacy.vps");
-        merge_files_atomic(&merged_shared, &[first.clone()]).unwrap();
+        merge_files_atomic(&merged_shared, std::slice::from_ref(&first)).unwrap();
         merge_files_atomic(&merged_legacy, &[legacy]).unwrap();
         assert_eq!(
             std::fs::read(merged_shared).unwrap(),

--- a/src/verified_pair_snapshot/shared.rs
+++ b/src/verified_pair_snapshot/shared.rs
@@ -1,0 +1,151 @@
+//! Content-addressed envelope storage. Legacy v1 payload encoding is unchanged.
+use super::*;
+use sha2::{Digest, Sha256};
+
+pub(super) const MAGIC: &[u8] = b"VISLOC-PAIR-CHUNK-V1\0";
+
+fn envelope_path(parent: &Path, digest: &[u8]) -> PathBuf {
+    let hex = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    parent.join(format!("envelope-{hex}.vpe"))
+}
+
+fn parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|value| !value.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+/// Atomically publish a pair chunk referencing an immutable SHA-256 envelope.
+/// Keep the `.vpe` files alongside chunks when moving/copying a run directory.
+/// Existing legacy writers remain unchanged. This reduces serialized storage;
+/// callers still need an envelope cache to avoid repeated envelope reads.
+pub fn write_shared_atomic(path: &Path, snapshot: &Snapshot) -> Result<(), String> {
+    let mut prefix = Vec::new();
+    encode_payload_prefix(
+        snapshot,
+        snapshot.pair_order_hash,
+        snapshot.unordered_edge_hash,
+        snapshot.accepted_match_count,
+        snapshot.pairs.len() as u64,
+        &mut prefix,
+    )?;
+    let split = prefix
+        .len()
+        .checked_sub(32)
+        .ok_or("invalid snapshot prefix")?;
+    let envelope = &prefix[..split];
+    let digest = Sha256::digest(envelope);
+    let directory = parent(path);
+    std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+    let envelope_destination = envelope_path(directory, &digest);
+    if !envelope_destination.exists() {
+        let (temporary, mut file) = create_merge_temporary_file(directory, "envelope", "shared")?;
+        file.write_all(envelope)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| error.to_string())?;
+        // Atomic create-if-absent, including concurrent workers using the same envelope.
+        match std::fs::hard_link(&temporary.path, &envelope_destination) {
+            Ok(()) => (),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (),
+            Err(error) => return Err(format!("publish envelope: {error}")),
+        }
+    }
+    // Never replace a corrupt file at a content-addressed name.
+    if std::fs::read(&envelope_destination).map_err(|error| error.to_string())? != envelope {
+        return Err("existing shared envelope content mismatch".to_owned());
+    }
+    let suffix_len = payload_len(snapshot)?
+        .checked_sub(split as u64)
+        .ok_or("invalid suffix size")?;
+    let (temporary, file) = create_merge_temporary_file(directory, "chunk", "shared")?;
+    let mut writer = BufWriter::new(file);
+    writer
+        .write_all(MAGIC)
+        .and_then(|()| writer.write_all(&digest))
+        .and_then(|()| writer.write_all(&suffix_len.to_le_bytes()))
+        .map_err(|error| error.to_string())?;
+    let mut payload = PayloadDigestWriter::new(&mut writer);
+    for byte in &digest {
+        payload.checksum ^= u64::from(*byte);
+        payload.checksum = payload.checksum.wrapping_mul(0x100000001b3);
+    }
+    payload
+        .write_all(&prefix[split..])
+        .map_err(|error| error.to_string())?;
+    for pair in &snapshot.pairs {
+        encode_pair(pair, &mut payload)?;
+    }
+    if payload.len != suffix_len {
+        return Err("shared chunk length mismatch".to_owned());
+    }
+    let checksum = payload.checksum;
+    writer
+        .write_all(&checksum.to_le_bytes())
+        .and_then(|()| writer.flush())
+        .and_then(|()| writer.get_ref().sync_all())
+        .map_err(|error| error.to_string())?;
+    drop(writer);
+    std::fs::rename(&temporary.path, path).map_err(|error| format!("publish chunk: {error}"))
+}
+
+pub(super) fn read(path: &Path, retain: bool, cap: Option<usize>) -> Result<Snapshot, String> {
+    let mut file = std::fs::File::open(path).map_err(|error| error.to_string())?;
+    let length = file.metadata().map_err(|error| error.to_string())?.len();
+    let header_len = MAGIC.len() as u64 + 32 + 8;
+    file.seek(SeekFrom::Start(MAGIC.len() as u64))
+        .map_err(|error| error.to_string())?;
+    let mut digest = [0u8; 32];
+    let mut bytes = [0u8; 8];
+    file.read_exact(&mut digest)
+        .and_then(|()| file.read_exact(&mut bytes))
+        .map_err(|error| error.to_string())?;
+    let suffix_len = u64::from_le_bytes(bytes);
+    if header_len
+        .checked_add(suffix_len)
+        .and_then(|size| size.checked_add(8))
+        != Some(length)
+    {
+        return Err("shared chunk length mismatch".to_owned());
+    }
+    let envelope = std::fs::read(envelope_path(parent(path), &digest))
+        .map_err(|error| format!("read shared envelope: {error}"))?;
+    if Sha256::digest(&envelope)[..] != digest {
+        return Err("shared envelope SHA-256 mismatch".to_owned());
+    }
+    let mut remaining = suffix_len;
+    let mut checksum = 0xcbf29ce484222325u64;
+    for byte in &digest {
+        checksum ^= u64::from(*byte);
+        checksum = checksum.wrapping_mul(0x100000001b3);
+    }
+    let mut buffer = vec![0u8; 1024 * 1024];
+    while remaining > 0 {
+        let count = remaining.min(buffer.len() as u64) as usize;
+        file.read_exact(&mut buffer[..count])
+            .map_err(|error| error.to_string())?;
+        for byte in &buffer[..count] {
+            checksum ^= u64::from(*byte);
+            checksum = checksum.wrapping_mul(0x100000001b3);
+        }
+        remaining -= count as u64;
+    }
+    file.read_exact(&mut bytes)
+        .map_err(|error| error.to_string())?;
+    if checksum != u64::from_le_bytes(bytes) {
+        return Err("shared chunk checksum mismatch".to_owned());
+    }
+    file.seek(SeekFrom::Start(header_len))
+        .map_err(|error| error.to_string())?;
+    let payload_len = (envelope.len() as u64)
+        .checked_add(suffix_len)
+        .ok_or("shared payload size overflow")?;
+    decode_payload(
+        std::io::Cursor::new(envelope).chain(BufReader::new(file.take(suffix_len))),
+        payload_len,
+        retain,
+        cap,
+    )
+}


### PR DESCRIPTION
## Summary
- Add shared immutable SHA-256 envelopes and atomic pair chunks, opt-in via --shared-snapshot-envelope; legacy default unchanged.
- Decode both formats using the existing lossless and mapper-compact decoder. Streaming merger accepts shared inputs.
- Add fresh-directory converter with full per-shard Snapshot equality checks.

## Validation
- Library snapshot tests: 15 passed; example tests: 64 passed.
- Clippy (library, SfM example, converter): warnings denied, passed.
- Real dense bank: all 2500 shards / 64862 pairs round-trip exactly; total stored bytes 1294392088 -> 517615442 including one shared envelope.
- Missing/corrupt envelope, corrupt/truncated chunk, retry, compact/capped read, and merge parity tests.

## Remaining gates
Envelope read/write caching is still needed for linear metadata I/O/CPU. Forced-interruption and concurrent publication, real worker output parity, and 100k stress remain open. This is not full E2E or COLMAP quality completion. See docs/shared_snapshot_envelopes.md.