### PR TITLE
perf: share decoded snapshot envelopes across merge shards

### DIFF
--- a/benchmarks/electro/m8-dense-borrowed-merge-v1.json
+++ b/benchmarks/electro/m8-dense-borrowed-merge-v1.json
@@ -1,0 +1,15 @@
+{
+  "status": "full-merged-byte-parity-pass",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-borrowed-merge-v1/report.json",
+  "input": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-worker-full-v1/matches",
+  "binary_sha256": "d85410b5b1a63eed6105450c44468aab5b772b74a62db7c63d30562a70e8d661",
+  "shards": 2500,
+  "output_sha256": "02cd6475098453cb6cf93761ff990ea31acba86217b715dfaf43660f3af0f05c",
+  "wall_seconds": 8.19,
+  "peak_rss_kib": 16256,
+  "rayon_num_threads": 1,
+  "malloc_arena_max": "1",
+  "exit_code": 0,
+  "time_report_sha256": "45c2e0ea8daea4b8919dfec8639e7c9b2227078b977f572e810a12bcfea15d5f",
+  "scope": "Single warm-cache merge of newly generated real worker shards. Full output SHA matches frozen reference. Not repeated speed evidence, full100k validation, restart, E2E, or COLMAP trajectory quality."
+}

--- a/benchmarks/electro/m8-shared-worker-full-v1.json
+++ b/benchmarks/electro/m8-shared-worker-full-v1.json
@@ -1,0 +1,22 @@
+{
+  "status": "all-real-worker-shards-full-record-parity-pass",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-worker-full-v1/report.json",
+  "binary_sha256": "b02f85ecce56074e000d77a6bbd63242b3d0f568294f9c22fcc9a2dc4ca01c50",
+  "compare_binary_sha256": "1180dc17ec811c5a5ceb1a90ae893a4c668354e8e95b2eefcd6508b610af55d9",
+  "shards": 2500,
+  "candidate_pairs": 80000,
+  "feature_images": 10000,
+  "plan_sha256": "cb8005bd13fa6f490123efeaa0b36f0d3e0a0890309c641d34964e1cfc010d2a",
+  "reference_plan_sha256": "cb8005bd13fa6f490123efeaa0b36f0d3e0a0890309c641d34964e1cfc010d2a",
+  "feature_manifest_sha256": "9a58c1dd0699e72ed52149096cf17e85ee894ffaaf9d55772a1eb6b1c3d95ce2",
+  "membership_matches": true,
+  "worker_exit_code": 0,
+  "comparison_exit_code": 0,
+  "wall_seconds": 594.68,
+  "peak_rss_kib": 451060,
+  "rayon_num_threads": 4,
+  "malloc_arena_max": "1",
+  "time_report_sha256": "70d62f3839490019a8fbcf8bf69b5cb8518938e9c0567628e212cb4cc60dcb27",
+  "scope": "All2500 dense matching shards using the retained full10k feature bank. Exact output membership and every decoded record match legacy reference. Not extraction, restart, continuous E2E, or COLMAP quality.",
+  "timing_limit": "This single run does not establish a matching speedup; the previous legacy replay measured 557.35s under a different run history. Shared storage reduction and parity are the demonstrated outcomes."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`test/shared-worker-parity`。
+現作業branchは`perf/borrowed-snapshot-envelope`。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -100,6 +100,25 @@ Python43 tests/比較example Clippy通過。PR126旧branch整理とprobe結果�
 全件の終了/一致は未判定。完了後report.jsonのexit/membership/比較を確認する。
 同sessionをpollし、観測timeoutで再起動しない。保存binary使用、同時build/測定なし。
 全goal未達。full worker後もborrowed reader/restart/抽出E2E/COLMAP品質は残る。
+
+更新: PR127はhead`d5b0386`でCI9成功後`a5d51961e6e8eb5d6bce7e2623aa3f30fd58759e`へmerge。
+full workerは同session60175/PID3577312で継続、直近1803/2500 shard（elapsed7:41）。
+完了後の全出力比較は未確認。保存binary実行中、別build/測定はしない。
+新branchでborrowed envelope readerを準備中（src/verified_pair_snapshot.rsとshared.rs）。
+pair decoderを分離、解析済みenvelopeをArcで共有し、同一Arcのmetadata再比較を省く。
+公開Snapshot API/v1形式は維持。参照共有と不一致拒否のテスト追加、まだ未build/未test。
+このWIPは今回のagent変更。worker終了後にlib/example test・tests込みClippyを実行してから
+実dense merge全SHA一致と100k読取を確認する。PR127旧branch整理も次。全goal未達。
+
+更新: full worker session60175はexit0完了。全2500 shardのmembership/全レコードが従来一致。
+worker594.68s/451060KiB（以前legacy557.35sより速いとは示せない、単発/別run履歴）。
+証跡`m8-shared-worker-full-v1.json`。保存binaryと出力保持。再起動/poll不要。
+borrowed envelope実装はlib19/example64 tests、tests込みClippy、Python43 tests通過。
+新worker全2500 shardをborrowed readerでmergeし最終SHA02cd6475...全一致。
+8.19s/16256KiB、証跡`m8-dense-borrowed-merge-v1.json`。session94712もexit0完了。
+次はこのbranchのPR/CI/merge、100k読取・強制中断restart。全E2E/軌跡品質は未達。
+常駐画像metadataをArcで共有、同一envelopeを再解析/再比較しない。公開owned APIは維持。
+測定プロセスなし、空き約10GiB。全goal未達。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -51,6 +51,14 @@ The first eight-shard probe passed: IDs 0, 357, 714, 1071, 1428, 1785, 2142,
 membership and every decoded snapshot record match the retained legacy shards.
 Worker peak RSS was 451,184 KiB. Evidence: `m8-shared-worker-probe-v1.json`.
 
+The complete 2,500-shard/80,000-candidate worker replay also passed exact output
+membership and full decoded record equality. The plan itself matches the frozen
+reference byte-for-byte. Worker-only time was 594.68 s, peak 451,060 KiB.
+This single run does not show a matching speedup (the earlier legacy replay was
+557.35 s under a different run history). The demonstrated outcomes are parity
+and shared storage reduction, not E2E or COLMAP quality. Evidence:
+`m8-shared-worker-full-v1.json`.
+
 ## Remaining work
 
 The streaming merger now uses a one-entry envelope cache per pass. It validates
@@ -58,7 +66,13 @@ on first load, before eviction, and at pass completion; caches are not retained
 between passes. A change fails the merge before output publication. Standalone
 reads remain uncached. The cache assumes immutable inputs within each pass and
 uses the validated bytes consistently; it is not an instantaneous file watcher.
-Memory is bounded to one serialized envelope, not one per shard. Alternating
+The cache now retains a parsed immutable envelope, not just serialized bytes.
+An internal merge view shares that envelope by `Arc` and owns only shard-local
+pairs. The existing public owned `Snapshot` API remains unchanged. The pair
+decoder is shared with legacy and compact/capped reads, preserving validation.
+Repeated shards with the same cached envelope skip redundant envelope comparisons
+using pointer identity; a new envelope still receives full compatibility checks.
+Memory is bounded to a constant number of envelopes, not one per shard. Alternating
 different envelopes can still cause misses; normal same-bank shards share one.
 
 All 2,500 real dense shards merge to the exact retained legacy output SHA with
@@ -82,8 +96,11 @@ pairs copied from one seed payload. Output sizes are 20,012,094 / 200,292,475 /
 readback. The synthetic manifest/pair hashes do not represent real input banks.
 See `m8-shared-writer-scaling-v1.json` and `stress_shared_snapshot_writer`.
 
-This does not eliminate repeated envelope decoding/owned Snapshot construction.
-Add borrowed-envelope reading before claiming linear metadata CPU. Verify
+The shared-input merger now avoids repeated envelope decoding/owned Snapshot
+construction. Standalone owned reads and legacy v1 shards still pay their own
+envelope costs. This does not establish that the entire native pipeline is
+N²-free: candidate planning, restart orchestration, and other consumers need
+their own scaling evidence. Verify
 forced-interruption restart, real persistent-worker output parity,
 and 100k scaling before switching the native runner default. Full E2E, trajectory
 quality and whole-pipeline memory gates remain separate.

--- a/scripts/probe_shared_match_worker.py
+++ b/scripts/probe_shared_match_worker.py
@@ -83,7 +83,9 @@ def main():
                   measurement=parse_gnu_time(output / 'time.txt'),
                   status='pass' if comparison and comparison.returncode == 0 else 'fail')
     report_path.write_text(json.dumps(report, indent=2) + '\n')
