### PR TITLE
test: validate 100k shared readback and SIGKILL resume

### DIFF
--- a/benchmarks/electro/m8-shared-readback-scaling-v1.json
+++ b/benchmarks/electro/m8-shared-readback-scaling-v1.json
@@ -1,0 +1,13 @@
+{
+  "status": "synthetic-structural-readback-pass",
+  "binary_sha256": "680b6539cb397a49be946831ad7002a13f0c77c797e8015396e2d2953c6d5db2",
+  "external_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-writer-stress-v1",
+  "recipe": "validate_snapshot_shards DIRECTORY",
+  "measurements": [
+    {"images": 1000, "shards": 32, "pairs": 999, "accepted_matches": 305694, "envelope_loads": 1, "wall_seconds": 0.08, "peak_rss_kib": 4296},
+    {"images": 10000, "shards": 313, "pairs": 9999, "accepted_matches": 3059694, "envelope_loads": 1, "wall_seconds": 0.82, "peak_rss_kib": 6008},
+    {"images": 100000, "shards": 3125, "pairs": 99999, "accepted_matches": 30599694, "envelope_loads": 1, "wall_seconds": 8.79, "peak_rss_kib": 20524}
+  ],
+  "time_report_sha256_100000": "80a11f7ddd6def579d3590168213243399c86450c277a5e172b49b4a5689d11d",
+  "scope": "All shard payload checksums, raw/inlier relationships, envelope compatibility, image IDs, disjoint edges, and accepted counts checked. Synthetic fixture; external feature banks and declared pair-order/edge hashes are not validated. Not full100k SfM, quality, or E2E."
+}

