### PR TITLE
feat: measure native command scope under explicit memory limits

### DIFF
--- a/benchmarks/electro/m8-native-cgroup-preflight-v1.json
+++ b/benchmarks/electro/m8-native-cgroup-preflight-v1.json
@@ -1,0 +1,17 @@
+{
+  "schema": "m8-native-cgroup-preflight-v1",
+  "date": "2026-09-09",
+  "status": "configuration-and-child-inheritance-pass",
+  "launcher": ["systemd-run", "--user", "--scope", "--property=MemoryMax=2G", "--property=MemorySwapMax=0"],
+  "observed_cgroup": "/user.slice/user-1000.slice/user@1000.service/app.slice/run-r85e19ce7df844b53b04fbcafafd33c95.scope",
+  "memory_max_bytes": 2147483648,
+  "memory_swap_max_bytes": 0,
+  "python_child_inherited_same_cgroup": true,
+  "probe_memory_peak_bytes": 11530240,
+  "limits": [
+    "Short Python parent/child configuration probe only; no SfM or memory-pressure/OOM test.",
+    "cgroup memory accounting includes charged file cache and kernel memory; memory.peak is not peak RSS.",
+    "The real runner must verify its own cgroup limits, capture memory.peak and memory.events before scope exit, and separately measure aggregate process-tree RSS.",
+    "Do not sum individual child high-water RSS values into a pipeline peak or silently retry uncapped after failure."
+  ]
+}

--- a/benchmarks/electro/m8-native-scope-measurement-probes-v1.json
+++ b/benchmarks/electro/m8-native-scope-measurement-probes-v1.json
@@ -1,0 +1,9 @@
+{
+  "schema": "m8-native-scope-measurement-probes-v1",
+  "status": "probe-expectations-pass",
+  "artifact_root": "/home/sasaki/datasets/openloris",
+  "normal": {"report": "m8-native-scope-measure-probe-v1.json", "status": "pass", "exit_code": 0, "sampled_aggregate_peak_rss_kib": 56588, "cgroup_memory_peak_bytes": 44490752},
+  "nonzero": {"report": "m8-native-scope-nonzero-probe-v1.json", "status": "fail", "exit_code": 7},
+  "timeout": {"report": "m8-native-scope-timeout-probe-v2.json", "status": "fail", "exit_code": -9},
+  "scope": "Real dedicated systemd user scopes with MemoryMax=2G and MemorySwapMax=0. Small Python commands only, not SfM, OOM injection, full pipeline restart or performance comparison. Timeout v1 omitted the killed child's exit code; v2 records it."
+}

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -246,6 +246,26 @@ claims.
 
 ## Extraction and storage preflights
 
+For the future continuous executor, `scripts/measure_native_scope.py` wraps a
+command in an **already configured dedicated** cgroup v2 scope:
+
+```sh
+systemd-run --user --scope --property=MemoryMax=2G --property=MemorySwapMax=0 \
+  python3 scripts/measure_native_scope.py --report NEW_REPORT.json \
+  --timeout 3600 -- COMMAND ARGUMENTS
+```
+
+It rejects different limits or initial unrelated scope members, samples aggregate
+RSS every 50 ms (including the monitor), and records cgroup `memory.peak` and
+before/after `memory.events`. Charged cache/kernel memory makes the cgroup value
+different from RSS; shared mappings can be counted repeatedly in summed RSS.
+Short peaks between samples may be missed. The cgroup is the hard limit, not the
+sampler. A timeout kills the owned command process group; leftover descendants
+or new OOM events prevent success. Commands must not escape the scope/session.
+A small 32 MiB allocation probe exited zero; a sleeping child hit its deadline
+and returned failure. These are launcher checks, not SfM resource evidence.
+The runner still needs the complete extraction-to-atlas DAG and restart protocol.
+
 The 2026-09-09 post-full-runner preflight found 8,914,128,896 bytes free on
 the dataset filesystem. Fresh base, dense (including loci) and adaptive banks
 alone require 8,332,098,526 logical bytes, leaving only 582,030,370 bytes before

--- a/scripts/measure_native_scope.py
+++ b/scripts/measure_native_scope.py
@@ -103,6 +103,7 @@ def main():
                 except ProcessLookupError:
                     pass
                 process.wait(timeout=10)
