### PR TITLE
feat: immutable adaptive feature sharing with 10k parity

### DIFF
--- a/benchmarks/electro/m8-linked-adaptive-bank-v2.json
+++ b/benchmarks/electro/m8-linked-adaptive-bank-v2.json
@@ -1,0 +1,20 @@
+{
+  "schema": "m8-linked-adaptive-bank-v2",
+  "status": "pass",
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-linked-adaptive-bank-v2",
+  "files": 10000,
+  "linked_files": 9308,
+  "selected_independent_files": 692,
+  "inventory_sha256": "c8d22b395f172b9326837ea220e916617e2929856ea45d2c7e44ec5bda43e6f1",
+  "selection_sha256": "fc0e26c55a75bab87ebf6b15187ea4666876e5de076c6961aa05ed8b4c018b57",
+  "all_reference_bytes_equal": true,
+  "base_bytes_unchanged": true,
+  "resume_reused": 10000,
+  "resume_written": 0,
+  "shared_logical_bytes": 1662345890,
+  "new_regular_file_allocated_bytes": 257925120,
+  "publication_wall_seconds": 4.826319043990225,
+  "allocation_excludes": "directory entries, metadata, logs and report",
+  "scope": "Retained-bank publication parity; not fresh extraction, E2E, peak-DAG disk, RSS, independent backup or speedup evidence.",
+  "failed_preflight": "v1 rejected the tier's source symlinks before publication. v2 uses their verified common real directory, with exact 10k membership and resolved path equality checked. No input bytes were modified."
+}

--- a/benchmarks/electro/m8-native-e2e-storage-preflight-v1.json
+++ b/benchmarks/electro/m8-native-e2e-storage-preflight-v1.json
@@ -1,0 +1,17 @@
+{
+  "schema": "m8-native-e2e-storage-preflight-v1",
+  "date": "2026-09-09",
+  "status": "do-not-launch-all-banks-retained",
+  "dataset_root": "/home/sasaki/datasets/openloris",
+  "measurement": "Sum st_size of immediate regular files (following bank symlinks); filesystem free from shutil.disk_usage(dataset_root). Logical bytes, not allocated blocks or a complete DAG peak estimate.",
+  "banks": {
+    "corridor1-1-m5/tiers/tier-10000/features256": {"files": 10000, "bytes": 1689203490},
+    "corridor1-1-m8-dense256x2-full10k-v2/features": {"files": 20000, "bytes": 4724000399},
+    "corridor1-1-m8-adaptive-bank-publication-v1/features": {"files": 10000, "bytes": 1918894637}
+  },
+  "feature_banks_only_bytes": 8332098526,
+  "root_free_bytes_at_observation": 8914128896,
+  "remaining_before_matching_models_and_temporary_files": 582030370,
+  "decision": "Do not launch continuous extraction yet. Assemble artifact lifetimes and peak storage requirements first. Existing evidence is protected. This observation does not authorize deleting banks or silently using retained features in a cold E2E run.",
+  "next": "Version-pin the complete execution DAG; identify last consumers of newly generated artifacts, keep resume dependencies explicit, and recheck actual free space before launch. A sampled process-tree RSS monitor is not a hard memory cap."
+}

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -228,6 +228,17 @@ claims.
 
 ## Extraction and storage preflights
 
+The 2026-09-09 post-full-runner preflight found 8,914,128,896 bytes free on
+the dataset filesystem. Fresh base, dense (including loci) and adaptive banks
+alone require 8,332,098,526 logical bytes, leaving only 582,030,370 bytes before
+matching outputs, models, allocation overhead and temporary files. Do not launch
+an all-banks-retained cold run under that observation. See
+`m8-native-e2e-storage-preflight-v1.json`. This is not a complete peak-storage
+estimate: the executable DAG must establish last consumers and resume dependencies
+before releasing any newly generated intermediate. Retained evidence stays
+protected; using retained feature banks would change a cold extraction-inclusive
+measurement into a resumed/replay measurement. Recheck free space at launch.
+
 ### Snapshot storage audit
 
 `scripts/audit_snapshot_envelopes.py` measured the 2,500 dense matching snapshots:

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -239,6 +239,18 @@ before releasing any newly generated intermediate. Retained evidence stays
 protected; using retained feature banks would change a cold extraction-inclusive
 measurement into a resumed/replay measurement. Recheck free space at launch.
 
+`merge_sift_supplements.py --hardlink-unselected` is an opt-in storage primitive
+for newly generated immutable banks on the same filesystem. Unselected files
+share their base inode; selected files still use independent atomic publication.
+Default behavior remains independent copies. Cross-device linking fails without
+silently copying, and source symlinks are rejected for new links. Never edit either
+bank in place: this mode is not independent backup storage. Resume compares bytes
+against current inputs, so an externally pinned base manifest must be validated
+to detect mutations that would affect both links. No input file is deleted.
+Unit tests cover copy/link inventory equality, selected-file independence, resume
+and cross-device failure; real10k linked-bank parity and peak-DAG disk accounting
+remain required before this is used in a measured continuous run.
+
 ### Snapshot storage audit
 
 `scripts/audit_snapshot_envelopes.py` measured the 2,500 dense matching snapshots:

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -248,8 +248,14 @@ bank in place: this mode is not independent backup storage. Resume compares byte
 against current inputs, so an externally pinned base manifest must be validated
 to detect mutations that would affect both links. No input file is deleted.
 Unit tests cover copy/link inventory equality, selected-file independence, resume
