### PR TITLE
test: verify native shared runner SIGKILL resume against control

### DIFF
--- a/benchmarks/electro/m8-native-shared-restart-v2.json
+++ b/benchmarks/electro/m8-native-shared-restart-v2.json
@@ -1,0 +1,20 @@
+{
+  "status": "native-matching-merge-runner-sigkill-resume-parity-pass",
+  "external_report": "/home/sasaki/datasets/openloris/corridor1-1-m8-native-shared-restart-v2/report.json",
+  "recipe": "python3 scripts/stress_native_shared_restart.py --binary SFM_BINARY --merge-binary MERGE_BINARY --output NEW_ROOT",
+  "binary_sha256": "b02f85ecce56074e000d77a6bbd63242b3d0f568294f9c22fcc9a2dc4ca01c50",
+  "merge_binary_sha256": "d85410b5b1a63eed6105450c44468aab5b772b74a62db7c63d30562a70e8d661",
+  "images": 128,
+  "candidate_pairs": 988,
+  "shards": 124,
+  "interrupted_exit_code": -9,
+  "completed_before_resume": 8,
+  "resumed_worker_shards": 116,
+  "complete_index_entries": 124,
+  "entries_with_envelope_binding": 124,
+  "prior_chunks_unchanged": true,
+  "all_shards_byte_equal": true,
+  "control_and_resumed_merged_sha256": "3148fd727c015d126da52b4febdf3fc9b9abbc6253302d4e3a1a4d0105fe79a0",
+  "scope": "Actual CLI runner with retained real features: prepare, matching, merge, partial process-group SIGKILL and resume. Not extraction, mapper restart, full10k, trajectory quality, or continuous E2E.",
+  "first_attempt": "v1 failed before matching because match dispatch lacked the shared_snapshot_envelope keyword. Fixed in PR130 head e63a1fd with a focused dispatch regression test; v1 failure logs retained."
+}

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -9,7 +9,7 @@
 PR122（head`506510e`、CI9成功）は`8ca18505b11ad871ef1329be44d2b5a5328a4bac`
 へmerge、旧branch整理済み。空語彙修正はPR123（head`ee0fa5a`）、CI9成功後
 `d5e465e41d776f01d5b197683dc5b9613f823a14`へmerge済み。
-現作業branchは`feat/runner-shared-snapshot-bindings`（PR129の子）。
+現作業branchは`test/native-runner-shared-restart`（PR130の子）。
 サブエージェントは使わない。
 
 - native候補生成は現代版`3ae253a`だと3,761ペア差。旧版`a7ff5ff`再buildで
@@ -145,6 +145,17 @@ runner tests21件/scripts tests43件通過。欠落/改変/未記録依存・完
 
 更新: PR129はhead`ecd3819`でCI9成功後`7fe9e7d885bb0d22f16721ef35cb5aabbd4aef23`へmerge。
 旧branchをremote/local整理、現branchをmainへrebase済み。
+
+更新: 実native runner restart試験のv1がmatching前にTypeErrorで停止。
+run_match_shardsへのshared_snapshot_envelope引数転送漏れをPR130で修正し、
+dispatch回帰test追加。head`e63a1fd`をpush、子branchへrebase済み。最終CI待ち。
+v2試験はpass。128実特徴画像/988候補/124 shardをcontrolと中断系で実行。
+専用runner+worker process groupを8 shard完了時にSIGKILL(-9)、再開workerは残り116のみ。
+全124 shard/統合snapshotがcontrol全bytes一致、既存8ファイル不変、全indexにenvelope binding。
+証跡`m8-native-shared-restart-v2.json`、外部root同名。session7249はexit0完了。
+v1失敗logも保存、session29544はexit1完了。再poll/再起動不要。
+runner tests22通過。次はPR130最終CI/mergeと現branchのPR、全10k runner/E2E・品質改善。
+これはmatching+merge restartで、抽出・mapper・全10k restartではない。全goal未達。
 
 ### 以前の状態（上記を優先）
 

--- a/docs/codex_handover.md
+++ b/docs/codex_handover.md
@@ -157,6 +157,15 @@ v1失敗logも保存、session29544はexit1完了。再poll/再起動不要。
 runner tests22通過。次はPR130最終CI/mergeと現branchのPR、全10k runner/E2E・品質改善。
 これはmatching+merge restartで、抽出・mapper・全10k restartではない。全goal未達。
 
+更新: PR130修正head`e63a1fd`はCI9成功後`9e270c8250d7f7c0ddd4e52522657cb564aa9b37`へmerge。
+旧branchをremote/local整理し、現branchをmainへrebase済み。実restart証跡と更新計画をPR化。
+`docs/openloris_m8_m10_plan.md`最新checkpointを09-09へ更新し、既に失敗した品質候補の
+再試験を避け、全10k Python runner→連続native DAG→未達軌跡品質→最終tier行列の順を明示。
+次は既存dense10k候補/特徴を新artifact rootでrunner prepare/match/merge/completed-resume。
+候補はv2、shared snapshotは明示ON。初期入力は凍結済みなので抽出/E2E達成としない。
+Python runnerの--prepareはpersistent flag禁止なのでprepareとmatchを別CLIにする。
+測定プロセスなし。全goal未達。
+
 ### 以前の状態（上記を優先）
 
 PR117は最終head68b1f72のCI9成功後a769432へmerge、branch整理済み。

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -9,7 +9,53 @@ time and peak RSS in both mapper-only and native end-to-end comparisons.
 This plan is outcome-gated. ANN retrieval, bridge discovery, track repair, and
 BA changes are possible means, not milestone success by themselves.
 