--- a/benchmarks/electro/m8-shared-snapshot-restart-v1.json
+++ b/benchmarks/electro/m8-shared-snapshot-restart-v1.json
@@ -1,0 +1,12 @@
+{
+  "status": "partial-conversion-sigkill-resume-pass",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-snapshot-restart-v1/report.json",
+  "binary_sha256": "05cf9e2ad3880ea4ef5b2a4fb097a68165541fbbeced7bf1ecf478335923e21c",
+  "interrupted_exit_code": -9,
+  "completed_before_resume": 253,
+  "expected_shards": 2500,
+  "final_shards": 2500,
+  "resume_exit_code": 0,
+  "prior_chunks_byte_unchanged": true,
+  "scope": "Actual child-process SIGKILL during partial dense snapshot conversion. Resume compares all decoded output records against source. Not a guaranteed interruption inside a particular file write, power-loss durability, matching-worker resume, mapper restart, or continuous native E2E."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`perf/borrowed-snapshot-envelope`。
+現作業branchは`test/shared-snapshot-readback`（PR128の子）。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -119,6 +119,17 @@ borrowed envelope実装はlib19/example64 tests、tests込みClippy、Python43 t
 次はこのbranchのPR/CI/merge、100k読取・強制中断restart。全E2E/軌跡品質は未達。
 常駐画像metadataをArcで共有、同一envelopeを再解析/再比較しない。公開owned APIは維持。
 測定プロセスなし、空き約10GiB。全goal未達。
+
+更新: PR128 head`7ee56a2`はCI8成功/rust実行中。100k structural readbackを実施し、
+全3125 shard/99999 pairs/30599694 matches検証、envelope load1回、8.79s/20524KiB。
+1k/10kもpass。validate_files API/validate_snapshot_shards example追加。
+チェックサム/raw-inlier関係/画像ID/ペア重複/件数を検証。外部bankと宣言edge hashの検証ではない。
+変換converterに明示--resumeを追加。実子プロセスを253 shard時にSIGKILL(-9)して再開、
+全2500のdecodedレコードが元と一致、既存253ファイルも全bytes不変。session81409完了。
+これは変換batch restartのみ、worker/mapper/full E2E restartではない。
+証跡shared-readback-scaling-v1/shared-snapshot-restart-v1。lib20 tests/Clippy通過。
+readback session37522も完了。測定稼働なし。次はPR128最終CI/merge、現branchのPR、
+native runnerでの共有形式とrestart統合、全抽出E2E/COLMAP品質改善。全goal未達。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -131,6 +131,9 @@ borrowed envelope実装はlib19/example64 tests、tests込みClippy、Python43 t
 readback session37522も完了。測定稼働なし。次はPR128最終CI/merge、現branchのPR、
 native runnerでの共有形式とrestart統合、全抽出E2E/COLMAP品質改善。全goal未達。
 
+更新: PR128はhead`7ee56a2`でCI9成功後`4b51e97a84f3c9d99e70086a8ba20ec9dfe8151c`へmerge、
+旧branchはremote/local整理済み。現branchはmainへrebase済み。Python43 testsも通過。
+
 ### 以前の状態（上記を優先）
 
 PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -28,8 +28,26 @@ cargo run --locked --release --example compact_verified_pair_snapshots -- INPUT_
 ```
 
 The converter retains one input/output shard at a time. It does not replace or
-delete inputs and refuses an existing destination. The writer supports retry;
-the batch converter itself does not yet resume partially completed conversions.
+delete inputs and refuses an existing destination unless `--resume` is explicit.
+Resume requires that directory to exist, rejects unexpected `.vps` files, and
+validates every existing output against its source before accepting it. Missing
+chunks are written atomically; existing corrupt chunks fail instead of being
+silently replaced. Interrupted temporary files are not treated as complete chunks.
+
+`stress_shared_snapshot_restart.py` confirmed SIGKILL during a real partial
+conversion with 253 published chunks. Resume completed all 2,500 shards with full
+decoded-record equality and all previously published chunk bytes unchanged.
+This tests partial-batch process interruption, not a guaranteed mid-file kill,
+power-loss durability, matching-worker resume, or mapper restart. Evidence:
+`m8-shared-snapshot-restart-v1.json`.
+
+`validate_snapshot_shards DIRECTORY` performs bounded structural readback using
+the shared reader. It checks payload checksums, raw/inlier relationships,
+compatible envelopes, image IDs, disjoint pair membership, and accepted counts.
+It does not recompute declared edge/order hashes or bind external feature banks.
+All 100k synthetic output chunks passed (3,125 shards, 99,999 pairs), with one
+envelope load, 8.79 s and peak 20,524 KiB. 1k/10k runs also passed. This is not
+full100k SfM or quality evidence; see `m8-shared-readback-scaling-v1.json`.
 
 ## Real worker parity probe
 

--- a/examples/compact_verified_pair_snapshots.rs
+++ b/examples/compact_verified_pair_snapshots.rs
@@ -4,9 +4,11 @@ use visloc_rs::verified_pair_snapshot::{read, write_shared_atomic};
 
 fn main() -> Result<(), String> {
     let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if args.len() != 2 {
+    let resume = args.len() == 3 && args[2] == "--resume";
+    if args.len() != 2 && !resume {
         return Err(
-            "usage: compact_verified_pair_snapshots INPUT_DIRECTORY NEW_OUTPUT_DIRECTORY".into(),
+            "usage: compact_verified_pair_snapshots INPUT_DIRECTORY OUTPUT_DIRECTORY [--resume]"
+                .into(),
         );
     }
     let source = PathBuf::from(&args[0]);
@@ -21,12 +23,35 @@ fn main() -> Result<(), String> {
     if paths.is_empty() {
         return Err("no snapshot shards".into());
     }
-    std::fs::create_dir(&destination).map_err(|error| error.to_string())?;
+    if resume {
+        if !destination.is_dir() {
+            return Err("resume requires an existing output directory".into());
+        }
+        let expected = paths
+            .iter()
+            .filter_map(|path| path.file_name())
+            .collect::<std::collections::HashSet<_>>();
+        for entry in std::fs::read_dir(&destination).map_err(|error| error.to_string())? {
+            let path = entry.map_err(|error| error.to_string())?.path();
+            if path.extension().is_some_and(|extension| extension == "vps")
+                && !path.file_name().is_some_and(|name| expected.contains(name))
+            {
+                return Err("resume output contains an unexpected snapshot".into());
+            }
+        }
+    } else {
+        std::fs::create_dir(&destination).map_err(|error| error.to_string())?;
+    }
     let mut pairs = 0usize;
+    let mut reused = 0usize;
     for (index, path) in paths.iter().enumerate() {
         let snapshot = read(path)?;
         let output = destination.join(path.file_name().ok_or("missing filename")?);
-        write_shared_atomic(&output, &snapshot)?;
+        if resume && output.exists() {
+            reused += 1;
+        } else {
+            write_shared_atomic(&output, &snapshot)?;
+        }
         if read(&output)? != snapshot {
             return Err(format!("round-trip mismatch: {}", path.display()));
         }
@@ -36,7 +61,7 @@ fn main() -> Result<(), String> {
         }
     }
     println!(
-        "verified {} shards, {pairs} pairs; shared-envelope record parity passed",
+        "verified {} shards, {pairs} pairs, {reused} reused; shared-envelope record parity passed",
         paths.len()
     );
     Ok(())

--- a/examples/validate_snapshot_shards.rs
+++ b/examples/validate_snapshot_shards.rs
@@ -1,0 +1,19 @@
+//! Structural readback only; does not validate external banks or SfM quality.
+use std::path::PathBuf;
+use visloc_rs::verified_pair_snapshot::validate_files;
+
+fn main() -> Result<(), String> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 1 {
+        return Err("usage: validate_snapshot_shards DIRECTORY".into());
+    }
+    let mut paths = std::fs::read_dir(PathBuf::from(&args[0]))
+        .map_err(|error| error.to_string())?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    paths.retain(|path| path.extension().is_some_and(|extension| extension == "vps"));
+    paths.sort();
+    println!("PASS: {:?}", validate_files(&paths)?);
+    Ok(())
+}

--- a/scripts/stress_shared_snapshot_restart.py
+++ b/scripts/stress_shared_snapshot_restart.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Kill our own partial converter process, then validate resume and prior bytes."""
+import argparse
+import json
+from pathlib import Path
+import signal
+import subprocess
+import time
+
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--source', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve(strict=True)
+    source = args.source.resolve(strict=True)
+    expected = {path.name for path in source.glob('*.vps')}
+    if len(expected) < 500:
+        parser.error('Use at least 500 shards for a partial-batch interruption')
+    root = args.output.resolve()
+    root.mkdir()
+    destination = root / 'matches'
+    command = [str(binary), str(source), str(destination)]
+    killed = False
+    with (root / 'interrupted.log').open('w') as log:
+        process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT)
+        try:
+            deadline = time.monotonic() + 120
+            while process.poll() is None and time.monotonic() < deadline:
+                completed = len(list(destination.glob('*.vps')))
+                if 250 <= completed < len(expected):
+                    process.kill()  # Only this script's own child.
+                    killed = True
+                    break
+                time.sleep(0.02)
+            if process.poll() is None and not killed:
+                process.kill()
+            exit_code = process.wait(timeout=10)
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=10)
+    prior = {path.name: sha(path) for path in destination.glob('*.vps')}
+    if not killed or exit_code != -signal.SIGKILL or not 0 < len(prior) < len(expected):
+        raise RuntimeError('Did not confirm SIGKILL during a partial conversion')
+    with (root / 'resume.log').open('w') as log:
+        result = subprocess.run([*command, '--resume'], stdout=log, stderr=subprocess.STDOUT, timeout=180)
+    actual = {path.name for path in destination.glob('*.vps')}
+    unchanged = all(sha(destination / name) == digest for name, digest in prior.items())
+    report = {'status': 'pass' if result.returncode == 0 and actual == expected and unchanged else 'fail',
+              'binary_sha256': sha(binary), 'source': str(source),
+              'interrupted_exit_code': exit_code, 'completed_before_resume': len(prior),
+              'expected_shards': len(expected), 'final_shards': len(actual),
+              'resume_exit_code': result.returncode, 'prior_chunks_byte_unchanged': unchanged,
+              'scope': 'SIGKILL during partial real-bank conversion, not mapper or full native pipeline restart. Converter readback compares every output record to its source.'}
+    (root / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/verified_pair_snapshot.rs
+++ b/src/verified_pair_snapshot.rs
@@ -295,6 +295,64 @@ fn validate_cached_merge_envelope(
     Ok(())
 }
 
+/// Bounded-memory structural readback statistics, not reconstruction quality.
+#[derive(Debug, PartialEq)]
+pub struct ReadbackSummary {
+    pub images: usize,
+    pub shards: usize,
+    pub pairs: usize,
+    pub accepted_matches: u64,
+    pub envelope_loads: usize,
+}
+
+/// Read and validate all shard payload checksums, raw/inlier relationships,
+/// compatible envelopes, image indices and disjoint pair membership. Retains
+/// one shard and O(pair count) edge keys. Does not validate external feature
+/// banks or recompute the declared pair-order/unordered-edge hashes.
+pub fn validate_files<P: AsRef<Path>>(inputs: &[P]) -> Result<ReadbackSummary, String> {
+    if inputs.is_empty() {
+        return Err("cannot validate an empty snapshot list".to_owned());
+    }
+    let mut cache = shared::EnvelopeCache::default();
+    let mut previous = None;
+    let mut first = None;
+    let mut edges = std::collections::HashSet::new();
+    let mut accepted_matches = 0u64;
+    for (index, path) in inputs.iter().enumerate() {
+        let snapshot = read_for_merge(path.as_ref(), &mut cache)?;
+        if let Some(envelope) = &first {
+            validate_cached_merge_envelope(index, &snapshot, envelope, &mut previous)?;
+        } else {
+            first = Some(snapshot_envelope(&snapshot));
+            previous = Some(std::sync::Arc::clone(&snapshot.envelope));
+        }
+        let mut shard_matches = 0u64;
+        for pair in &snapshot.pairs {
+            let edge = validate_merge_pair(pair, snapshot.image_names.len())?;
+            if !edges.insert(edge) {
+                return Err(format!("snapshot shards overlap at pair {edge:?}"));
+            }
+            shard_matches = shard_matches
+                .checked_add(pair.matches.len() as u64)
+                .ok_or("snapshot match count overflow")?;
+        }
+        if shard_matches != snapshot.accepted_match_count {
+            return Err("snapshot accepted-match count mismatch".to_owned());
+        }
+        accepted_matches = accepted_matches
+            .checked_add(shard_matches)
+            .ok_or("snapshot match count overflow")?;
+    }
+    cache.finish()?;
+    Ok(ReadbackSummary {
+        images: first.unwrap().image_names.len(),
+        shards: inputs.len(),
+        pairs: edges.len(),
+        accepted_matches,
+        envelope_loads: cache.loads,
+    })
+}
+
 fn snapshot_envelope(snapshot: &Snapshot) -> Snapshot {
     let effective_config = format!("verified-pair-export-v1;{}", snapshot.verifier_config);
     Snapshot {
@@ -1781,6 +1839,36 @@ mod tests {
             "visloc_verified_pair_snapshot_{tag}_{}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn readback_checks_counts_and_overlaps() {
+        let root = temp_path("readback");
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("one.vps");
+        let mut snapshot = sample();
+        super::write_shared_atomic(&path, &snapshot).unwrap();
+        let summary = super::validate_files(std::slice::from_ref(&path)).unwrap();
+        assert_eq!(
+            summary,
+            super::ReadbackSummary {
+                images: 2,
+                shards: 1,
+                pairs: 1,
+                accepted_matches: 2,
+                envelope_loads: 1
+            }
+        );
+        assert!(super::validate_files(&[&path, &path])
+            .unwrap_err()
+            .contains("overlap"));
+        snapshot.accepted_match_count += 1;
+        super::write_shared_atomic(&path, &snapshot).unwrap();
+        assert!(super::validate_files(std::slice::from_ref(&path))
+            .unwrap_err()
+            .contains("count mismatch"));
+        assert!(super::validate_files::<PathBuf>(&[]).is_err());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add bounded structural shard readback with shared-envelope reuse, overlap/count checks, and explicit validation scope.
- Add opt-in converter --resume: validate completed chunks against source, write missing chunks, reject unexpected/corrupt outputs.
- Add an actual partial-batch SIGKILL/resume harness and evidence.

## Validation
- Library snapshot tests: 20 passed. Python: 43 passed. Clippy including tests/affected examples passed.
- 1k/10k/100k readback passed; 100k: 3125 shards, 99999 pairs, one envelope load, 8.79s, peak20524KiB.
- Real dense converter killed after253 chunks, exit-9. Resume verified all2500 against source; prior253 chunk bytes unchanged.

## Limits
Structural synthetic100k validation does not bind external feature banks or recompute declared graph hashes, and is not SfM quality/E2E. Restart test covers conversion only, not worker/mapper/native pipeline restart. Full goal remains open.