### PR TITLE
feat: validate shared snapshot dependencies in native runner

### DIFF
--- a/benchmarks/electro/m8-runner-envelope-bindings-v1.json
+++ b/benchmarks/electro/m8-runner-envelope-bindings-v1.json
@@ -1,0 +1,9 @@
+{
+  "status": "real-worker-envelope-binding-audit-pass",
+  "source": "/home/sasaki/datasets/openloris/corridor1-1-m8-shared-worker-full-v1/matches",
+  "shards": 2500,
+  "bound_shards": 2500,
+  "envelope_cache_entries": 1,
+  "envelope_sha256": "2c9273dbc3f298ed47319243b80560dc38d7f7a0325958984a31ba876f6c52b3",
+  "scope": "Read-only application of the native runner binding helper to existing real worker output. Not a fresh runner execution or runner SIGKILL/resume test. Payload correctness was established separately by full worker parity."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`test/shared-snapshot-readback`（PR128の子）。
+現作業branchは`feat/runner-shared-snapshot-bindings`（PR129の子）。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -133,6 +133,15 @@ native runnerでの共有形式とrestart統合、全抽出E2E/COLMAP品質改�
 
 更新: PR128はhead`7ee56a2`でCI9成功後`4b51e97a84f3c9d99e70086a8ba20ec9dfe8151c`へmerge、
 旧branchはremote/local整理済み。現branchはmainへrebase済み。Python43 testsも通過。
+
+更新: native runnerへ--shared-snapshot-envelope（persistentのみ）を追加。
+completed chunkには参照envelopeのfilename/SHAを記録し、resume/merge index検証で
+本体と参照の両方を確認。completion log回収も同じ経路。検証call内で共通envelopeは1回hash。
+runner tests21件/scripts tests43件通過。欠落/改変/未記録依存・完了記録・既定OFFを検証。
+実worker既存2500出力へbinding helper適用、全件同一envelope1個を確認。
+証跡`m8-runner-envelope-bindings-v1.json`。新runner経由の実行/強制中断はまだ未検証。
+次はPR129最終CI/merge、現branchのPR、新runner実行とresume検証、全E2E/品質改善。
+測定プロセスなし。全goal未達。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -143,6 +143,9 @@ runner tests21件/scripts tests43件通過。欠落/改変/未記録依存・完
 次はPR129最終CI/merge、現branchのPR、新runner実行とresume検証、全E2E/品質改善。
 測定プロセスなし。全goal未達。
 
+更新: PR129はhead`ecd3819`でCI9成功後`7fe9e7d885bb0d22f16721ef35cb5aabbd4aef23`へmerge。
+旧branchをremote/local整理、現branchをmainへrebase済み。
+
 ### 以前の状態（上記を優先）
 
 PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -4,6 +4,17 @@
 persistent worker shards) into a compact, lossless representation. Default
 exports remain legacy v1. Snapshot readers and the streaming merger accept both.
 
+The Python native runner (`scripts/benchmark_electro.py`) also accepts
+`--shared-snapshot-envelope` with `--persistent-matcher`. It forwards the flag
+and records each completed chunk's `snapshot_envelope` filename/SHA-256 alongside
+the chunk hash. Completion recovery uses the same binding path. Resume/index
+validation and merge preflight reject missing, changed, or unrecorded envelope
+dependencies. Within one validation call, each immutable envelope is hashed
+once. The Rust reader separately validates payload checksums and bindings.
+Defaults remain legacy; mixed legacy/shared completed shards can be read.
+This runner integration is unit-tested; a fresh real runner interruption test
+is still required, separately from the converter SIGKILL test below.
+
 Each directory stores immutable `envelope-<sha256>.vpe` files and pair chunks.
 The envelope is the exact v1 payload prefix through verifier configuration;
 the chunk contains the four shard-specific counters/hashes and encoded pairs.

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -1671,6 +1671,7 @@ def run_match_shards(
     resume: bool = True,
     persistent_matcher: bool = False,
     stream_match_features: bool = False,
+    shared_snapshot_envelope: bool = False,
     feature_manifest_path: Path | None = None,
 ) -> dict[str, Any]:
     """Run pending match shards, updating the index only after hash checks."""
@@ -1694,8 +1695,11 @@ def run_match_shards(
             match_ratio=match_ratio,
             resume=resume,
             stream_match_features=stream_match_features,
+            shared_snapshot_envelope=shared_snapshot_envelope,
         )
 
