### PR TITLE
test: verify prepared shared writer through real matching worker

### DIFF
--- a/benchmarks/electro/m8-shared-worker-probe-v1.json
+++ b/benchmarks/electro/m8-shared-worker-probe-v1.json
@@ -1,0 +1,18 @@
+{
+  "status": "selected-real-worker-shards-full-record-parity-pass",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-worker-probe-v1/report.json",
+  "binary_sha256": "b02f85ecce56074e000d77a6bbd63242b3d0f568294f9c22fcc9a2dc4ca01c50",
+  "compare_binary_sha256": "1180dc17ec811c5a5ceb1a90ae893a4c668354e8e95b2eefcd6508b610af55d9",
+  "shard_ids": [0, 357, 714, 1071, 1428, 1785, 2142, 2499],
+  "candidate_pairs": 256,
+  "feature_images": 10000,
+  "plan_sha256": "007ac7326102f5cdb02bcb17a0b79a9a420caad82a8c2cb16f95eeb92f5fdb94",
+  "reference_plan_sha256": "cb8005bd13fa6f490123efeaa0b36f0d3e0a0890309c641d34964e1cfc010d2a",
+  "feature_manifest_sha256": "9a58c1dd0699e72ed52149096cf17e85ee894ffaaf9d55772a1eb6b1c3d95ce2",
+  "membership_matches": true,
+  "worker_exit_code": 0,
+  "comparison_exit_code": 0,
+  "peak_rss_kib": 451184,
+  "time_report_sha256": "501723694c8d5b082a0486d8379ae9bac34e0faa206b39db6e138c48b65f13e0",
+  "scope": "Eight spread-out real matching shards using the full retained 10k feature bank. Every decoded output record matches its legacy reference. Not all2500-shard matching, extraction, restart, or continuous E2E."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -92,6 +92,15 @@ session92952はexit0完了。空き約11GiB。次はborrowed reader、restart、
 同sessionをpollし、観測timeoutだけで再起動しない。稼働中は同時build/性能測定を避ける。
 Python43 tests/比較example Clippy通過。PR126旧branch整理とprobe結果の記録が次。
 
+更新: PR126旧branchはremote/local整理済み。8-shard probe session55995はexit0完了、
+出力membershipと全Snapshotレコードが従来8 shardと一致。peak451184KiB。
+証跡`m8-shared-worker-probe-v1.json`。保存binaryはprobe rootのsfm-b02f85e/compare-1180dc1。
+続いて全2500 shard/80000候補の共有形式workerを開始、exec session60175。
+出力root`/home/sasaki/datasets/openloris/corridor1-1-m8-shared-worker-full-v1`、timeout1800秒。
+全件の終了/一致は未判定。完了後report.jsonのexit/membership/比較を確認する。
+同sessionをpollし、観測timeoutで再起動しない。保存binary使用、同時build/測定なし。
+全goal未達。full worker後もborrowed reader/restart/抽出E2E/COLMAP品質は残る。
+
 ### 以前の状態（上記を優先）
 
 PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`perf/shared-envelope-read-cache`（PR125の子）。
+現作業branchは`test/shared-worker-parity`。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -81,6 +81,16 @@ SharedSnapshotWriter/SharedPairChunkを追加し、persistent workerの明示sha
 証跡`m8-shared-writer-scaling-v1.json`、外部root`corridor1-1-m8-shared-writer-stress-v1`。
 session92952はexit0完了。空き約11GiB。次はborrowed reader、restart、実worker parity。
 現branchはcacheとprepared writerをまとめてPR化。全goal未達。
+
+更新: PR126はhead`e3312fd`でCI9成功後`70f221d69ce4ac53a9d08b701ae421ba2ea7afed`へmerge。
+実workerの8-shard probeを開始。`scripts/probe_shared_match_worker.py`で10k dense特徴の
+全manifestと候補hashを検証し、全scheduleから等間隔8 shardを共有形式で再matching。
+完了後`compare_verified_pair_snapshots`で従来shardの全レコードと比較する。
+現在exec session55995、worker PID3573965で稼働確認（elapsed2:16/CPU2:15、RSS451512KiB）。
+出力root`/home/sasaki/datasets/openloris/corridor1-1-m8-shared-worker-probe-v1`。
+まだ完了/一致とは判定していない。初期全10k特徴読込・検証中。timeout1800秒。
+同sessionをpollし、観測timeoutだけで再起動しない。稼働中は同時build/性能測定を避ける。
+Python43 tests/比較example Clippy通過。PR126旧branch整理とprobe結果の記録が次。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -46,6 +46,11 @@ by that comparison utility; the probe enforces candidate membership separately.
 Use `--shards 2500` to cover the entire retained dense schedule. This is matching
 parity, not extraction or continuous native E2E.
 
+The first eight-shard probe passed: IDs 0, 357, 714, 1071, 1428, 1785, 2142,
+2499, covering 256 candidate pairs with the full 10k feature bank. Exact output
+membership and every decoded snapshot record match the retained legacy shards.
+Worker peak RSS was 451,184 KiB. Evidence: `m8-shared-worker-probe-v1.json`.
+
 ## Remaining work
 
 The streaming merger now uses a one-entry envelope cache per pass. It validates

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -31,6 +31,21 @@ The converter retains one input/output shard at a time. It does not replace or
 delete inputs and refuses an existing destination. The writer supports retry;
 the batch converter itself does not yet resume partially completed conversions.
 
+## Real worker parity probe
+
+`scripts/probe_shared_match_worker.py --binary SFM_BINARY --compare-binary
+COMPARE_BINARY --output NEW_DIRECTORY --shards 8` uses the retained dense
+candidate plan and feature bank, selecting evenly spaced shard IDs. It preserves
+the full image order and upstream candidate-index binding, but generates a subset
+plan with the selected pair/shard counts. Input candidate hashes and the full
+feature manifest are checked before running the worker with
+`--shared-snapshot-envelope`. Output membership must match exactly, and
+`compare_verified_pair_snapshots` checks full decoded record equality against
+each corresponding legacy shard. Reference-only shards are intentionally allowed
+by that comparison utility; the probe enforces candidate membership separately.
+Use `--shards 2500` to cover the entire retained dense schedule. This is matching
+parity, not extraction or continuous native E2E.
+
 ## Remaining work
 
 The streaming merger now uses a one-entry envelope cache per pass. It validates

--- a/examples/compare_verified_pair_snapshots.rs
+++ b/examples/compare_verified_pair_snapshots.rs
@@ -1,0 +1,32 @@
+//! Compare every snapshot record in a candidate directory with its reference.
+use std::path::PathBuf;
+use visloc_rs::verified_pair_snapshot::read;
+
+fn main() -> Result<(), String> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        return Err(
+            "usage: compare_verified_pair_snapshots CANDIDATE_DIRECTORY REFERENCE_DIRECTORY".into(),
+        );
+    }
+    let candidate = PathBuf::from(&args[0]);
+    let reference = PathBuf::from(&args[1]);
+    let mut paths = std::fs::read_dir(candidate)
+        .map_err(|error| error.to_string())?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    paths.retain(|path| path.extension().is_some_and(|extension| extension == "vps"));
+    paths.sort();
+    if paths.is_empty() {
+        return Err("no candidate snapshots".into());
+    }
+    for path in &paths {
+        let reference = reference.join(path.file_name().ok_or("missing filename")?);
+        if read(path)? != read(&reference)? {
+            return Err(format!("snapshot record mismatch: {}", path.display()));
+        }
+    }
+    println!("PASS: {} candidate snapshots match all reference records (reference may contain additional shards)", paths.len());
+    Ok(())
+}

