### PR TITLE
perf: cache shared envelopes and prepare worker writes once

### DIFF
--- a/benchmarks/electro/m8-dense-shared-merge-cache-v1.json
+++ b/benchmarks/electro/m8-dense-shared-merge-cache-v1.json
@@ -1,0 +1,26 @@
+{
+  "status": "full-merged-byte-parity-pass",
+  "binary_sha256": "c5c88d648cf4fc8112b1a2e572ca637e3250e5c3a7c440101783dae8a21e7860",
+  "shards": 2500,
+  "output_sha256_both_formats": "02cd6475098453cb6cf93761ff990ea31acba86217b715dfaf43660f3af0f05c",
+  "shared": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-shared-merge-cache-v1/report.json",
+    "time_report_sha256": "74c1fc7cd130d482a7d160bd823781305dd25bd1f561274691bdaa71693176d1",
+    "wall_seconds": 10.54,
+    "user_seconds": 9.82,
+    "system_seconds": 0.71,
+    "peak_rss_kib": 16644
+  },
+  "legacy": {
+    "report": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-legacy-merge-cache-v1/report.json",
+    "time_report_sha256": "21f73f18752c97429420ae8a52f85397d373467bd873b564088f5abe347b292a",
+    "wall_seconds": 13.95,
+    "user_seconds": 12.74,
+    "system_seconds": 1.20,
+    "peak_rss_kib": 16832
+  },
+  "rayon_num_threads": 1,
+  "malloc_arena_max": "1",
+  "scope": "Same binary, one sequential run per input format, warm filesystem cache. Not repeated speed evidence, not an uncached-shared A/B, not E2E or full-pipeline memory.",
+  "cache_contract": "One envelope per merge pass. Validate on initial load, before eviction and at pass completion. Clear between passes. Standalone reads remain uncached. Decoding and snapshot ownership still repeat O(N) envelope work per shard."
+}