-    print(json.dumps(report, indent=2))
+    summary = {key: value for key, value in report.items() if key not in ('command', 'shard_ids')}
+    summary['shards'] = len(report['shard_ids'])
+    print(json.dumps(summary, indent=2))
     return 0 if report['status'] == 'pass' else 1
 
 

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -229,6 +229,72 @@ struct MergePairIndex {
     encoded_hash: u64,
 }
 
+struct MergeSnapshot {
+    envelope: std::sync::Arc<Snapshot>,
+    pairs: Vec<PairRecord>,
+    pair_order_hash: u64,
+    unordered_edge_hash: u64,
+    accepted_match_count: u64,
+}
+
+impl std::ops::Deref for MergeSnapshot {
+    type Target = Snapshot;
+    fn deref(&self) -> &Snapshot {
+        &self.envelope
+    }
+}
+
+impl MergeSnapshot {
+    fn from_owned(mut snapshot: Snapshot) -> Self {
+        let pairs = std::mem::take(&mut snapshot.pairs);
+        Self {
+            pairs,
+            pair_order_hash: snapshot.pair_order_hash,
+            unordered_edge_hash: snapshot.unordered_edge_hash,
+            accepted_match_count: snapshot.accepted_match_count,
+            envelope: std::sync::Arc::new(snapshot),
+        }
+    }
+
+    fn into_owned(self) -> Snapshot {
+        let mut snapshot = std::sync::Arc::try_unwrap(self.envelope)
+            .unwrap_or_else(|envelope| (*envelope).clone());
+        snapshot.pairs = self.pairs;
+        snapshot.pair_order_hash = self.pair_order_hash;
+        snapshot.unordered_edge_hash = self.unordered_edge_hash;
+        snapshot.accepted_match_count = self.accepted_match_count;
+        snapshot
+    }
+}
+
+fn read_for_merge(path: &Path, cache: &mut shared::EnvelopeCache) -> Result<MergeSnapshot, String> {
+    let mut file = std::fs::File::open(path).map_err(|error| error.to_string())?;
+    let mut magic = vec![0; shared::MAGIC.len()];
+    file.read_exact(&mut magic)
+        .map_err(|error| error.to_string())?;
+    if magic == shared::MAGIC {
+        shared::read_merge(path, true, None, Some(cache))
+    } else {
+        read(path).map(MergeSnapshot::from_owned)
+    }
+}
+
+fn validate_cached_merge_envelope(
+    index: usize,
+    snapshot: &MergeSnapshot,
+    first: &Snapshot,
+    previous: &mut Option<std::sync::Arc<Snapshot>>,
+) -> Result<(), String> {
+    if !previous
+        .as_ref()
+        .is_some_and(|old| std::sync::Arc::ptr_eq(old, &snapshot.envelope))
+    {
+        validate_merge_envelope(index, snapshot, first)?;
+        *previous = Some(std::sync::Arc::clone(&snapshot.envelope));
+    }
+    Ok(())
+}
+
 fn snapshot_envelope(snapshot: &Snapshot) -> Snapshot {
     let effective_config = format!("verified-pair-export-v1;{}", snapshot.verifier_config);
     Snapshot {
@@ -467,9 +533,10 @@ fn write_streamed_merge_temp(
         let mut encoded_pair_bytes = 0u64;
         let mut accepted_match_count = 0u64;
         let mut envelope_cache = shared::EnvelopeCache::default();
+        let mut previous_envelope = None;
         for (shard_index, path) in input_paths.iter().enumerate() {
-            let snapshot = read_with_cache(path, true, None, Some(&mut envelope_cache))?;
-            validate_merge_envelope(shard_index, &snapshot, first)?;
+            let snapshot = read_for_merge(path, &mut envelope_cache)?;
+            validate_cached_merge_envelope(shard_index, &snapshot, first, &mut previous_envelope)?;
             for pair in &snapshot.pairs {
                 let expected = expected_pairs.get(pair_cursor).ok_or_else(|| {
                     format!("merge input shard {shard_index} contains an unexpected pair")
@@ -641,13 +708,20 @@ pub fn merge_files_atomic<P: AsRef<Path>>(output: &Path, inputs: &[P]) -> Result
     let mut pair_payload_bytes = 0u64;
     let mut accepted_match_count = 0u64;
     let mut envelope_cache = shared::EnvelopeCache::default();
+    let mut previous_envelope = None;
     for (shard_index, path) in input_paths.iter().enumerate() {
-        let snapshot = read_with_cache(path, true, None, Some(&mut envelope_cache))?;
+        let snapshot = read_for_merge(path, &mut envelope_cache)?;
         if let Some(first_snapshot) = first.as_ref() {
-            validate_merge_envelope(shard_index, &snapshot, first_snapshot)?;
+            validate_cached_merge_envelope(
+                shard_index,
+                &snapshot,
+                first_snapshot,
+                &mut previous_envelope,
+            )?;
         } else {
             validate_snapshot_envelope(&snapshot)?;
             first = Some(snapshot_envelope(&snapshot));
+            previous_envelope = Some(std::sync::Arc::clone(&snapshot.envelope));
         }
         let image_count = first
             .as_ref()
@@ -1192,6 +1266,39 @@ fn decode_payload<R: Read>(
     let effective_config = reader.string("effective config")?;
     let verifier_config_hash = reader.u64()?;
     let verifier_config = reader.string("verifier config")?;
+    let chunk = decode_pair_payload(&mut reader, retain_audit_streams, mapper_match_limit)?;
+    Ok(Snapshot {
+        schema_version,
+        image_names,
+        image_manifest_hash,
+        feature_manifest_hash,
+        feature_counts,
+        width,
+        height,
+        intrinsics_bits,
+        effective_config_hash,
+        effective_config,
+        verifier_config_hash,
+        verifier_config,
+        pair_order_hash: chunk.pair_order_hash,
+        unordered_edge_hash: chunk.unordered_edge_hash,
+        accepted_match_count: chunk.accepted_match_count,
+        pairs: chunk.pairs,
+    })
+}
+
+struct DecodedPairs {
+    pair_order_hash: u64,
+    unordered_edge_hash: u64,
+    accepted_match_count: u64,
+    pairs: Vec<PairRecord>,
+}
+
+fn decode_pair_payload<R: Read>(
+    reader: &mut Reader<R>,
+    retain_audit_streams: bool,
+    mapper_match_limit: Option<usize>,
+) -> Result<DecodedPairs, String> {
     let pair_order_hash = reader.u64()?;
     let unordered_edge_hash = reader.u64()?;
     let accepted_match_count = reader.u64()?;
@@ -1328,19 +1435,7 @@ fn decode_payload<R: Read>(
     let accepted_match_count = mapper_match_limit.map_or(accepted_match_count, |_| {
         pairs.iter().map(|pair| pair.matches.len() as u64).sum()
     });
-    Ok(Snapshot {
-        schema_version,
-        image_names,
-        image_manifest_hash,
-        feature_manifest_hash,
-        feature_counts,
-        width,
-        height,
-        intrinsics_bits,
-        effective_config_hash,
-        effective_config,
-        verifier_config_hash,
-        verifier_config,
+    Ok(DecodedPairs {
         pair_order_hash,
         unordered_edge_hash,
         accepted_match_count,
@@ -1686,6 +1781,35 @@ mod tests {
             "visloc_verified_pair_snapshot_{tag}_{}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn merge_reader_borrows_one_decoded_envelope_and_rejects_mismatches() {
+        let root = temp_path("borrowed_envelope");
+        std::fs::create_dir(&root).unwrap();
+        let snapshot = sample();
+        let first_path = root.join("first.vps");
+        super::write_shared_atomic(&first_path, &snapshot).unwrap();
+        let mut cache = super::shared::EnvelopeCache::default();
+        let first = super::read_for_merge(&first_path, &mut cache).unwrap();
+        let second = super::read_for_merge(&first_path, &mut cache).unwrap();
+        assert!(std::sync::Arc::ptr_eq(&first.envelope, &second.envelope));
+        assert_eq!(cache.loads, 1);
+        assert_eq!(first.into_owned(), snapshot);
+        assert_eq!(second.into_owned(), snapshot);
+        cache.finish().unwrap();
+
+        let mut other = sample();
+        other.feature_manifest_hash += 1;
+        let second_path = root.join("second.vps");
+        super::write_shared_atomic(&second_path, &other).unwrap();
+        let output = root.join("merged.vps");
+        std::fs::write(&output, b"prior-output").unwrap();
+        assert!(merge_files_atomic(&output, &[first_path, second_path])
+            .unwrap_err()
+            .contains("manifest"));
+        assert_eq!(std::fs::read(&output).unwrap(), b"prior-output");
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/verified_pair_snapshot/shared.rs
+++ b/src/verified_pair_snapshot/shared.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 struct CachedEnvelope {
     path: PathBuf,
     digest: [u8; 32],
-    bytes: Arc<[u8]>,
+    decoded: Arc<Snapshot>,
 }
 
 /// One-entry cache scoped to a single immutable-input merge pass. Revalidate
@@ -38,22 +38,35 @@ impl EnvelopeCache {
         Ok(())
     }
 
-    fn get(&mut self, path: PathBuf, digest: [u8; 32]) -> Result<Arc<[u8]>, String> {
+    fn get(&mut self, path: PathBuf, digest: [u8; 32]) -> Result<Arc<Snapshot>, String> {
         if let Some(entry) = &self.entry {
             if entry.path == path && entry.digest == digest {
-                return Ok(Arc::clone(&entry.bytes));
+                return Ok(Arc::clone(&entry.decoded));
             }
         }
         self.finish()?;
-        let bytes = load_envelope(&path, &digest)?;
+        let decoded = decode_envelope(load_envelope(&path, &digest)?)?;
         self.loads += 1;
         self.entry = Some(CachedEnvelope {
             path,
             digest,
-            bytes: Arc::clone(&bytes),
+            decoded: Arc::clone(&decoded),
         });
-        Ok(bytes)
+        Ok(decoded)
     }
+}
+
+fn decode_envelope(bytes: Arc<[u8]>) -> Result<Arc<Snapshot>, String> {
+    let length = (bytes.len() as u64)
+        .checked_add(32)
+        .ok_or("shared envelope size overflow")?;
+    decode_payload(
+        std::io::Cursor::new(bytes).chain(std::io::Cursor::new([0u8; 32])),
+        length,
+        true,
+        None,
+    )
+    .map(Arc::new)
 }
 
 fn load_envelope(path: &Path, digest: &[u8; 32]) -> Result<Arc<[u8]>, String> {
@@ -226,6 +239,15 @@ pub(super) fn read(
     cap: Option<usize>,
     cache: Option<&mut EnvelopeCache>,
 ) -> Result<Snapshot, String> {
+    read_merge(path, retain, cap, cache).map(MergeSnapshot::into_owned)
+}
+
+pub(super) fn read_merge(
+    path: &Path,
+    retain: bool,
+    cap: Option<usize>,
+    cache: Option<&mut EnvelopeCache>,
+) -> Result<MergeSnapshot, String> {
     let mut file = std::fs::File::open(path).map_err(|error| error.to_string())?;
     let length = file.metadata().map_err(|error| error.to_string())?.len();
     let header_len = MAGIC.len() as u64 + 32 + 8;
@@ -247,7 +269,7 @@ pub(super) fn read(
     let envelope_path = envelope_path(parent(path), &digest);
     let envelope = match cache {
         Some(cache) => cache.get(envelope_path, digest)?,
-        None => load_envelope(&envelope_path, &digest)?,
+        None => decode_envelope(load_envelope(&envelope_path, &digest)?)?,
     };
     let mut remaining = suffix_len;
     let mut checksum = 0xcbf29ce484222325u64;
@@ -273,13 +295,13 @@ pub(super) fn read(
     }
     file.seek(SeekFrom::Start(header_len))
         .map_err(|error| error.to_string())?;
-    let payload_len = (envelope.len() as u64)
-        .checked_add(suffix_len)
-        .ok_or("shared payload size overflow")?;
-    decode_payload(
-        std::io::Cursor::new(envelope).chain(BufReader::new(file.take(suffix_len))),
-        payload_len,
-        retain,
-        cap,
-    )
+    let mut reader = Reader::new(BufReader::new(file.take(suffix_len)), suffix_len);
+    let chunk = decode_pair_payload(&mut reader, retain, cap)?;
+    Ok(MergeSnapshot {
+        envelope,
+        pairs: chunk.pairs,
+        pair_order_hash: chunk.pair_order_hash,
+        unordered_edge_hash: chunk.unordered_edge_hash,
+        accepted_match_count: chunk.accepted_match_count,
+    })
 }


### PR DESCRIPTION
## Summary
- Share parsed immutable envelopes across shared-format merge shards using an internal Arc-backed view; preserve the public owned Snapshot API.
- Reuse the existing pair decoder and skip redundant envelope comparisons only for identical cached objects. Cache eviction/pass-boundary revalidation remains intact.
- Record successful full2500-shard real-worker parity and subsequent byte-exact borrowed-reader merge.

## Validation
- 19 snapshot library tests, 64 SfM example tests, Python43 tests passed.
- Clippy with tests and affected merge example: passed with warnings denied.
- Full worker: all2500 shards match all legacy records; 594.68s / peak451060KiB. No matching speedup claimed.
- New merge over actual worker output: exact frozen SHA, single warm-cache 8.19s / peak16256KiB.
- Arc reuse and incompatible-envelope rejection with prior-output preservation are tested.

## Remaining
100k readback, forced interruption/restart, continuous native E2E, and COLMAP trajectory parity remain open. No full-goal completion or repeated speed claim.