### PR TITLE
feat: compile native source mapper recipes and atlas bindings

### DIFF
--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -54,6 +54,24 @@ process tree with wall/RSS accounting, and evaluate the unchanged COLMAP gates.
 The earlier 1,250-image extraction and synthetic bank-only 100k tests do not
 close full10k extraction, whole-pipeline restart or full SfM100k I/O gates.
 
+The source-mapping portion can now be compiled without executing shell snippets:
+
+```sh
+python3 scripts/build_native_source_recipe.py
+```
+
+This emits 21 argv templates and 23 atlas node bindings from the successful
+source reproduction evidence. Binary/source identities, evidence hashes,
+timeouts and expected model hashes are retained. Node model hashes must agree
+with their producing source evidence. The source4200 debug environment is
+preserved explicitly; apply environment removals before overrides. All five
+input path flags and the output directory become named placeholders; an
+unconverted absolute argv path is rejected. This is a recipe compiler, not a
+runner: it does not validate a live binary, extract features, execute mapping,
+enforce RSS, or establish input provenance. The future executor must bind inputs
+to outputs of the same cold run and verify them before launch. Expected model
+hashes are post-execution comparison data, never reconstruction inputs.
+
 Disk cleanup on 2026-09-09 restored about 21 GiB of root free space before the
 next replay. Do not silently move measured outputs to memory-backed storage or
 discard retained evidence to obtain a pass.

--- a/scripts/build_native_source_recipe.py
+++ b/scripts/build_native_source_recipe.py
@@ -59,7 +59,8 @@ def build(evidence_root):
     if len(paths) != 21:
         raise ValueError('Expected exactly 21 source executions')
     executions = [compile_execution(path) for path in paths]
-    bindings = json.loads((evidence_root / 'm8-openloris-regenerated-nodes-v1.json').read_text())['audit']['rows']
+    binding_bytes = (evidence_root / 'm8-openloris-regenerated-nodes-v1.json').read_bytes()
+    bindings = json.loads(binding_bytes)['audit']['rows']
     by_evidence = {row['evidence']: row for row in executions}
     nodes = []
     for row in bindings:
@@ -73,6 +74,7 @@ def build(evidence_root):
     if len(nodes) != 23 or len({row['node'] for row in nodes}) != 23:
         raise ValueError('Expected 23 unique atlas nodes')
     return {'schema': 'native-source-recipe-v1', 'executions': executions, 'nodes': nodes,
+            'node_evidence_sha256': hashlib.sha256(binding_bytes).hexdigest(),
             'scope': 'Non-executing source-mapping templates only. Bind and validate newly generated inputs, binary hash, environment and resource limits before execution. Not a complete E2E DAG or a passing quality result.'}
 
 