--- a/scripts/probe_shared_match_worker.py
+++ b/scripts/probe_shared_match_worker.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Replay spread-out dense matching shards through the prepared shared writer."""
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+
+from benchmark_electro import parse_gnu_time, validate_feature_manifest
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--compare-binary', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--shards', type=int, default=8)
+    args = parser.parse_args()
+    base = Path('/home/sasaki/datasets/openloris')
+    reference = base / 'corridor1-1-m8-dense-matching-replay-v1'
+    original = base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1'
+    features = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
+    binary = args.binary.resolve(strict=True)
+    compare = args.compare_binary.resolve(strict=True)
+    lines = (reference / 'match-worker.plan').read_text().splitlines()
+    rows = [line for line in lines if line.startswith('shard ')]
+    if not 2 <= args.shards <= len(rows):
+        parser.error('--shards must be 2..2500')
+    selected = [rows[index * (len(rows) - 1) // (args.shards - 1)] for index in range(args.shards)]
+    validate_feature_manifest(original / 'features.json', features)
+    output = args.output.resolve()
+    output.mkdir()
+    (output / 'candidates').mkdir()
+    (output / 'matches').mkdir()
+    for row in selected:
+        fields = row.split()
+        if len(fields) != 5 or fields[2] != f'candidates/candidate-{int(fields[1]):06d}.txt' or fields[3] != f'matches/verified-{int(fields[1]):06d}.vps':
+            raise RuntimeError('Unsafe or unexpected shard paths')
+        source = reference / fields[2]
+        if sha(source) != fields[4]:
+            raise RuntimeError('Retained candidate shard changed')
+        if 'pairs 32' not in source.read_text().splitlines():
+            raise RuntimeError('Expected 32-pair shards')
+        shutil.copyfile(source, output / fields[2])
+    plan = [f'pairs {32 * args.shards}' if line.startswith('pairs ') else
+            f'shards {args.shards}' if line.startswith('shards ') else line
+            for line in lines if not line.startswith('shard ')] + selected
+    (output / 'match-worker.plan').write_text('\n'.join(plan) + '\n')
+    recipe = original / 'timing/persistent-match.time.txt'
+    command = shlex.split(shlex.split(recipe.read_text().splitlines()[0].split('Command being timed: ', 1)[1])[0])
+    command[0] = str(binary)
+    if '--stream-match-features' not in command:
+        raise RuntimeError('Missing streaming matching recipe')
+    for flag, path in [('--persistent-match-worker-plan', output / 'match-worker.plan'),
+                       ('--features-dir', features), ('--out-colmap', output / 'unused-model')]:
+        command[command.index(flag) + 1] = str(path)
+    command.append('--shared-snapshot-envelope')
+    invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
+                  'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
+    report = {'status': 'running', 'command': invocation, 'binary_sha256': sha(binary),
+              'compare_binary_sha256': sha(compare), 'shard_ids': [int(row.split()[1]) for row in selected],
+              'plan_sha256': sha(output / 'match-worker.plan'),
+              'reference_plan_sha256': sha(reference / 'match-worker.plan'),
+              'feature_manifest_sha256': sha(original / 'features.json'),
+              'scope': 'Selected real matching shards; not full10k matching unless all2500 requested, not E2E.'}
+    report_path = output / 'report.json'
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    with (output / 'run.log').open('w') as log:
+        result = subprocess.run(invocation, stdout=log, stderr=subprocess.STDOUT,
+                                env=dict(os.environ, RAYON_NUM_THREADS='4', MALLOC_ARENA_MAX='1'))
+    expected = {Path(row.split()[3]).name for row in selected}
+    actual = {path.name for path in (output / 'matches').glob('*.vps')}
+    comparison = None
+    if result.returncode == 0 and expected == actual:
+        comparison = subprocess.run([str(compare), str(output / 'matches'), str(reference / 'matches')],
+                                    capture_output=True, text=True, timeout=180)
+    report.update(exit_code=result.returncode, membership_matches=expected == actual,
+                  comparison_exit_code=comparison.returncode if comparison else None,
+                  comparison_output=(comparison.stdout + comparison.stderr) if comparison else None,
+                  measurement=parse_gnu_time(output / 'time.txt'),
+                  status='pass' if comparison and comparison.returncode == 0 else 'fail')
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add real dense-worker replay with spread-out subset or full2500-shard selection, candidate/feature hash validation, and exact output membership checks.
- Add a Rust directory comparison utility checking every decoded snapshot field against legacy reference shards.
- Eight real shards / 256 candidate pairs pass complete record equality through the new prepared writer.

## Validation
- Actual 8-shard worker: exit0, exact membership, all records equal; peak451184KiB.
- Python43 tests, py_compile, comparator Clippy passed.
- Full2500-shard run is now in progress and not claimed complete.

## Limits
This is matching parity with retained features, not extraction, restart, or continuous native E2E. COLMAP trajectory parity remains open.