+    if shared_snapshot_envelope:
+        raise ValidationError('shared snapshot envelopes require the persistent matcher')
     if stream_match_features:
         raise ValidationError("streamed match features require the persistent matcher")
 

--- a/scripts/benchmark_electro.py
+++ b/scripts/benchmark_electro.py
@@ -1144,6 +1144,7 @@ def build_persistent_match_command(
     min_matches: int = 30,
     match_ratio: float = 0.8,
     stream_match_features: bool = False,
+    shared_snapshot_envelope: bool = False,
 ) -> list[str]:
     """Build the single-process frozen NN/full persistent worker command."""
 
@@ -1178,6 +1179,8 @@ def build_persistent_match_command(
         command.extend(["--images-dir", str(images_dir)])
     if stream_match_features:
         command.append("--stream-match-features")
+    if shared_snapshot_envelope:
+        command.append("--shared-snapshot-envelope")
     return command
 
 
@@ -1583,6 +1586,33 @@ def write_persistent_match_worker_plan(
     return plan_path
 
 
+def snapshot_envelope_binding(snapshot_path: Path, cache=None):
+    """Bind shared chunks to their immutable envelope; legacy snapshots need none."""
+    magic = b"VISLOC-PAIR-CHUNK-V1\0"
+    try:
+        with snapshot_path.open('rb') as stream:
+            if stream.read(len(magic)) != magic:
+                return None
+            digest = stream.read(32)
+    except OSError as error:
+        raise ValidationError(f'Cannot read snapshot binding: {snapshot_path}: {error}') from error
+    if len(digest) != 32:
+        raise ValidationError('Truncated shared snapshot envelope binding')
+    expected = digest.hex()
+    name = f'envelope-{expected}.vpe'
+    path = snapshot_path.parent / name
+    key = path.resolve()
+    if cache is None or key not in cache:
+        actual = sha256_file(path)
+        if cache is not None:
+            cache[key] = actual
+    else:
+        actual = cache[key]
+    if actual != expected:
+        raise ValidationError('Shared snapshot envelope hash mismatch')
+    return {'path': name, 'sha256': expected}
+
+
 def validate_match_index(
     index_path: Path,
     candidate_index_path: Path,
@@ -1601,6 +1631,7 @@ def validate_match_index(
     shards = index.get("shards")
     if not isinstance(shards, list) or len(shards) != len(candidate["shards"]):
         raise ValidationError("match index shard list does not match candidate index")
+    envelope_cache = {}
     for expected_id, (entry, candidate_entry) in enumerate(zip(shards, candidate["shards"])):
         if not isinstance(entry, dict) or entry.get("id") != expected_id:
             raise ValidationError(f"match index shard {expected_id} is malformed")
@@ -1619,6 +1650,9 @@ def validate_match_index(
             actual_hash = sha256_file(snapshot_path)
             if actual_hash != expected_hash:
                 raise ValidationError(f"match shard {expected_id} snapshot hash mismatch")
+            binding = snapshot_envelope_binding(snapshot_path, envelope_cache)
+            if entry.get('snapshot_envelope') != binding:
+                raise ValidationError(f"match shard {expected_id} envelope binding mismatch")
     return {"index": index, "index_sha256": sha256_file(index_path), "candidate": candidate}
 
 
@@ -1859,6 +1893,7 @@ def _apply_persistent_match_completions(
     if not isinstance(plan_path, str) or not plan_path:
         raise ValidationError("persistent worker validation omitted plan path")
     plan_root = Path(plan_path).resolve().parent
+    envelope_cache = {}
     for completion in completions:
         shard_id = completion["shard_id"]
         if shard_id in seen:
@@ -1881,6 +1916,11 @@ def _apply_persistent_match_completions(
             raise ValidationError(f"persistent worker shard {shard_id} verified pair count exceeds candidates")
         snapshot_path = plan_root / completion["snapshot_path"]
         actual_hash = sha256_file(snapshot_path)
+        binding = snapshot_envelope_binding(snapshot_path, envelope_cache)
+        if binding is not None:
+            entry['snapshot_envelope'] = binding
+        else:
+            entry.pop('snapshot_envelope', None)
         entry.update(
             {
                 "status": "complete",
@@ -1983,6 +2023,7 @@ def run_persistent_matcher(
     match_ratio: float = 0.8,
     resume: bool = True,
     stream_match_features: bool = False,
+    shared_snapshot_envelope: bool = False,
 ) -> dict[str, Any]:
     """Run all pending shards through one Rust feature-bank process."""
 
@@ -2026,6 +2067,7 @@ def run_persistent_matcher(
         min_matches=min_matches,
         match_ratio=match_ratio,
         stream_match_features=stream_match_features,
+        shared_snapshot_envelope=shared_snapshot_envelope,
     )
     timing_path = root.parent / "timing" / "persistent-match.time.txt"
     log_path = root / "persistent-match.log"
@@ -2068,6 +2110,7 @@ def run_persistent_matcher(
     persistent_worker = {
         "mode": "persistent-stream-v1" if stream_match_features else "persistent-v1",
         "stream_match_features": stream_match_features,
+        "shared_snapshot_envelope": shared_snapshot_envelope,
         "plan": str(plan_path.resolve()),
         "plan_sha256": sha256_file(plan_path),
         "elapsed_s": worker_elapsed,
@@ -2218,6 +2261,8 @@ def _parser() -> argparse.ArgumentParser:
         help="hydrate and cache only descriptors needed by each persistent match shard",
     )
     parser.add_argument("--min-pnp-inliers", type=int, default=12)
+    parser.add_argument('--shared-snapshot-envelope', action='store_true',
+                        help='use shared-envelope chunks in the persistent matching worker')
     parser.add_argument("--max-mapper-matches-per-pair", type=int)
     parser.add_argument(
         "--snapshot-keypoints-only",
@@ -2262,6 +2307,8 @@ def main(argv: list[str] | None = None) -> int:
             raise ValidationError("--persistent-matcher is only valid with --match or --run")
         if args.stream_match_features and not args.persistent_matcher:
             raise ValidationError("--stream-match-features requires --persistent-matcher")
+        if args.shared_snapshot_envelope and not args.persistent_matcher:
+            raise ValidationError('--shared-snapshot-envelope requires --persistent-matcher')
         if args.rig_frame_manifest is not None:
             if args.pair_source != "temporal-pyramid":
                 raise ValidationError("--rig-frame-manifest requires --pair-source temporal-pyramid")
@@ -2433,6 +2480,7 @@ def main(argv: list[str] | None = None) -> int:
                 resume=not args.no_resume,
                 persistent_matcher=args.persistent_matcher,
                 stream_match_features=args.stream_match_features,
+                shared_snapshot_envelope=args.shared_snapshot_envelope,
                 feature_manifest_path=feature_manifest_path,
             )
             persistent_worker_measurement = match_result.get("persistent_worker")

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -61,6 +61,17 @@ class ElectroBenchmarkTests(unittest.TestCase):
         self.assertNotIn('--shared-snapshot-envelope', benchmark.build_persistent_match_command(Path('worker'), **kwargs))
         self.assertIn('--shared-snapshot-envelope', benchmark.build_persistent_match_command(Path('worker'), shared_snapshot_envelope=True, **kwargs))
 
+    def test_match_dispatch_forwards_shared_snapshot_flag(self):
+        kwargs = dict(binary=Path('worker'), features_dir=Path('features'), calibration_dir=Path('calibration'),
+                      feature_manifest_path=Path('features.json'), shared_snapshot_envelope=True)
+        with mock.patch.object(benchmark, 'run_persistent_matcher', return_value={'ok': True}) as worker:
+            result = benchmark.run_match_shards(Path('candidate-index'), Path('match-index'),
+                                                persistent_matcher=True, **kwargs)
+            self.assertTrue(result['ok'])
+            self.assertTrue(worker.call_args.kwargs['shared_snapshot_envelope'])
+        with self.assertRaisesRegex(benchmark.ValidationError, 'persistent matcher'):
+            benchmark.run_match_shards(Path('candidate-index'), Path('match-index'), **kwargs)
+
     def test_shared_completion_records_dependency_before_marking_complete(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_benchmark_electro.py
+++ b/tests/test_benchmark_electro.py
@@ -20,6 +20,67 @@ SPEC.loader.exec_module(benchmark)
 
 
 class ElectroBenchmarkTests(unittest.TestCase):
+    def test_shared_snapshot_dependencies_are_bound_and_revalidated(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, _, _ = self._candidate(root)
+            benchmark.split_candidate_manifest(source, root / 'candidates', 2)
+            candidates = root / 'candidates/index.json'
+            benchmark.prepare_match_index(candidates, root / 'matches')
+            index_path = root / 'matches/index.json'
+            index = json.loads(index_path.read_text())
+            envelope = root / 'matches/envelope.tmp'
+            envelope.write_bytes(b'shared metadata fixture')
+            digest = benchmark.sha256_file(envelope)
+            bound = envelope.with_name(f'envelope-{digest}.vpe')
+            envelope.rename(bound)
+            for entry in index['shards']:
+                path = index_path.parent / entry['snapshot_path']
+                path.write_bytes(b'VISLOC-PAIR-CHUNK-V1\0' + bytes.fromhex(digest))
+                entry.update(status='complete', snapshot_sha256=benchmark.sha256_file(path),
+                             snapshot_envelope={'path': bound.name, 'sha256': digest})
+            benchmark.atomic_json(index_path, index)
+            with mock.patch.object(benchmark, 'sha256_file', wraps=benchmark.sha256_file) as hashes:
+                benchmark.validate_match_index(index_path, candidates, require_complete=True)
+                self.assertEqual(sum(call.args[0] == bound for call in hashes.call_args_list), 1)
+            del index['shards'][0]['snapshot_envelope']
+            benchmark.atomic_json(index_path, index)
+            with self.assertRaisesRegex(benchmark.ValidationError, 'binding mismatch'):
+                benchmark.validate_match_index(index_path, candidates)
+            index['shards'][0]['snapshot_envelope'] = {'path': bound.name, 'sha256': digest}
+            benchmark.atomic_json(index_path, index)
+            bound.write_bytes(b'corrupt')
+            with self.assertRaisesRegex(benchmark.ValidationError, 'envelope hash mismatch'):
+                benchmark.validate_match_index(index_path, candidates)
+            bound.unlink()
+            with self.assertRaises(benchmark.ValidationError):
+                benchmark.validate_match_index(index_path, candidates)
+
+    def test_shared_worker_command_is_opt_in(self):
+        kwargs = dict(features_dir=Path('features'), calibration_dir=Path('calibration'), plan=Path('plan'))
+        self.assertNotIn('--shared-snapshot-envelope', benchmark.build_persistent_match_command(Path('worker'), **kwargs))
+        self.assertIn('--shared-snapshot-envelope', benchmark.build_persistent_match_command(Path('worker'), shared_snapshot_envelope=True, **kwargs))
+
+    def test_shared_completion_records_dependency_before_marking_complete(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            envelope = root / 'metadata'
+            envelope.write_bytes(b'envelope')
+            digest = benchmark.sha256_file(envelope)
+            envelope.rename(root / f'envelope-{digest}.vpe')
+            snapshot = root / 'chunk.vps'
+            snapshot.write_bytes(b'VISLOC-PAIR-CHUNK-V1\0' + bytes.fromhex(digest))
+            shard = {'id': 0, 'candidate_path': 'candidate.txt', 'snapshot_path': 'chunk.vps', 'candidate_sha256': 'a' * 64}
+            index = {'shards': [{**shard, 'status': 'running'}]}
+            validation = {'plan': {'shards': [shard]}, 'plan_path': str(root / 'plan'),
+                          'candidate': {'shards': [{'pair_count': 1}]}}
+            completion = {**shard, 'shard_id': 0, 'candidate_pairs': 1, 'pairs': 1,
+                          'accepted': 3, 'elapsed_s': 0.1, 'ordered_edge_fnv1a64': '0' * 16,
+                          'unordered_edge_fnv1a64': '0' * 16}
+            benchmark._apply_persistent_match_completions(index, validation, [completion], require_all=True)
+            self.assertEqual(index['shards'][0]['status'], 'complete')
+            self.assertEqual(index['shards'][0]['snapshot_envelope']['sha256'], digest)
+
     def _candidate(self, root: Path) -> tuple[Path, list[str], list[tuple[int, int]]]:
         names = [f"{index:06d}.png" for index in range(5)]
         pairs = [(0, 1), (0, 2), (1, 2), (1, 3), (2, 4)]


### PR DESCRIPTION
## Summary
- Forward opt-in --shared-snapshot-envelope through the persistent native runner.
- Record envelope identity with completed snapshot hashes, including completion-log recovery.
- Validate referenced metadata on resume/index checks and merge preflight; hash each common envelope once per validation call.

## Validation
- 21 focused native runner tests and 43 scripts tests passed.
- Tests cover opt-in command, completion binding, missing/changed/unrecorded dependency rejection, and one hash per common envelope.
- Read-only audit of all2500 real worker outputs found one valid shared envelope binding.

## Limits
This does not yet prove a fresh native-runner execution or runner SIGKILL/resume; those are next. Rust payload verification remains separate from Python artifact binding. E2E and COLMAP quality remain open.