--- a/scripts/build_native_source_recipe.py
+++ b/scripts/build_native_source_recipe.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Compile reproduced source-mapper evidence into argv templates; never execute it."""
+import hashlib
+import json
+from pathlib import Path
+import shlex
+
+
+INPUTS = {
+    '--manifest': '{rig_manifest}',
+    '--features-dir': '{adaptive_features}',
+    '--append-features-dir': '{dense_features}',
+    '--snapshot': '{targeted_admission}',
+    '--deferred-overlay-snapshot': '{dense_snapshot}',
+}
+
+
+def compile_execution(path):
+    raw = path.read_bytes()
+    evidence = json.loads(raw)
+    if 'RAYON_NUM_THREADS=1' not in shlex.split(evidence['command']):
+        raise ValueError('Missing recorded single-thread environment')
+    line = evidence['audit']['time'].splitlines()[0]
+    command = shlex.split(shlex.split(line.split('Command being timed: ', 1)[1])[0])
+    if command[:4] != ['timeout', '--signal=TERM', '--kill-after=10s', '180s']:
+        raise ValueError('Unexpected timeout wrapper')
+    command = command[4:]
+    environment = {'RAYON_NUM_THREADS': '1'}
+    if command[:2] == ['env', 'VISLOC_DEFERRED_DEBUG=1']:
+        environment['VISLOC_DEFERRED_DEBUG'] = '1'
+        command = command[2:]
+    if Path(command[0]).name != 'rig-0466499':
+        raise ValueError('Unexpected mapper executable')
+    command[0] = '{mapper_binary}'
+    identity = path.stem.removeprefix('m8-openloris-').removesuffix('-v1')
+    substitutions = dict(INPUTS, **{'--out-colmap': '{run_root}/sources/' + identity + '/model'})
+    for flag, value in substitutions.items():
+        if command.count(flag) != 1 or command.index(flag) + 1 >= len(command):
+            raise ValueError(f'Missing/duplicate path flag: {flag}')
+        command[command.index(flag) + 1] = value
+    if any(value.startswith('/') for value in command):
+        raise ValueError('Unbound absolute path remains')
+    expected = evidence['audit']['new_hashes']
+    if not expected or not evidence['audit']['exact']:
+        raise ValueError('Source lacks exact reproduction evidence')
+    return {'id': identity, 'argv': command, 'environment': environment,
+            'unset_environment': ['VISLOC_SFM_DEBUG', 'VISLOC_SFM_DEBUG_BA',
+                                  'VISLOC_BA_TRACE_PHASE_TIMING', 'VISLOC_DEFERRED_DEBUG'],
+            'environment_order': 'unset listed variables, then apply environment',
+            'timeout_seconds': 180, 'binary_sha256': evidence['binary_sha256'],
+            'source_commit': evidence['build_commit'],
+            'evidence': path.name, 'evidence_sha256': hashlib.sha256(raw).hexdigest(),
+            'expected_model_hashes': expected}
+
+
+def build(evidence_root):
+    paths = sorted([*evidence_root.glob('m8-openloris-source-spec-*-v1.json'),
+                    *evidence_root.glob('m8-openloris-source-replay-*-v1.json')])
+    if len(paths) != 21:
+        raise ValueError('Expected exactly 21 source executions')
+    executions = [compile_execution(path) for path in paths]
+    bindings = json.loads((evidence_root / 'm8-openloris-regenerated-nodes-v1.json').read_text())['audit']['rows']
+    by_evidence = {row['evidence']: row for row in executions}
+    nodes = []
+    for row in bindings:
+        execution = by_evidence[Path(row['evidence']).name]
+        component = Path(row['images']).parent.name
+        for name, digest in row['hashes'].items():
+            if execution['expected_model_hashes'].get(component + '/' + name) != digest:
+                raise ValueError('Node/source hash mismatch')
+        nodes.append({'node': row['node'], 'offset': row['offset'],
+                      'execution': execution['id'], 'component': component})
+    if len(nodes) != 23 or len({row['node'] for row in nodes}) != 23:
+        raise ValueError('Expected 23 unique atlas nodes')
+    return {'schema': 'native-source-recipe-v1', 'executions': executions, 'nodes': nodes,
+            'scope': 'Non-executing source-mapping templates only. Bind and validate newly generated inputs, binary hash, environment and resource limits before execution. Not a complete E2E DAG or a passing quality result.'}
+
+
+if __name__ == '__main__':
+    print(json.dumps(build(Path(__file__).resolve().parents[1] / 'benchmarks/electro'), indent=2))

--- a/scripts/tests/test_native_source_recipe.py
+++ b/scripts/tests/test_native_source_recipe.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from build_native_source_recipe import build, compile_execution, INPUTS
+
+
+class SourceRecipeTests(unittest.TestCase):
+    root = Path(__file__).resolve().parents[2] / 'benchmarks/electro'
+
+    def test_all_sources_and_nodes_bind_without_retained_paths(self):
+        recipe = build(self.root)
+        self.assertEqual(len(recipe['executions']), 21)
+        self.assertEqual(len(recipe['nodes']), 23)
+        for row in recipe['executions']:
+            self.assertFalse(any(arg.startswith('/') for arg in row['argv']))
+            for flag, value in INPUTS.items():
+                self.assertEqual(row['argv'][row['argv'].index(flag) + 1], value)
+        debug = [r['id'] for r in recipe['executions'] if 'VISLOC_DEFERRED_DEBUG' in r['environment']]
+        self.assertEqual(debug, ['source-replay-4200'])
+
+    def test_unknown_input_path_is_rejected(self):
+        original = self.root / 'm8-openloris-source-spec-0-v1.json'
+        evidence = json.loads(original.read_text())
+        evidence['audit']['time'] = evidence['audit']['time'].replace('--manifest ', '--unknown-input ')
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / original.name
+            path.write_text(json.dumps(evidence))
+            with self.assertRaisesRegex(ValueError, 'path flag'):
+                compile_execution(path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Compiles 21 reproduced mapper argv templates and 23 atlas node bindings without evaluating shell snippets. Pins evidence and node-binding hashes; preserves mapper hash, source identity, timeout, environment and expected output hashes. Replaces all five input paths and output paths with placeholders. Node/source hash mismatches and unbound absolute argv paths are rejected. 47 script tests passed. This does not execute mapping or certify live binary/input provenance, full DAG memory/disk, extraction, E2E or quality. Stacked on PR133; retarget after its merge.