-## Latest checkpoint (2026-09-08)
+## Latest checkpoint (2026-09-09)
+
+The shared-snapshot path now has complete dense worker parity on the retained
+10k feature bank: all 2,500 shards/80,000 candidates reproduce every legacy
+snapshot record. Borrowed-envelope merge reproduces the complete frozen merged
+file. Synthetic 1k/10k/100k writer and structural readback checks pass; the 100k
+reader loads the envelope once. Actual 128-image native matching+merge runner
+SIGKILL/resume passes against uninterrupted control, running only the remaining
+116 of 124 shards. See `docs/shared_snapshot_envelopes.md` and the full-worker,
+borrowed-merge, readback-scaling and native-shared-restart-v2 evidence JSONs.
+
+These results close specific storage/reader/restart gaps, **not** M8–M10.
+The full worker took 594.68 s versus a previous legacy replay's 557.35 s under
+a different run history; there is no demonstrated matching speedup. Neither
+synthetic 100k I/O nor the 128-image restart establishes full100k SfM or full10k
+pipeline restart. The retained atlas still misses the frozen COLMAP RMSE gate.
+
+### Remaining execution order
+
+1. Finish CI/merge for runner dependency binding and the actual runner restart
+   evidence. Reject any missing envelope on resume; keep shared output opt-in
+   until full runner integration is exercised.
+2. Exercise the real 10k dense schedule through the Python runner, including
+   its index/recovery/merge path. Use the already verified feature bank; do not
+   conflate this with extraction or candidate generation. Require full shard
+   record and merged-file parity, and validate completed-resume behavior.
+3. Assemble one executable, version-pinned native DAG covering base and dense
+   extraction, retrieval, adaptive selection, matching, repair/targeted
+   selection, source mapping and atlas integration. The dense bank also supplies
+   supplemental features; do not extract those 692 images twice. Preflight disk
+   space and an aggregate process-tree memory cap before launching extraction.
+   Measure a continuous cold run and a separately labelled resumed run, not a
+   sum of historical phase times. Four-image base and one dense extraction
+   shard parity are preflights, not full extraction completion.
+4. Address the still-failing trajectory gate on that reproducible pipeline.
+   Reuse prior negative evidence: unchanged weak-angle freezing, Huber loss,
+   fixed-boundary, and retry-cache experiments are not new candidates. Declare
+   a concrete non-GT geometric hypothesis and fixed acceptance criteria before
+   another intervention; score GT only after model publication. Do not infer
+   trajectory quality from lower reprojection cost.
+5. Only the final candidate receives the complete 1k/2.5k/5k/10k repeated
+   quality/resource matrix, full pipeline restart checks and same-condition
+   COLMAP comparison. README promotion follows those results, not these
+   infrastructure checkpoints; preserve the requested visual COLMAP comparison
+   and omit a memory-before/after table.
+
+## Previous checkpoint (2026-09-08)
 
 All21 producing source executions have now regenerated their retained outputs
 (five recorded-command replays, sixteen explicit new-policy reproductions).

--- a/docs/shared_snapshot_envelopes.md
+++ b/docs/shared_snapshot_envelopes.md
@@ -12,8 +12,13 @@ validation and merge preflight reject missing, changed, or unrecorded envelope
 dependencies. Within one validation call, each immutable envelope is hashed
 once. The Rust reader separately validates payload checksums and bindings.
 Defaults remain legacy; mixed legacy/shared completed shards can be read.
-This runner integration is unit-tested; a fresh real runner interruption test
-is still required, separately from the converter SIGKILL test below.
+`stress_native_shared_restart.py` now tests the actual CLI runner with 128 real
+feature files and 988 local candidate pairs (124 shards). The runner/worker
+process group was SIGKILLed after eight completed shards; resume ran only the
+remaining 116. All 124 chunks and the merged snapshot match uninterrupted control
+bytes, prior chunks are unchanged, and all complete index entries bind their
+envelopes. Evidence: `m8-native-shared-restart-v2.json`. This covers matching and
+merge restart, not extraction, mapper restart, full10k or continuous E2E.
 
 Each directory stores immutable `envelope-<sha256>.vpe` files and pair chunks.
 The envelope is the exact v1 payload prefix through verifier configuration;