-and cross-device failure; real10k linked-bank parity and peak-DAG disk accounting
-remain required before this is used in a measured continuous run.
+and cross-device failure. The real10k probe now passes: 9,308 shared files and
+692 independent selected files exactly match the retained adaptive bank; base
+bytes are unchanged and resume reuses all10k. Newly allocated regular file blocks
+total 257,925,120 bytes, excluding directories/metadata/logs. Evidence:
+`m8-linked-adaptive-bank-v2.json`. The initial v1 correctly rejected source
+symlinks; v2 checks the tier's exact membership and resolves every entry to the
+common real base directory before using it. Peak-DAG disk accounting remains
+required before a measured continuous run; this is not extraction or E2E proof.
 
 ### Snapshot storage audit
 

--- a/scripts/merge_sift_supplements.py
+++ b/scripts/merge_sift_supplements.py
@@ -85,7 +85,7 @@ def bank_chunks(base, supplement, selected):
             yield from iter(lambda: stream.read(1024 * 1024), b"")
 
 
-def write_bank(base, supplement, selection, output, resume=False):
+def write_bank(base, supplement, selection, output, resume=False, hardlink_unselected=False):
     names = selection["image_names"]
     if len(names) != len(set(names)):
         raise ValueError("duplicate selected image")
@@ -134,7 +134,17 @@ def write_bank(base, supplement, selection, output, resume=False):
             # Keep orphaned staging files outside the bank after SIGKILL.
             # Hard-link publication requires the parent and bank to share a
             # filesystem; EXDEV fails closed without publishing partial bytes.
-            publish_file(destination, measured(), staging_directory=output.parent)
+            if hardlink_unselected and name not in selected:
+                source = base / name
+                if source.is_symlink() or not source.is_file():
+                    raise ValueError(f"hardlink source must be a regular nonsymlink file: {name}")
+                for _ in measured():
+                    pass
+                # Opt-in immutable-bank contract: never modify either link in
+                # place. EXDEV fails closed; do not silently copy across disks.
+                os.link(source, destination)
+            else:
+                publish_file(destination, measured(), staging_directory=output.parent)
             written += 1
         inventory.update(f"{name}\t{size}\t{hasher.hexdigest()}\n".encode())
     return {"files": len(expected), "written": written, "reused": reused,
@@ -146,9 +156,12 @@ def main():
     for flag in ("base", "supplement", "selection", "output"):
         parser.add_argument("--" + flag, type=Path, required=True)
     parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--hardlink-unselected", action="store_true",
+                        help="Share unchanged base files on the same filesystem; both banks must remain immutable")
     args = parser.parse_args()
     result = write_bank(args.base, args.supplement,
-                        json.loads(args.selection.read_text()), args.output, args.resume)
+                        json.loads(args.selection.read_text()), args.output, args.resume,
+                        args.hardlink_unselected)
     print(json.dumps(result, indent=2, sort_keys=True))
 
 