+                report['exit_code'] = process.returncode
             raise
         finally:
             report.update(wall_seconds=time.monotonic() - start,

--- a/scripts/measure_native_scope.py
+++ b/scripts/measure_native_scope.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Measure a command inside a dedicated, already memory-capped cgroup v2 scope."""
+import argparse
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import time
+
+
+def validate_limits(root):
+    maximum = (root / 'memory.max').read_text().strip()
+    swap = (root / 'memory.swap.max').read_text().strip()
+    if maximum != str(2 * 1024**3) or swap != '0':
+        raise ValueError('Require dedicated MemoryMax=2G MemorySwapMax=0 scope')
+
+
+def resident_kib(status):
+    for line in status.splitlines():
+        if line.startswith('VmRSS:'):
+            return int(line.split()[1])
+    return 0
+
+
+def scope_pids(root):
+    # Traverse descendant cgroups too; do not count the same PID twice.
+    pids = set()
+    for file in [root / 'cgroup.procs', *root.glob('**/cgroup.procs')]:
+        try:
+            pids.update(file.read_text().split())
+        except FileNotFoundError:
+            pass
+    return pids
+
+
+def sample_rss(root):
+    total = 0
+    pids = scope_pids(root)
+    for pid in pids:
+        try:
+            total += resident_kib((Path('/proc') / pid / 'status').read_text())
+        except ProcessLookupError:
+            pass
+        except FileNotFoundError:
+            pass
+    return total
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--report', type=Path, required=True)
+    parser.add_argument('--timeout', type=float, required=True)
+    parser.add_argument('command', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ['--'] else args.command
+    if not command or not 0 < args.timeout < float('inf'):
+        parser.error('Require command and finite positive timeout')
+    entry = Path('/proc/self/cgroup').read_text().strip()
+    if not entry.startswith('0::/'):
+        raise ValueError('Require unified cgroup v2')
+    root = Path('/sys/fs/cgroup') / entry[3:].lstrip('/')
+    validate_limits(root)
+    if scope_pids(root) != {str(os.getpid())}:
+        raise ValueError('Scope must initially contain only the measurement process')
+    # Exclusive creation protects previous measurements.
+    with args.report.open('x') as output:
+        report = {'status': 'running', 'command': command, 'cgroup': str(root),
+                  'rss_sampling_interval_seconds': 0.05,
+                  'scope': 'Sampled aggregate RSS includes monitor; shared pages may be counted multiple times. cgroup peak includes charged cache/kernel memory and is not RSS.'}
+        def save():
+            output.seek(0)
+            json.dump(report, output, indent=2)
+            output.write('\n')
+            output.truncate()
+            output.flush()
+        save()
+        before = (root / 'memory.events').read_text()
+        start = time.monotonic()
+        process = None
+        peak = sample_rss(root)
+        try:
+            process = subprocess.Popen(command, start_new_session=True)
+            while process.poll() is None:
+                peak = max(peak, sample_rss(root))
+                if time.monotonic() - start > args.timeout:
+                    raise TimeoutError('Command deadline exceeded')
+                time.sleep(0.05)
+            if scope_pids(root) != {str(os.getpid())}:
+                raise RuntimeError('Command left descendants running')
+            events_before = dict(line.split() for line in before.splitlines())
+            events_after = dict(line.split() for line in (root / 'memory.events').read_text().splitlines())
+            if any(int(events_after.get(k, 0)) > int(events_before.get(k, 0))
+                   for k in ('oom', 'oom_kill', 'oom_group_kill')):
+                raise RuntimeError('Memory OOM event during command')
+            report.update(exit_code=process.returncode,
+                          status='pass' if process.returncode == 0 else 'fail')
+        except BaseException as error:
+            report.update(status='fail', error=repr(error))
+            if process is not None:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait(timeout=10)
+            raise
+        finally:
+            report.update(wall_seconds=time.monotonic() - start,
+                          sampled_aggregate_peak_rss_kib=peak,
+                          cgroup_memory_peak_bytes=int((root / 'memory.peak').read_text()),
+                          memory_events_before=before,
+                          memory_events_after=(root / 'memory.events').read_text())
+            save()
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/tests/test_measure_native_scope.py
+++ b/scripts/tests/test_measure_native_scope.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from measure_native_scope import validate_limits, resident_kib
+
+
+class ScopeTests(unittest.TestCase):
+    def test_limits_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for maximum, swap, valid in [('2147483648', '0', True),
+                                          ('max', '0', False),
+                                          ('2147483648', 'max', False)]:
+                (root / 'memory.max').write_text(maximum)
+                (root / 'memory.swap.max').write_text(swap)
+                if valid:
+                    validate_limits(root)
+                else:
+                    with self.assertRaises(ValueError):
+                        validate_limits(root)
+
+    def test_rss_not_virtual_or_high_water(self):
+        self.assertEqual(resident_kib('VmSize: 999 kB\nVmHWM: 500 kB\nVmRSS: 123 kB'), 123)
+        self.assertEqual(resident_kib('State: Z'), 0)


### PR DESCRIPTION
Adds dedicated cgroup v2 command measurement, requiring MemoryMax=2G and MemorySwapMax=0. Records 50ms sampled aggregate RSS separately from cgroup memory.peak/events; propagates nonzero, timeout, lingering descendant and OOM failures. Includes 49 passing script tests and real small Python normal/nonzero/timeout probes. Not SfM memory evidence, a complete native DAG, OOM injection, or E2E result. Commands must remain in the dedicated scope/session. Stacked on PR134.