--- a/scripts/stress_native_shared_restart.py
+++ b/scripts/stress_native_shared_restart.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Linux real runner process-group SIGKILL/restart versus uninterrupted control."""
+import argparse
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+from benchmark_electro import write_candidate_manifest
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--merge-binary', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    if not sys.platform.startswith('linux'):
+        parser.error('This process-group interruption fixture requires Linux')
+    binary = args.binary.resolve(strict=True)
+    merger = args.merge_binary.resolve(strict=True)
+    root = args.output.resolve()
+    root.mkdir()
+    features = root / 'features'
+    features.mkdir()
+    base = Path('/home/sasaki/datasets/openloris')
+    source = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
+    selected = sorted(source.glob('*_features.txt'))[:128]
+    if len(selected) != 128:
+        raise RuntimeError('Expected 128 real feature files')
+    for path in selected:
+        (features / path.name).symlink_to(path.resolve(strict=True))
+    names = [path.name.removesuffix('_features.txt') + '.png' for path in selected]
+    pairs = [(i, j) for i in range(len(names)) for j in range(i + 1, min(i + 9, len(names)))]
+    runner = Path(__file__).resolve().with_name('benchmark_electro.py')
+    common = [sys.executable, str(runner), '--features-dir', str(features),
+              '--calibration-dir', str(base / 'corridor1-1-m5/tiers/tier-10000/calibration'),
+              '--binary', str(binary), '--merge-binary', str(merger), '--pairs-per-shard', '8']
+
+    def run(command, log):
+        with log.open('w') as stream:
+            result = subprocess.run(command, stdout=stream, stderr=subprocess.STDOUT, timeout=300)
+        if result.returncode:
+            raise RuntimeError(f'Runner failed ({result.returncode}); see {log}')
+
+    commands = {}
+    for name in ('control', 'resumed'):
+        output = root / name
+        output.mkdir()
+        write_candidate_manifest(output / 'candidates.txt', names, pairs)
+        command = [*common, '--artifact-root', str(output)]
+        run([*command, '--prepare'], root / f'{name}-prepare.log')
+        commands[name] = [*command, '--match', '--persistent-matcher', '--stream-match-features',
+                          '--shared-snapshot-envelope', '--resume']
+    run(commands['control'], root / 'control.log')
+    interrupted = root / 'resumed'
+    worker_log = interrupted / 'matches/persistent-match.log'
+    killed = False
+    with (root / 'interrupted.log').open('w') as stream:
+        process = subprocess.Popen(commands['resumed'], stdout=stream, stderr=subprocess.STDOUT,
+                                   start_new_session=True)
+        try:
+            deadline = time.monotonic() + 180
+            while process.poll() is None and time.monotonic() < deadline:
+                if worker_log.exists() and worker_log.read_text().count('persistent-match-complete ') >= 8:
+                    os.killpg(process.pid, signal.SIGKILL)  # Our isolated child group only.
+                    killed = True
+                    break
+                time.sleep(0.02)
+            if process.poll() is None and not killed:
+                os.killpg(process.pid, signal.SIGKILL)
+            exit_code = process.wait(timeout=10)
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=10)
+    prior = {path.name: sha(path) for path in (interrupted / 'matches').glob('*.vps')}
+    expected = {path.name: sha(path) for path in (root / 'control/matches').glob('*.vps')}
+    if not killed or exit_code != -signal.SIGKILL or not 0 < len(prior) < len(expected):
+        raise RuntimeError('Did not confirm a partial runner SIGKILL')
+    run(commands['resumed'], root / 'resume.log')
+    actual = {path.name: sha(path) for path in (interrupted / 'matches').glob('*.vps')}
+    control_merged = sha(root / 'control/mapping/verified-merged.vps')
+    resumed_merged = sha(interrupted / 'mapping/verified-merged.vps')
+    unchanged = all(actual.get(name) == digest for name, digest in prior.items())
+    report = {'status': 'pass' if actual == expected and unchanged and control_merged == resumed_merged else 'fail',
+              'binary_sha256': sha(binary), 'merge_binary_sha256': sha(merger),
+              'images': len(names), 'candidate_pairs': len(pairs), 'shards': len(expected),
+              'interrupted_exit_code': exit_code, 'completed_before_resume': len(prior),
+              'prior_chunks_unchanged': unchanged, 'all_shards_byte_equal': actual == expected,
+              'control_merged_sha256': control_merged, 'resumed_merged_sha256': resumed_merged,
+              'scope': '128-image real-feature matching+merge runner restart, not feature extraction, mapper restart, full10k or continuous E2E.'}
+    (root / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a real CLI runner interruption harness using 128 retained feature images and 988 local candidate pairs.
- Interrupt the isolated runner/worker process group after eight completed shards and compare resumed output with uninterrupted control.
- Reconcile the execution plan with achieved infrastructure gates and still-open 10k runner/native E2E/trajectory gates.

## Evidence
- Actual SIGKILL exit-9; resume ran remaining116 of124 shards.
- All124 shard files and the merged snapshot match control bytes; prior8 chunks unchanged, all index entries bind envelopes.
- First attempt exposed match dispatch keyword forwarding omission, fixed and regression-tested in merged PR130.
- 22 runner tests and 43 scripts tests passed in prior validation; harness py_compile passed.

## Limits
128-image matching+merge restart only, not feature extraction, mapper restart, full10k, trajectory quality or continuous E2E. Next execute the full frozen10k schedule through the Python runner and completed resume.