--- a/scripts/probe_linked_adaptive_bank.py
+++ b/scripts/probe_linked_adaptive_bank.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Validate immutable hardlink publication against the retained real 10k bank."""
+import argparse
+import json
+import os
+from pathlib import Path
+import time
+
+from merge_sift_supplements import write_bank
+from replay_native_candidates import sha
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    root = args.output.resolve()
+    root.mkdir()
+    dataset = Path('/home/sasaki/datasets/openloris')
+    base = dataset / 'corridor1-1-m5/feature-extract/features'
+    tier = dataset / 'corridor1-1-m5/tiers/tier-10000/features256'
+    dense = dataset / 'corridor1-1-m8-dense256x2-full10k-v2/features'
+    reference = dataset / 'corridor1-1-m8-adaptive-bank-publication-v1/features'
+    selection_path = dataset / 'corridor1-1-m8-adaptive32-halo8-10k-v1/selection.json'
+    selection = json.loads(selection_path.read_text())
+    selected = {Path(name).stem + '_features.txt' for name in selection['image_names']}
+    report = {'status': 'running', 'selection_sha256': sha(selection_path),
+              'scope': 'Retained-bank publication parity and incremental file allocation, not extraction, E2E, RSS or independent backup.'}
+
+    def save():
+        (root / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+
+    save()
+    try:
+        assert {p.name for p in tier.glob('*_features.txt')} == {p.name for p in base.glob('*_features.txt')}
+        assert all(p.resolve() == base / p.name for p in tier.glob('*_features.txt'))
+        before = {p.name: sha(p) for p in base.glob('*_features.txt')}
+        expected = {p.name: sha(p) for p in reference.glob('*_features.txt')}
+        assert len(before) == len(expected) == 10000 and len(selected) == 692
+        started = time.monotonic()
+        report['publication'] = write_bank(base, dense, selection, root / 'features', hardlink_unselected=True)
+        report['publication_wall_seconds'] = time.monotonic() - started
+        actual = {p.name: sha(p) for p in (root / 'features').iterdir()}
+        assert actual == expected
+        linked = allocated = shared_bytes = 0
+        for name in actual:
+            path = root / 'features' / name
+            shared = os.path.samefile(path, base / name)
+            assert shared == (name not in selected)
+            linked += shared
+            if shared:
+                shared_bytes += path.stat().st_size
+            else:
+                allocated += path.stat().st_blocks * 512
+        report['resume'] = write_bank(base, dense, selection, root / 'features',
+                                      resume=True, hardlink_unselected=True)
+        assert report['resume']['reused'] == 10000 and report['resume']['written'] == 0
+        assert before == {p.name: sha(p) for p in base.glob('*_features.txt')}
+        assert actual == {p.name: sha(p) for p in (root / 'features').iterdir()}
+        report.update(status='pass', files=10000, selected_independent_files=692,
+                      linked_files=linked, shared_logical_bytes=shared_bytes,
+                      new_regular_file_allocated_bytes=allocated,
+                      allocation_excludes='directory entries, metadata, logs and report',
+                      all_reference_bytes_equal=True, base_bytes_unchanged=True)
+    except BaseException as error:
+        report.update(status='fail', error=repr(error))
+        save()
+        raise
+    save()
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_merge_sift_supplements.py
+++ b/scripts/tests/test_merge_sift_supplements.py
@@ -5,6 +5,8 @@ import tempfile
 import subprocess
 import sys
 import os
+import errno
+from unittest.mock import patch
 
 SPEC = importlib.util.spec_from_file_location(
     "merge_sift_supplements", Path(__file__).resolve().parents[1] / "merge_sift_supplements.py")
@@ -13,6 +15,41 @@ SPEC.loader.exec_module(MODULE)
 
 
 class MergeTests(unittest.TestCase):
+    def test_hardlink_failure_does_not_fallback_or_publish(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            base, supplement = root / "base", root / "supplement"
+            base.mkdir()
+            supplement.mkdir()
+            (base / "a_features.txt").write_bytes(b"0 0 base\n")
+            with patch.object(MODULE.os, "link", side_effect=OSError(errno.EXDEV, "cross-device")):
+                with self.assertRaises(OSError):
+                    MODULE.write_bank(base, supplement, {"image_names": []}, root / "out",
+                                      hardlink_unselected=True)
+            self.assertEqual(list((root / "out").iterdir()), [])
+
+    def test_opt_in_hardlinks_preserve_inventory_and_selected_independence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            base, supplement = root / "base", root / "supplement"
+            base.mkdir()
+            supplement.mkdir()
+            (base / "a_features.txt").write_bytes(b"0 0 base\n")
+            (base / "b_features.txt").write_bytes(b"1 1 unchanged\n")
+            (supplement / "a_features.txt").write_bytes(b"2 2 novel\n")
+            selection = {"image_names": ["a.png"]}
+            control = MODULE.write_bank(base, supplement, selection, root / "copy")
+            linked = MODULE.write_bank(base, supplement, selection, root / "linked",
+                                       hardlink_unselected=True)
+            self.assertEqual(control["inventory_sha256"], linked["inventory_sha256"])
+            self.assertTrue(os.path.samefile(base / "b_features.txt", root / "linked/b_features.txt"))
+            self.assertFalse(os.path.samefile(base / "b_features.txt", root / "copy/b_features.txt"))
+            self.assertFalse(os.path.samefile(base / "a_features.txt", root / "linked/a_features.txt"))
+            resumed = MODULE.write_bank(base, supplement, selection, root / "linked",
+                                        resume=True, hardlink_unselected=True)
+            self.assertEqual(resumed["reused"], 2)
+            self.assertEqual(resumed["inventory_sha256"], control["inventory_sha256"])
+
     @unittest.skipIf(os.name == "nt", "POSIX SIGKILL recovery test")
     def test_sigkill_staging_does_not_block_bank_resume(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Adds opt-in hardlink publication for unchanged adaptive features; default independent copy is preserved. Shared banks must remain immutable and are not independent backups. Cross-device links fail without fallback; source symlinks are rejected. Real 10k probe matches all reference bytes, validates 9308 shared and 692 independent files, unchanged base bytes and complete resume reuse. Added file allocation is 257925120 bytes excluding metadata. 45 script tests passed. Includes failed v1 source-layout preflight and successful v2 evidence. No extraction, E2E, RSS or speedup claim; full DAG disk accounting remains open.