--- a/benchmarks/electro/m8-shared-writer-scaling-v1.json
+++ b/benchmarks/electro/m8-shared-writer-scaling-v1.json
@@ -1,0 +1,15 @@
+{
+  "status": "synthetic-writer-scaling-pass",
+  "binary_sha256": "1b701ca799ac1562c6a7fdadd9c76b93b8c98f42f5afe4614895a302086291c2",
+  "external_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-writer-stress-v1",
+  "seed": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-matching-replay-v1/matches/verified-000000.vps",
+  "recipe": "stress_shared_snapshot_writer SEED_SNAPSHOT IMAGE_COUNT NEW_OUTPUT_DIRECTORY",
+  "measurements": [
+    {"images": 1000, "pairs": 999, "chunks": 32, "directory_bytes": 20012094, "wall_seconds": 0.07, "peak_rss_kib": 4388, "exit_code": 0},
+    {"images": 10000, "pairs": 9999, "chunks": 313, "directory_bytes": 200292475, "wall_seconds": 0.72, "peak_rss_kib": 5184, "exit_code": 0},
+    {"images": 100000, "pairs": 99999, "chunks": 3125, "directory_bytes": 2003096487, "wall_seconds": 8.86, "peak_rss_kib": 19324, "exit_code": 0}
+  ],
+  "time_report_sha256_100000": "70762bc0ea6df6bab2d7ca6484d68bfb161e6d9c87dc785ac2eebc70ff3d9326",
+  "scope": "Prepared writer I/O only. Repeats one real pair payload on synthetic adjacent image IDs; manifests and pair hashes are synthetic placeholders. Not matching, mapping, quality, restart, or full100k SfM. Full output readback is not part of this timed writer test.",
+  "remaining": "Shared decoding still reconstructs owned N-image envelopes per shard. Optimize borrowed-envelope reading and verify forced restart and real worker output parity."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`feat/shared-snapshot-envelope`。
+現作業branchは`perf/shared-envelope-read-cache`（PR125の子）。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -61,6 +61,16 @@ Python43 tests通過。全goal未達。PR123旧branch整理と現branchのPRが�
 lib15/example64 testsとClippy通過。現形式は読書きごとにenvelopeを再検証するため
 I/O/CPUのN²解消は未達。次はbounded cache、強制中断/同時publication、worker実出力と
 100k stress。変換session79247はexit0完了。全goal未達。
+
+更新: PR125初回CIはlib testの不要cloneによるClippy警告1件で失敗。
+修正head`3b3464a`をpush済み、子branchへrebase済み。mergeは最終CI待ち。
+mergeの各passに1-entry envelope cacheを実装、load/eviction/終了時検証・pass間破棄。
+lib17 tests（並行8 writer/キャッシュeviction・変更検出を含む）通過。
+実dense2500 shardのshared/legacy入力を同binaryで統合、双方全SHA一致。
+shared10.54s/16644KiB（単発warm-cache、E2Eではない）。証跡shared-merge-cache-v1。
+両実行session58380/10776はexit0完了。standalone readはuncached。
+writer側とdecoded envelopeの反復CPU処理は未解消。次はprepared writer/borrowed envelope、
+強制中断restartとworker実出力/100k。全goal未達。空き約14GiB。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -72,6 +72,16 @@ shared10.54s/16644KiB（単発warm-cache、E2Eではない）。証跡shared-mer
 writer側とdecoded envelopeの反復CPU処理は未解消。次はprepared writer/borrowed envelope、
 強制中断restartとworker実出力/100k。全goal未達。空き約14GiB。
 
+更新: PR125修正head`3b3464a`はCI9成功後`b25c3d8ddedd0653746fd1c9db1089a85affb63d`へmerge。
+SharedSnapshotWriter/SharedPairChunkを追加し、persistent workerの明示shared出力へ組込。
+画像envelopeを1回だけ準備し、以後pairのみ書く。lib18 tests/example64 tests・tests込みClippy通過。
+合成1k/10k/100k writer stress成功、100k 99999 pairs/3125 chunks/8.86s/19324KiB。
+保存量は約20MB/200MB/2003MBで線形。seedのペアを合成隣接画像へ複製、manifest/hashは
+合成placeholder。writer-onlyで全出力readback・restart・SfM品質は未検証。
+証跡`m8-shared-writer-scaling-v1.json`、外部root`corridor1-1-m8-shared-writer-stress-v1`。
+session92952はexit0完了。空き約11GiB。次はborrowed reader、restart、実worker parity。
+現branchはcacheとprepared writerをまとめてPR化。全goal未達。
+
 ### 以前の状態（上記を優先）
 
 PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -33,9 +33,24 @@ the batch converter itself does not yet resume partially completed conversions.
 
 ## Remaining work
 
-This format removes repeated envelope storage, but currently reads and validates
-the shared envelope for every chunk. Add a bounded, explicit reader/writer
-envelope cache before claiming linear metadata I/O/CPU. Verify concurrent
-publication, forced-interruption restart, real persistent-worker output parity,
+The streaming merger now uses a one-entry envelope cache per pass. It validates
+on first load, before eviction, and at pass completion; caches are not retained
+between passes. A change fails the merge before output publication. Standalone
+reads remain uncached. The cache assumes immutable inputs within each pass and
+uses the validated bytes consistently; it is not an instantaneous file watcher.
+Memory is bounded to one serialized envelope, not one per shard. Alternating
+different envelopes can still cause misses; normal same-bank shards share one.
+
+All 2,500 real dense shards merge to the exact retained legacy output SHA with
+both shared and legacy input formats. Single warm-cache measurements were
+10.54 s / 16,644 KiB for shared input; these are not repeated speed evidence or
+an uncached-shared A/B. See `m8-dense-shared-merge-cache-v1.json`.
+Eight concurrent writers also pass the unit test with exactly one envelope and
+eight valid chunks. Missing/changed envelopes and cache eviction are tested.
+
+This does not eliminate repeated envelope decoding/owned Snapshot construction,
+nor writer-side envelope serialization/validation. Add prepared writer/borrowed
+envelope interfaces before claiming linear metadata CPU. Verify
+forced-interruption restart, real persistent-worker output parity,
 and 100k scaling before switching the native runner default. Full E2E, trajectory
 quality and whole-pipeline memory gates remain separate.

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -48,9 +48,22 @@ an uncached-shared A/B. See `m8-dense-shared-merge-cache-v1.json`.
 Eight concurrent writers also pass the unit test with exactly one envelope and
 eight valid chunks. Missing/changed envelopes and cache eviction are tested.
 
-This does not eliminate repeated envelope decoding/owned Snapshot construction,
-nor writer-side envelope serialization/validation. Add prepared writer/borrowed
-envelope interfaces before claiming linear metadata CPU. Verify
+`SharedSnapshotWriter` now prepares an envelope once and accepts only shard-local
+`SharedPairChunk` records afterward. The opt-in persistent worker uses this API
+and requires a single output directory. It validates the immutable envelope at
+preparation and at batch completion; image-index bounds and pair encoding are
+checked on each write. Standalone `write_shared_atomic` remains a convenience
+wrapper that prepares and validates for each call.
+
+The synthetic writer stress spans 1k/10k/100k image envelopes with adjacent-image
+pairs copied from one seed payload. Output sizes are 20,012,094 / 200,292,475 /
+2,003,096,487 bytes. The 100k write completed in 8.86 s, peak 19,324 KiB, with
+3,125 chunks. This is writer-only scaling, not matching, mapping, or full output
+readback. The synthetic manifest/pair hashes do not represent real input banks.
+See `m8-shared-writer-scaling-v1.json` and `stress_shared_snapshot_writer`.
+
+This does not eliminate repeated envelope decoding/owned Snapshot construction.
+Add borrowed-envelope reading before claiming linear metadata CPU. Verify
 forced-interruption restart, real persistent-worker output parity,
 and 100k scaling before switching the native runner default. Full E2E, trajectory
 quality and whole-pipeline memory gates remain separate.

--- a/examples/stress_shared_snapshot_writer.rs
+++ b/examples/stress_shared_snapshot_writer.rs
@@ -1,0 +1,77 @@
+//! Synthetic image-envelope/pair-chunk I/O scaling; not a reconstruction benchmark.
+use std::path::PathBuf;
+use visloc_rs::verified_pair_snapshot::{read, SharedPairChunk, SharedSnapshotWriter};
+
+fn main() -> Result<(), String> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 3 {
+        return Err(
+            "usage: stress_shared_snapshot_writer SEED_SNAPSHOT IMAGE_COUNT NEW_OUTPUT_DIRECTORY"
+                .into(),
+        );
+    }
+    let count = args[1]
+        .parse::<usize>()
+        .map_err(|error| error.to_string())?;
+    if !(2..=100_000).contains(&count) {
+        return Err("image count must be 2..100000".into());
+    }
+    let mut snapshot = read(&PathBuf::from(&args[0]))?;
+    let seed = snapshot
+        .pairs
+        .first()
+        .ok_or("seed needs a nonempty pair")?
+        .clone();
+    let features = *snapshot
+        .feature_counts
+        .iter()
+        .max()
+        .ok_or("seed needs images")?;
+    snapshot.image_names = (0..count)
+        .map(|index| format!("synthetic_{index:06}.png"))
+        .collect();
+    snapshot.feature_counts = vec![features; count];
+    // Synthetic metadata: these are not claimed to bind any real feature bank.
+    snapshot.image_manifest_hash = 0;
+    snapshot.feature_manifest_hash = 0;
+    snapshot.pairs.clear();
+    let output = PathBuf::from(&args[2]);
+    std::fs::create_dir(&output).map_err(|error| error.to_string())?;
+    let writer = SharedSnapshotWriter::new(&output, &snapshot)?;
+    let mut chunks = 0;
+    for start in (0..count - 1).step_by(32) {
+        let pairs = (start..(start + 32).min(count - 1))
+            .map(|index| {
+                let mut pair = seed.clone();
+                pair.image_i = index as u64;
+                pair.image_j = index as u64 + 1;
+                pair
+            })
+            .collect::<Vec<_>>();
+        let path = output.join(format!("chunk-{chunks:06}.vps"));
+        writer.write_chunk(
+            &path,
+            SharedPairChunk {
+                pair_order_hash: 0,
+                unordered_edge_hash: 0,
+                accepted_match_count: pairs.iter().map(|pair| pair.matches.len() as u64).sum(),
+                pairs: &pairs,
+            },
+        )?;
+        chunks += 1;
+    }
+    writer.finish()?;
+    let bytes = std::fs::read_dir(&output)
+        .map_err(|error| error.to_string())?
+        .map(|entry| {
+            entry
+                .and_then(|entry| entry.metadata())
+                .map(|metadata| metadata.len())
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .sum::<u64>();
+    println!("synthetic images={count} pairs={} chunks={chunks} directory_bytes={bytes}; writer I/O only, no SfM or quality claim", count - 1);
+    Ok(())
+}

--- a/examples/unordered_sfm_demo.rs
+++ b/examples/unordered_sfm_demo.rs
@@ -8710,6 +8710,33 @@ fn write_verified_pair_snapshot_with_validation(
     feature_validation: Option<&SnapshotFeatureValidation>,
     atomic: bool,
 ) -> Result<(), String> {
+    let snapshot = snapshot_for_export(
+        image_names,
+        features,
+        camera,
+        pairwise,
+        metadata_by_pair,
+        args,
+        feature_validation,
+    )?;
+    if args.shared_snapshot_envelope {
+        verified_pair_snapshot::write_shared_atomic(path, &snapshot)
+    } else if atomic {
+        verified_pair_snapshot::write_atomic(path, &snapshot)
+    } else {
+        verified_pair_snapshot::write(path, &snapshot)
+    }
+}
+
+fn snapshot_for_export(
+    image_names: &[String],
+    features: &[FeatureSet],
+    camera: &Camera,
+    pairwise: &[PairwiseMatches],
+    metadata_by_pair: &HashMap<(usize, usize), SnapshotPairMetadata>,
+    args: &Args,
+    feature_validation: Option<&SnapshotFeatureValidation>,
+) -> Result<VerifiedPairSnapshot, String> {
     let feature_counts: Vec<u64> = feature_validation
         .map(|validation| {
             validation
@@ -8768,13 +8795,7 @@ fn write_verified_pair_snapshot_with_validation(
             .sum::<usize>() as u64,
         pairs: records,
     };
-    if args.shared_snapshot_envelope {
-        verified_pair_snapshot::write_shared_atomic(path, &snapshot)
-    } else if atomic {
-        verified_pair_snapshot::write_atomic(path, &snapshot)
-    } else {
-        verified_pair_snapshot::write(path, &snapshot)
-    }
+    Ok(snapshot)
 }
 
 fn vector_from_bits(bits: Option<[u64; 3]>) -> Option<Vector3<f64>> {
@@ -9060,6 +9081,35 @@ fn run_persistent_match_worker(
     let mut stream_resident_rows = 0usize;
     let mut stream_peak_resident_rows = 0usize;
     let mut stream_peak_resident_images = 0usize;
+    let shared_writer = if args.shared_snapshot_envelope {
+        let first = plan
+            .shards
+            .first()
+            .ok_or("shared snapshot worker requires a shard")?;
+        let path = plan.root.join(&first.snapshot_path);
+        let directory = path.parent().ok_or("shared snapshot directory missing")?;
+        if plan
+            .shards
+            .iter()
+            .any(|shard| plan.root.join(&shard.snapshot_path).parent() != Some(directory))
+        {
+            return Err("shared snapshot worker requires one output directory".into());
+        }
+        let envelope = snapshot_for_export(
+            image_names,
+            features,
+            camera,
+            &[],
+            &HashMap::new(),
+            args,
+            Some(feature_validation),
+        )?;
+        Some(verified_pair_snapshot::SharedSnapshotWriter::new(
+            directory, &envelope,
+        )?)
+    } else {
+        None
+    };
     for shard in &plan.shards {
         let candidate_path = plan.root.join(&shard.candidate_path);
         let (candidates, _candidate_metadata) = parse_persistent_candidate_manifest(
@@ -9139,16 +9189,43 @@ fn run_persistent_match_worker(
         let ordered_hash = ordered_pairwise_edge_hash(&pairwise);
         let unordered_hash = edge_hash_after;
         let snapshot_path = plan.root.join(&shard.snapshot_path);
-        write_verified_pair_snapshot_atomic(
-            &snapshot_path,
-            image_names,
-            features,
-            camera,
-            &pairwise,
-            &metadata,
-            args,
-            feature_validation,
-        )?;
+        if let Some(writer) = &shared_writer {
+            let records = pairwise
+                .iter()
+                .map(|pair| {
+                    let key = (
+                        pair.image_i.min(pair.image_j),
+                        pair.image_i.max(pair.image_j),
+                    );
+                    snapshot_pair_record(
+                        pair,
+                        metadata
+                            .get(&key)
+                            .filter(|metadata| snapshot_metadata_matches_pair(pair, metadata)),
+                    )
+                })
+                .collect::<Vec<_>>();
+            writer.write_chunk(
+                &snapshot_path,
+                verified_pair_snapshot::SharedPairChunk {
+                    pair_order_hash: ordered_hash,
+                    unordered_edge_hash: unordered_hash,
+                    accepted_match_count: accepted as u64,
+                    pairs: &records,
+                },
+            )?;
+        } else {
+            write_verified_pair_snapshot_atomic(
+                &snapshot_path,
+                image_names,
+                features,
+                camera,
+                &pairwise,
+                &metadata,
+                args,
+                feature_validation,
+            )?;
+        }
         let elapsed = started.elapsed().as_secs_f64();
         writeln!(
             stdout,
@@ -9182,6 +9259,9 @@ fn run_persistent_match_worker(
             stream_stamps[image] = None;
         }
         trim_process_allocator();
+    }
+    if let Some(writer) = &shared_writer {
+        writer.finish()?;
     }
     if stream_sources.is_some() {
         writeln!(

--- a/scripts/replay_shared_snapshot_merge.py
+++ b/scripts/replay_shared_snapshot_merge.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Merge shared-envelope shards and compare the full legacy reference bytes."""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+
+from benchmark_electro import parse_gnu_time
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--shards', type=Path, required=True)
+    parser.add_argument('--reference', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve(strict=True)
+    paths = sorted(args.shards.resolve(strict=True).glob('*.vps'))
+    if not paths:
+        parser.error('No shards')
+    reference_sha = sha(args.reference)
+    output = args.output.resolve()
+    output.mkdir()
+    if any(any(char.isspace() for char in str(path)) for path in paths):
+        parser.error('Snapshot-list format does not support whitespace in paths')
+    listing = output / 'snapshots.txt'
+    listing.write_text(''.join(str(path) + '\n' for path in paths))
+    command = [str(binary), '--output', str(output / 'merged.vps'), '--snapshot-list', str(listing)]
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '180s', *command]
+    report = {'status': 'running', 'binary_sha256': sha(binary),
+              'shards': len(paths), 'reference_sha256': reference_sha,
+              'command': invocation, 'rayon_num_threads': 1, 'malloc_arena_max': '1'}
+    report_path = output / 'report.json'
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, stdout=log, stderr=subprocess.STDOUT,
+                                env=dict(os.environ, RAYON_NUM_THREADS='1', MALLOC_ARENA_MAX='1'))
+    actual = sha(output / 'merged.vps') if (output / 'merged.vps').exists() else None
+    report.update(exit_code=result.returncode, output_sha256=actual,
+                  measurement=parse_gnu_time(output / 'time.txt'),
+                  status='pass' if result.returncode == 0 and actual == reference_sha else 'fail')
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps({key: value for key, value in report.items() if key != 'command'}, indent=2))
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub const SCHEMA_VERSION: u32 = 1;
 
 mod shared;
-pub use shared::write_shared_atomic;
+pub use shared::{write_shared_atomic, SharedPairChunk, SharedSnapshotWriter};
 
 const MAGIC: &[u8] = b"VISLOC-VERIFIED-PAIR-SNAPSHOT\0";
 const MAX_VECTOR_ITEMS: usize = 50_000_000;
@@ -1686,6 +1686,43 @@ mod tests {
             "visloc_verified_pair_snapshot_{tag}_{}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn prepared_shared_writer_preserves_chunks_and_rejects_wrong_directory() {
+        let root = temp_path("prepared_shared");
+        std::fs::create_dir(&root).unwrap();
+        let snapshot = sample();
+        let writer = super::SharedSnapshotWriter::new(&root, &snapshot).unwrap();
+        for index in 0..3 {
+            let path = root.join(format!("{index}.vps"));
+            writer
+                .write_chunk(
+                    &path,
+                    super::SharedPairChunk {
+                        pair_order_hash: snapshot.pair_order_hash,
+                        unordered_edge_hash: snapshot.unordered_edge_hash,
+                        accepted_match_count: snapshot.accepted_match_count,
+                        pairs: &snapshot.pairs,
+                    },
+                )
+                .unwrap();
+            assert_eq!(read(&path).unwrap(), snapshot);
+        }
+        assert!(writer
+            .write_chunk(
+                &root.join("elsewhere/0.vps"),
+                super::SharedPairChunk {
+                    pair_order_hash: 0,
+                    unordered_edge_hash: 0,
+                    accepted_match_count: 0,
+                    pairs: &[],
+                }
+            )
+            .is_err());
+        writer.finish().unwrap();
+        assert_eq!(std::fs::read_dir(&root).unwrap().count(), 4);
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -466,8 +466,9 @@ fn write_streamed_merge_temp(
         let mut pair_cursor = 0usize;
         let mut encoded_pair_bytes = 0u64;
         let mut accepted_match_count = 0u64;
+        let mut envelope_cache = shared::EnvelopeCache::default();
         for (shard_index, path) in input_paths.iter().enumerate() {
-            let snapshot = read(path)?;
+            let snapshot = read_with_cache(path, true, None, Some(&mut envelope_cache))?;
             validate_merge_envelope(shard_index, &snapshot, first)?;
             for pair in &snapshot.pairs {
                 let expected = expected_pairs.get(pair_cursor).ok_or_else(|| {
@@ -500,6 +501,7 @@ fn write_streamed_merge_temp(
                 pair_cursor += 1;
             }
         }
+        envelope_cache.finish()?;
         if pair_cursor != expected_pairs.len() {
             return Err(format!(
                 "merge inputs contain {pair_cursor} pairs but validation found {}",
@@ -638,8 +640,9 @@ pub fn merge_files_atomic<P: AsRef<Path>>(output: &Path, inputs: &[P]) -> Result
     let mut pair_count = 0u64;
     let mut pair_payload_bytes = 0u64;
     let mut accepted_match_count = 0u64;
+    let mut envelope_cache = shared::EnvelopeCache::default();
     for (shard_index, path) in input_paths.iter().enumerate() {
-        let snapshot = read(path)?;
+        let snapshot = read_with_cache(path, true, None, Some(&mut envelope_cache))?;
         if let Some(first_snapshot) = first.as_ref() {
             validate_merge_envelope(shard_index, &snapshot, first_snapshot)?;
         } else {
@@ -704,6 +707,7 @@ pub fn merge_files_atomic<P: AsRef<Path>>(output: &Path, inputs: &[P]) -> Result
             });
         }
     }
+    envelope_cache.finish()?;
     edge_writer
         .flush()
         .map_err(|error| format!("flush merge edge spool {}: {error}", edge_path.display()))?;
@@ -1494,6 +1498,15 @@ fn read_with_retention(
     retain_audit_streams: bool,
     mapper_match_limit: Option<usize>,
 ) -> Result<Snapshot, String> {
+    read_with_cache(path, retain_audit_streams, mapper_match_limit, None)
+}
+
+fn read_with_cache(
+    path: &Path,
+    retain_audit_streams: bool,
+    mapper_match_limit: Option<usize>,
+    cache: Option<&mut shared::EnvelopeCache>,
+) -> Result<Snapshot, String> {
     let header_len = MAGIC.len() + 4 + 8;
     let mut file =
         std::fs::File::open(path).map_err(|error| format!("read {}: {error}", path.display()))?;
@@ -1511,7 +1524,7 @@ fn read_with_retention(
     file.read_exact(&mut magic)
         .map_err(|error| format!("read {} header: {error}", path.display()))?;
     if magic.starts_with(shared::MAGIC) {
-        return shared::read(path, retain_audit_streams, mapper_match_limit);
+        return shared::read(path, retain_audit_streams, mapper_match_limit, cache);
     }
     if magic != MAGIC {
         return Err(format!(
@@ -1673,6 +1686,63 @@ mod tests {
             "visloc_verified_pair_snapshot_{tag}_{}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn shared_envelope_cache_is_bounded_and_revalidates_changes() {
+        let root = temp_path("shared_cache");
+        std::fs::create_dir(&root).unwrap();
+        let snapshot = sample();
+        let path = root.join("first.vps");
+        super::write_shared_atomic(&path, &snapshot).unwrap();
+        let mut cache = super::shared::EnvelopeCache::default();
+        for _ in 0..8 {
+            assert_eq!(
+                super::read_with_cache(&path, true, None, Some(&mut cache)).unwrap(),
+                snapshot
+            );
+        }
+        assert_eq!(cache.loads, 1);
+        let mut other = snapshot.clone();
+        other.image_manifest_hash += 1;
+        let second = root.join("second.vps");
+        super::write_shared_atomic(&second, &other).unwrap();
+        assert_eq!(
+            super::read_with_cache(&second, true, None, Some(&mut cache)).unwrap(),
+            other
+        );
+        assert_eq!(cache.loads, 2);
+        assert_eq!(
+            super::read_with_cache(&path, true, None, Some(&mut cache)).unwrap(),
+            snapshot
+        );
+        assert_eq!(cache.loads, 3); // Previous envelope was evicted, not accumulated.
+        for entry in std::fs::read_dir(&root).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().is_some_and(|extension| extension == "vpe") {
+                std::fs::write(path, b"corrupt").unwrap();
+            }
+        }
+        assert!(cache.finish().unwrap_err().contains("changed"));
+        assert!(super::read_with_cache(&path, true, None, Some(&mut cache)).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn shared_envelope_concurrent_publication_is_exact() {
+        let root = temp_path("shared_concurrent");
+        std::fs::create_dir(&root).unwrap();
+        std::thread::scope(|scope| {
+            for index in 0..8 {
+                let path = root.join(format!("{index}.vps"));
+                scope.spawn(move || super::write_shared_atomic(&path, &sample()).unwrap());
+            }
+        });
+        assert_eq!(std::fs::read_dir(&root).unwrap().count(), 9);
+        for index in 0..8 {
+            assert_eq!(read(&root.join(format!("{index}.vps"))).unwrap(), sample());
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/verified_pair_snapshot/shared.rs
+++ b/src/verified_pair_snapshot/shared.rs
@@ -1,6 +1,68 @@
 //! Content-addressed envelope storage. Legacy v1 payload encoding is unchanged.
 use super::*;
 use sha2::{Digest, Sha256};
+use std::sync::Arc;
+
+struct CachedEnvelope {
+    path: PathBuf,
+    digest: [u8; 32],
+    bytes: Arc<[u8]>,
+}
+
+/// One-entry cache scoped to a single immutable-input merge pass. Revalidate
+/// before eviction and before accepting the pass, never across merge passes.
+#[derive(Default)]
+pub(super) struct EnvelopeCache {
+    entry: Option<CachedEnvelope>,
+    pub(super) loads: usize,
+}
+
+impl EnvelopeCache {
+    pub(super) fn finish(&mut self) -> Result<(), String> {
+        if let Some(entry) = self.entry.take() {
+            let mut file = std::fs::File::open(&entry.path)
+                .map_err(|error| format!("revalidate shared envelope: {error}"))?;
+            let mut hasher = Sha256::new();
+            let mut buffer = vec![0u8; 64 * 1024];
+            loop {
+                let count = file.read(&mut buffer).map_err(|error| error.to_string())?;
+                if count == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..count]);
+            }
+            if hasher.finalize()[..] != entry.digest {
+                return Err("shared envelope changed during cached merge pass".to_owned());
+            }
+        }
+        Ok(())
+    }
+
+    fn get(&mut self, path: PathBuf, digest: [u8; 32]) -> Result<Arc<[u8]>, String> {
+        if let Some(entry) = &self.entry {
+            if entry.path == path && entry.digest == digest {
+                return Ok(Arc::clone(&entry.bytes));
+            }
+        }
+        self.finish()?;
+        let bytes = load_envelope(&path, &digest)?;
+        self.loads += 1;
+        self.entry = Some(CachedEnvelope {
+            path,
+            digest,
+            bytes: Arc::clone(&bytes),
+        });
+        Ok(bytes)
+    }
+}
+
+fn load_envelope(path: &Path, digest: &[u8; 32]) -> Result<Arc<[u8]>, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("read shared envelope: {error}"))?;
+    if Sha256::digest(&bytes)[..] != *digest {
+        return Err("shared envelope SHA-256 mismatch".to_owned());
+    }
+    Ok(bytes.into())
+}
 
 pub(super) const MAGIC: &[u8] = b"VISLOC-PAIR-CHUNK-V1\0";
 
@@ -91,7 +153,12 @@ pub fn write_shared_atomic(path: &Path, snapshot: &Snapshot) -> Result<(), Strin
     std::fs::rename(&temporary.path, path).map_err(|error| format!("publish chunk: {error}"))
 }
 
-pub(super) fn read(path: &Path, retain: bool, cap: Option<usize>) -> Result<Snapshot, String> {
+pub(super) fn read(
+    path: &Path,
+    retain: bool,
+    cap: Option<usize>,
+    cache: Option<&mut EnvelopeCache>,
+) -> Result<Snapshot, String> {
     let mut file = std::fs::File::open(path).map_err(|error| error.to_string())?;
     let length = file.metadata().map_err(|error| error.to_string())?.len();
     let header_len = MAGIC.len() as u64 + 32 + 8;
@@ -110,11 +177,11 @@ pub(super) fn read(path: &Path, retain: bool, cap: Option<usize>) -> Result<Snap
     {
         return Err("shared chunk length mismatch".to_owned());
     }
-    let envelope = std::fs::read(envelope_path(parent(path), &digest))
-        .map_err(|error| format!("read shared envelope: {error}"))?;
-    if Sha256::digest(&envelope)[..] != digest {
-        return Err("shared envelope SHA-256 mismatch".to_owned());
-    }
+    let envelope_path = envelope_path(parent(path), &digest);
+    let envelope = match cache {
+        Some(cache) => cache.get(envelope_path, digest)?,
+        None => load_envelope(&envelope_path, &digest)?,
+    };
     let mut remaining = suffix_len;
     let mut checksum = 0xcbf29ce484222325u64;
     for byte in &digest {

--- a/src/verified_pair_snapshot/shared.rs
+++ b/src/verified_pair_snapshot/shared.rs
@@ -85,72 +85,139 @@ fn parent(path: &Path) -> &Path {
 /// Existing legacy writers remain unchanged. This reduces serialized storage;
 /// callers still need an envelope cache to avoid repeated envelope reads.
 pub fn write_shared_atomic(path: &Path, snapshot: &Snapshot) -> Result<(), String> {
-    let mut prefix = Vec::new();
-    encode_payload_prefix(
-        snapshot,
-        snapshot.pair_order_hash,
-        snapshot.unordered_edge_hash,
-        snapshot.accepted_match_count,
-        snapshot.pairs.len() as u64,
-        &mut prefix,
+    let writer = SharedSnapshotWriter::new(parent(path), snapshot)?;
+    writer.write_chunk(
+        path,
+        SharedPairChunk {
+            pair_order_hash: snapshot.pair_order_hash,
+            unordered_edge_hash: snapshot.unordered_edge_hash,
+            accepted_match_count: snapshot.accepted_match_count,
+            pairs: &snapshot.pairs,
+        },
     )?;
-    let split = prefix
-        .len()
-        .checked_sub(32)
-        .ok_or("invalid snapshot prefix")?;
-    let envelope = &prefix[..split];
-    let digest = Sha256::digest(envelope);
-    let directory = parent(path);
-    std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
-    let envelope_destination = envelope_path(directory, &digest);
-    if !envelope_destination.exists() {
-        let (temporary, mut file) = create_merge_temporary_file(directory, "envelope", "shared")?;
-        file.write_all(envelope)
-            .and_then(|()| file.sync_all())
-            .map_err(|error| error.to_string())?;
-        // Atomic create-if-absent, including concurrent workers using the same envelope.
-        match std::fs::hard_link(&temporary.path, &envelope_destination) {
-            Ok(()) => (),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (),
-            Err(error) => return Err(format!("publish envelope: {error}")),
+    writer.finish()
+}
+
+/// Shard-local data referring to the immutable envelope supplied at preparation.
+pub struct SharedPairChunk<'a> {
+    pub pair_order_hash: u64,
+    pub unordered_edge_hash: u64,
+    pub accepted_match_count: u64,
+    pub pairs: &'a [PairRecord],
+}
+
+/// Prepare and publish an envelope once, then stream shard-local records only.
+/// Call `finish` before declaring the batch complete. The output directory must
+/// remain immutable except for this writer's chunk publications.
+pub struct SharedSnapshotWriter {
+    directory: PathBuf,
+    digest: [u8; 32],
+    image_count: usize,
+}
+
+impl SharedSnapshotWriter {
+    pub fn new(directory: &Path, snapshot: &Snapshot) -> Result<Self, String> {
+        let mut prefix = Vec::new();
+        encode_payload_prefix(
+            snapshot,
+            snapshot.pair_order_hash,
+            snapshot.unordered_edge_hash,
+            snapshot.accepted_match_count,
+            snapshot.pairs.len() as u64,
+            &mut prefix,
+        )?;
+        let split = prefix
+            .len()
+            .checked_sub(32)
+            .ok_or("invalid snapshot prefix")?;
+        let envelope = &prefix[..split];
+        let digest = Sha256::digest(envelope);
+        std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+        let envelope_destination = envelope_path(directory, &digest);
+        if !envelope_destination.exists() {
+            let (temporary, mut file) =
+                create_merge_temporary_file(directory, "envelope", "shared")?;
+            file.write_all(envelope)
+                .and_then(|()| file.sync_all())
+                .map_err(|error| error.to_string())?;
+            // Atomic create-if-absent, including concurrent workers using the same envelope.
+            match std::fs::hard_link(&temporary.path, &envelope_destination) {
+                Ok(()) => (),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (),
+                Err(error) => return Err(format!("publish envelope: {error}")),
+            }
         }
+        // Never replace a corrupt file at a content-addressed name.
+        if std::fs::read(&envelope_destination).map_err(|error| error.to_string())? != envelope {
+            return Err("existing shared envelope content mismatch".to_owned());
+        }
+        Ok(Self {
+            directory: directory.to_path_buf(),
+            digest: digest.into(),
+            image_count: snapshot.image_names.len(),
+        })
     }
-    // Never replace a corrupt file at a content-addressed name.
-    if std::fs::read(&envelope_destination).map_err(|error| error.to_string())? != envelope {
-        return Err("existing shared envelope content mismatch".to_owned());
+
+    pub fn finish(&self) -> Result<(), String> {
+        load_envelope(&envelope_path(&self.directory, &self.digest), &self.digest)?;
+        Ok(())
     }
-    let suffix_len = payload_len(snapshot)?
-        .checked_sub(split as u64)
-        .ok_or("invalid suffix size")?;
-    let (temporary, file) = create_merge_temporary_file(directory, "chunk", "shared")?;
-    let mut writer = BufWriter::new(file);
-    writer
-        .write_all(MAGIC)
-        .and_then(|()| writer.write_all(&digest))
-        .and_then(|()| writer.write_all(&suffix_len.to_le_bytes()))
-        .map_err(|error| error.to_string())?;
-    let mut payload = PayloadDigestWriter::new(&mut writer);
-    for byte in &digest {
-        payload.checksum ^= u64::from(*byte);
-        payload.checksum = payload.checksum.wrapping_mul(0x100000001b3);
+
+    pub fn write_chunk(&self, path: &Path, chunk: SharedPairChunk<'_>) -> Result<(), String> {
+        if parent(path) != self.directory
+            || path.file_name().is_none()
+            || path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("envelope-"))
+        {
+            return Err(
+                "shared chunk must be a non-envelope file in the prepared directory".to_owned(),
+            );
+        }
+        let directory = &self.directory;
+        let digest = &self.digest;
+        let mut suffix_len = 32u64;
+        for pair in chunk.pairs {
+            validate_merge_pair(pair, self.image_count)?;
+            suffix_len = suffix_len
+                .checked_add(pair_payload_len(pair)?)
+                .ok_or("shared chunk size overflow")?;
+        }
+        let (temporary, file) = create_merge_temporary_file(directory, "chunk", "shared")?;
+        let mut writer = BufWriter::new(file);
+        writer
+            .write_all(MAGIC)
+            .and_then(|()| writer.write_all(digest))
+            .and_then(|()| writer.write_all(&suffix_len.to_le_bytes()))
+            .map_err(|error| error.to_string())?;
+        let mut payload = PayloadDigestWriter::new(&mut writer);
+        for byte in digest {
+            payload.checksum ^= u64::from(*byte);
+            payload.checksum = payload.checksum.wrapping_mul(0x100000001b3);
+        }
+        for value in [
+            chunk.pair_order_hash,
+            chunk.unordered_edge_hash,
+            chunk.accepted_match_count,
+            chunk.pairs.len() as u64,
+        ] {
+            put_u64(&mut payload, value)?;
+        }
+        for pair in chunk.pairs {
+            encode_pair(pair, &mut payload)?;
+        }
+        if payload.len != suffix_len {
+            return Err("shared chunk length mismatch".to_owned());
+        }
+        let checksum = payload.checksum;
+        writer
+            .write_all(&checksum.to_le_bytes())
+            .and_then(|()| writer.flush())
+            .and_then(|()| writer.get_ref().sync_all())
+            .map_err(|error| error.to_string())?;
+        drop(writer);
+        std::fs::rename(&temporary.path, path).map_err(|error| format!("publish chunk: {error}"))
     }
-    payload
-        .write_all(&prefix[split..])
-        .map_err(|error| error.to_string())?;
-    for pair in &snapshot.pairs {
-        encode_pair(pair, &mut payload)?;
-    }
-    if payload.len != suffix_len {
-        return Err("shared chunk length mismatch".to_owned());
-    }
-    let checksum = payload.checksum;
-    writer
-        .write_all(&checksum.to_le_bytes())
-        .and_then(|()| writer.flush())
-        .and_then(|()| writer.get_ref().sync_all())
-        .map_err(|error| error.to_string())?;
-    drop(writer);
-    std::fs::rename(&temporary.path, path).map_err(|error| format!("publish chunk: {error}"))
 }
 
 pub(super) fn read(


### PR DESCRIPTION
## Summary
- Bound merge envelope caching to one entry per pass, validating before eviction and pass completion; standalone readers remain uncached.
- Add a prepared shared writer and use it in the opt-in persistent matching worker so per-shard output handles pair records only.
- Add concurrency, cache mutation/eviction, and prepared writer tests plus reproducible merge/scaling evidence.

## Validation
- 18 library snapshot tests, 64 SfM example tests, Python suite 43 passed.
- Clippy includes library tests and affected examples, warnings denied.
- Real 2500-shard shared and legacy merges both reproduce the complete reference SHA. One warm-cache run: 10.54s shared / 13.95s legacy, not repeated E2E evidence.
- Synthetic writer: 1k/10k/100k images with linear output growth. 100k: 99999 pairs, 3125 chunks, 8.86s, peak19324KiB. Writer-only; not full output readback or SfM.

## Remaining
Owned envelope decoding still repeats per shard. Borrowed reading, forced restart, actual prepared-worker output parity and full native E2E/COLMAP quality remain open. Defaults unchanged.