### PR TITLE
feat: explicit input bindings for frontend replay stages

### DIFF
--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -113,6 +113,16 @@ is unchanged. Binding a path is not proof that extraction ran: the enclosing
 executor must separately establish that provenance. This adapter does not yet
 connect extraction, all matching variants, admission and atlas execution.
 
+Matching replay accepts `--features-dir BANK --output NEW_MATCHING_DIRECTORY`
+alongside `--candidate-root`; merge replay accepts `--matching-root DIRECTORY
+--output NEW_MERGE_DIRECTORY`. Existing destinations remain rejected. Matching
+checks exact feature membership as well as manifest bytes, and merge retains
+its shard membership/content and final-byte checks. These options allow the
+diagnostic stages to exchange fresh outputs, but do not add extraction, an
+orchestrator, restart, or shared-envelope exports to the historical replay path.
+The final bounded-I/O runner must use the separately validated shared worker
+path, not promote legacy repeated-envelope artifacts as N²-free evidence.
+
 The external replay directories are
 `corridor1-1-m8-native-candidates-legacy-replay-v1` and
 `corridor1-1-m8-native-matching-replay-v1` under the OpenLORIS dataset root.

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -104,6 +104,15 @@ every resulting snapshot with the corresponding reference snapshot. These are
 diagnostic stage replays, not a continuous E2E runner or portable demo commands.
 Matching deliberately excludes snapshot merging and downstream reconstruction.
 
+Candidate replay now also accepts `--features-dir EXPLICIT_BANK --output
+NEW_CANDIDATE_DIRECTORY` for connection to an enclosing run. `--output` and
+`--output-name` are mutually exclusive. Both the default and explicit feature
+bank must validate against the frozen variant's manifest before output creation;
+the resolved bank and manifest hash are recorded. The final candidate comparison
+is unchanged. Binding a path is not proof that extraction ran: the enclosing
+executor must separately establish that provenance. This adapter does not yet
+connect extraction, all matching variants, admission and atlas execution.
+
 The external replay directories are
 `corridor1-1-m8-native-candidates-legacy-replay-v1` and
 `corridor1-1-m8-native-matching-replay-v1` under the OpenLORIS dataset root.

--- a/docs/openloris_m8_m10_plan.md
+++ b/docs/openloris_m8_m10_plan.md
@@ -33,7 +33,7 @@ pipeline restart. The retained atlas still misses the frozen COLMAP RMSE gate.
 2. Full10k Python runner validation now passes: all 2,500 bound shards match
    every legacy record, merged bytes match, and completed-resume does not rerun
    the matching worker or change prior chunks. See
-   `m8-full-native-shared-runner-v1.json`; finish its PR CI/merge. This is retained
+   `m8-full-native-shared-runner-v1.json` (PR132 merged). This is retained
    feature/candidate validation, not full pipeline extraction or restart.
 3. Assemble one executable, version-pinned native DAG covering base and dense
    extraction, retrieval, adaptive selection, matching, repair/targeted
@@ -43,6 +43,19 @@ pipeline restart. The retained atlas still misses the frozen COLMAP RMSE gate.
    Measure a continuous cold run and a separately labelled resumed run, not a
    sum of historical phase times. Four-image base and one dense extraction
    shard parity are preflights, not full extraction completion.
+   Current building blocks: PR133's opt-in immutable adaptive bank sharing
+   passed full10k parity/resume with 9,308 shared files and 692 independent files;
+   PR134's compiler binds 21 source commands to 23 atlas nodes. Dedicated cgroup
+   configuration/child inheritance and small command measurement probes pass,
+   but are not SfM memory evidence. Explicit feature/output binding adapters
+   preserve historical replay checks; they do not make the legacy shard format
+   suitable for the final no-quadratic-I/O claim. Remaining implementation is a
+   single executor that creates both feature banks from raw images, generates
+   candidates, uses shared matching, performs admissions/source mapping/atlas,
+   and records stage dependencies for resume. It must also budget simultaneous
+   live artifacts and recheck free space; the earlier 8.33 GB all-copy bank
+   footprint nearly exhausted the available disk. Do not replace this executor
+   with more unchanged isolated source replays or summed historical timings.
 4. Address the still-failing trajectory gate on that reproducible pipeline.
    Reuse prior negative evidence: unchanged weak-angle freezing, Huber loss,
    fixed-boundary, and retry-cache experiments are not new candidates. Declare

--- a/scripts/replay_native_candidates.py
+++ b/scripts/replay_native_candidates.py
@@ -26,6 +26,24 @@ def replace_path(command, flag, path):
     return result
 
 
+def bind_feature_input(command, manifest_path, override=None):
+    from benchmark_electro import validate_feature_manifest
+    if command.count('--features-dir') != 1:
+        raise ValueError('Missing or duplicate feature directory')
+    position = command.index('--features-dir') + 1
+    if position >= len(command):
+        raise ValueError('Missing feature directory value')
+    features = Path(override if override is not None else command[position]).resolve(strict=True)
+    validate_feature_manifest(manifest_path, features)
+    manifest = json.loads(manifest_path.read_text())
+    expected = {entry['feature'] for entry in manifest['images']}
+    actual = {path.name for path in features.iterdir()
+              if path.name.endswith(manifest['feature_suffix'])}
+    if actual != expected:
+        raise ValueError('Feature bank membership differs from frozen manifest')
+    return replace_path(command, '--features-dir', features), features
+
+
 def main():
     base = Path('/home/sasaki/datasets/openloris')
     parser = argparse.ArgumentParser(description=__doc__)
@@ -54,12 +72,8 @@ def main():
     recorded = shlex.split(first_line.split('Command being timed: ', 1)[1])[0]
     command = shlex.split(recorded)
     command[0] = str(binary)
-    if args.features_dir is not None:
-        command = replace_path(command, '--features-dir', args.features_dir.resolve(strict=True))
     # Validate either explicit or historical input before publishing any output.
-    from benchmark_electro import validate_feature_manifest
-    features = Path(command[command.index('--features-dir') + 1])
-    validate_feature_manifest(reference / 'features.json', features)
+    command, features = bind_feature_input(command, reference / 'features.json', args.features_dir)
     for flag, name in [('--export-candidate-manifest', 'candidates.txt'),
                        ('--out-colmap', 'unused-model-candidates')]:
         command = replace_path(command, flag, output / name)

--- a/scripts/replay_native_candidates.py
+++ b/scripts/replay_native_candidates.py
@@ -18,13 +18,24 @@ def sha(path):
     return result.hexdigest()
 
 
+def replace_path(command, flag, path):
+    if command.count(flag) != 1 or command.index(flag) + 1 >= len(command):
+        raise ValueError(f'Missing or duplicate path flag: {flag}')
+    result = list(command)
+    result[result.index(flag) + 1] = str(path)
+    return result
+
+
 def main():
     base = Path('/home/sasaki/datasets/openloris')
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--variant', choices=['native', 'dense'], default='native')
     parser.add_argument('--binary', type=Path, default=base / 'corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a')
     parser.add_argument('--binary-sha256', default='8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34')
-    parser.add_argument('--output-name')
+    outputs = parser.add_mutually_exclusive_group()
+    outputs.add_argument('--output-name')
+    outputs.add_argument('--output', type=Path, help='Fresh output directory for an enclosing run')
+    parser.add_argument('--features-dir', type=Path, help='Explicit bank; must match the frozen feature manifest')
     parser.add_argument('--source-commit', default='3ae253a0af909042fe0cfbdb08e8d50733b79375')
     args = parser.parse_args()
     if args.output_name is None:
@@ -33,7 +44,7 @@ def main():
         parser.error('--output-name must be a simple variant-specific candidate replay directory name')
     reference = (base / 'corridor1-1-m8-native-rig-runner-10k-v1' if args.variant == 'native'
                  else base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1')
-    output = base / args.output_name
+    output = args.output.resolve() if args.output is not None else base / args.output_name
     binary = args.binary.resolve(strict=True)
     expected_binary = args.binary_sha256
     if sha(binary) != expected_binary:
@@ -43,9 +54,15 @@ def main():
     recorded = shlex.split(first_line.split('Command being timed: ', 1)[1])[0]
     command = shlex.split(recorded)
     command[0] = str(binary)
+    if args.features_dir is not None:
+        command = replace_path(command, '--features-dir', args.features_dir.resolve(strict=True))
+    # Validate either explicit or historical input before publishing any output.
+    from benchmark_electro import validate_feature_manifest
+    features = Path(command[command.index('--features-dir') + 1])
+    validate_feature_manifest(reference / 'features.json', features)
     for flag, name in [('--export-candidate-manifest', 'candidates.txt'),
                        ('--out-colmap', 'unused-model-candidates')]:
-        command[command.index(flag) + 1] = str(output / name)
+        command = replace_path(command, flag, output / name)
     output.mkdir()  # Fail closed on an existing replay directory.
     env = dict(os.environ, RAYON_NUM_THREADS='8')
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
@@ -55,8 +72,10 @@ def main():
               'source_commit': args.source_commit,
               'reference_recipe_sha256': sha(timing),
               'reference_sha256': sha(reference / 'candidates.txt'),
+              'features_resolved': str(features.resolve()),
+              'feature_manifest_sha256': sha(reference / 'features.json'),
               'rayon_num_threads': 8, 'status': 'running',
-              'scope': 'candidate generation only; retained feature bank'}
+              'scope': 'Candidate generation only; manifest-validated bank. An explicit path does not by itself establish fresh extraction or E2E provenance.'}
     (output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
     started = time.monotonic()
     with (output / 'run.log').open('w') as log:

--- a/scripts/replay_native_matching.py
+++ b/scripts/replay_native_matching.py
@@ -13,7 +13,6 @@ import time
 from benchmark_electro import (
     candidate_image_manifest_sha256,
     parse_candidate_manifest_with_metadata,
-    validate_feature_manifest,
     write_candidate_manifest,
     write_candidate_shard_v2,
 )
@@ -73,9 +72,6 @@ def main():
         expected_pairs = 80000
     if len(names) != 10000 or len(pairs) != expected_pairs:
         raise RuntimeError('Unexpected candidate envelope')
-    output.mkdir()
-    (output / 'candidates').mkdir()
-    (output / 'matches').mkdir()
     # Use the recorded plan as a frozen schedule, not retained match outputs.
     plan = (reference / 'match-worker.plan').read_text()
     if args.variant in ('native', 'adaptive') and not same_candidate_schedule((native_reference / 'match-worker.plan').read_text(), plan):
@@ -89,6 +85,17 @@ def main():
     if is_v2 and (f'candidate_source_sha256 {source_hash}' not in plan.splitlines()
                   or f'image_manifest_sha256 {image_hash}' not in plan.splitlines()):
         raise RuntimeError('V2 plan source/image binding differs')
+    features = (base / 'corridor1-1-m5/tiers/tier-10000/features256' if args.variant == 'native'
+                else base / 'corridor1-1-m8-adaptive-bank-publication-v1/features')
+    if args.variant == 'dense':
+        features = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
+    _, features = bind_feature_input(['sfm', '--features-dir', str(features)],
+                                    reference / 'features.json', args.features_dir)
+    if f'feature_manifest_sha256 {sha(reference / "features.json")}' not in plan.splitlines():
+        raise RuntimeError('Plan does not bind the validated feature manifest')
+    output.mkdir()
+    (output / 'candidates').mkdir()
+    (output / 'matches').mkdir()
     for index, fields in enumerate(shard_rows):
         expected_candidate = f'candidates/candidate-{index:06d}.txt'
         expected_snapshot = f'matches/verified-{index:06d}.vps'
@@ -103,15 +110,6 @@ def main():
             write_candidate_manifest(destination, names, shard_pairs, metadata=metadata)
         if sha(destination) != fields[4]:
             raise RuntimeError(f'Regenerated shard differs: {index}')
-    features = (base / 'corridor1-1-m5/tiers/tier-10000/features256' if args.variant == 'native'
-                else base / 'corridor1-1-m8-adaptive-bank-publication-v1/features')
-    if args.variant == 'dense':
-        features = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
-    if args.features_dir is not None:
-        features = args.features_dir.resolve(strict=True)
-    validate_feature_manifest(reference / 'features.json', features)
-    if f'feature_manifest_sha256 {sha(reference / "features.json")}' not in plan.splitlines():
-        raise RuntimeError('Plan does not bind the validated feature manifest')
     shutil.copy2(reference / 'match-worker.plan', output / 'match-worker.plan')
     timing = reference / 'timing/persistent-match.time.txt'
     first_line = timing.read_text().splitlines()[0]
@@ -123,7 +121,6 @@ def main():
                        ('--features-dir', features),
                        ('--out-colmap', output / 'matches/unused-model-persistent')]:
         command[command.index(flag) + 1] = str(path)
-    command, features = bind_feature_input(command, reference / 'features.json', features)
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
                   'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
     report = {'status': 'running', 'command': invocation, 'rayon_num_threads': 4,

--- a/scripts/replay_native_matching.py
+++ b/scripts/replay_native_matching.py
@@ -17,7 +17,7 @@ from benchmark_electro import (
     write_candidate_manifest,
     write_candidate_shard_v2,
 )
-from replay_native_candidates import sha
+from replay_native_candidates import sha, bind_feature_input
 
 
 def snapshot_inventory(root, names):
@@ -40,6 +40,8 @@ def main():
     parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7', 'dense'], default='native')
     parser.add_argument('--candidate-root', type=Path,
                         default=base / 'corridor1-1-m8-native-candidates-replay-v1')
+    parser.add_argument('--features-dir', type=Path)
+    parser.add_argument('--output', type=Path)
     parser.add_argument('--binary', type=Path,
                         default=base / 'corridor1-1-m8-extract-resume-pilot-v1/extract-3ae253a')
     parser.add_argument('--binary-sha256',
@@ -53,7 +55,8 @@ def main():
     elif args.variant == 'dense':
         reference = base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1'
     candidate_root = args.candidate_root.resolve(strict=True)
-    output = base / f'corridor1-1-m8-{args.variant}-matching-replay-v1'
+    output = (args.output.resolve() if args.output is not None else
+              base / f'corridor1-1-m8-{args.variant}-matching-replay-v1')
     binary = args.binary.resolve(strict=True)
     expected_binary = args.binary_sha256
     candidate_ok = (args.variant == 'targeted7' or
@@ -104,6 +107,8 @@ def main():
                 else base / 'corridor1-1-m8-adaptive-bank-publication-v1/features')
     if args.variant == 'dense':
         features = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
+    if args.features_dir is not None:
+        features = args.features_dir.resolve(strict=True)
     validate_feature_manifest(reference / 'features.json', features)
     if f'feature_manifest_sha256 {sha(reference / "features.json")}' not in plan.splitlines():
         raise RuntimeError('Plan does not bind the validated feature manifest')
@@ -118,6 +123,7 @@ def main():
                        ('--features-dir', features),
                        ('--out-colmap', output / 'matches/unused-model-persistent')]:
         command[command.index(flag) + 1] = str(path)
+    command, features = bind_feature_input(command, reference / 'features.json', features)
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
                   'timeout', '--signal=TERM', '--kill-after=10s', '1800s', *command]
     report = {'status': 'running', 'command': invocation, 'rayon_num_threads': 4,

--- a/scripts/replay_native_merge.py
+++ b/scripts/replay_native_merge.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument('--variant', choices=['native', 'adaptive', 'targeted7', 'dense'], default='native')
     parser.add_argument('--binary', type=Path, required=True)
     parser.add_argument('--binary-sha256', required=True)
+    parser.add_argument('--matching-root', type=Path)
+    parser.add_argument('--output', type=Path)
     args = parser.parse_args()
     base = Path('/home/sasaki/datasets/openloris')
     reference = (base / 'corridor1-1-m8-native-rig-runner-10k-v1' if args.variant == 'native'
@@ -25,7 +27,8 @@ def main():
         reference = base / 'corridor1-1-m8-targeted7-dense256-v1'
     elif args.variant == 'dense':
         reference = base / 'corridor1-1-m8-dense256x2-10k-ann-gap128-local32-8n-v1'
-    matching = base / f'corridor1-1-m8-{args.variant}-matching-replay-v1'
+    matching = (args.matching_root.resolve(strict=True) if args.matching_root is not None else
+                base / f'corridor1-1-m8-{args.variant}-matching-replay-v1')
     report_path = matching / 'report.json'
     report = json.loads(report_path.read_text())
     accepted_status = 'complete-awaiting-merge-comparison' if args.variant == 'adaptive' else 'pass'
@@ -46,7 +49,8 @@ def main():
         if args.variant != 'adaptive' and sha(path) != sha(reference / 'matches' / name):
             raise RuntimeError(f'Snapshot changed: {name}')
         snapshots.append(path)
-    output = base / f'corridor1-1-m8-{args.variant}-merge-replay-v1'
+    output = (args.output.resolve() if args.output is not None else
+              base / f'corridor1-1-m8-{args.variant}-merge-replay-v1')
     output.mkdir()
     destination = output / 'verified-merged.vps'
     command = build_merge_command(args.binary.resolve(), destination, snapshots)

--- a/scripts/tests/test_native_candidate_binding.py
+++ b/scripts/tests/test_native_candidate_binding.py
@@ -1,12 +1,36 @@
 from pathlib import Path
 import sys
 import unittest
+import tempfile
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from replay_native_candidates import replace_path
+from replay_native_candidates import replace_path, bind_feature_input
+from benchmark_electro import feature_manifest, write_feature_manifest, ValidationError
 
 
 class CandidateBindingTests(unittest.TestCase):
+    def test_real_manifest_accepts_relocated_bank_rejects_corruption_and_extras(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bank = root / 'new-bank'
+            bank.mkdir()
+            feature = bank / 'a_features.txt'
+            feature.write_text('0 0 1 0\n')
+            manifest = root / 'features.json'
+            write_feature_manifest(manifest, feature_manifest(bank))
+            original = ['sfm', '--features-dir', '/unused-retained-bank']
+            command, actual = bind_feature_input(original, manifest, bank)
+            self.assertEqual(actual, bank.resolve())
+            self.assertEqual(command[2], str(bank.resolve()))
+            extra = bank / 'b_features.txt'
+            extra.write_text('0 0 1 0\n')
+            with self.assertRaisesRegex(ValueError, 'membership'):
+                bind_feature_input(original, manifest, bank)
+            extra.unlink()
+            feature.write_text('1 0 1 0\n')
+            with self.assertRaises(ValidationError):
+                bind_feature_input(original, manifest, bank)
+
     def test_replace_preserves_other_arguments_and_original(self):
         source = ['sfm', '--features-dir', '/old', '--topk', '128']
         result = replace_path(source, '--features-dir', Path('/new bank'))

--- a/scripts/tests/test_native_candidate_binding.py
+++ b/scripts/tests/test_native_candidate_binding.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from replay_native_candidates import replace_path
+
+
+class CandidateBindingTests(unittest.TestCase):
+    def test_replace_preserves_other_arguments_and_original(self):
+        source = ['sfm', '--features-dir', '/old', '--topk', '128']
+        result = replace_path(source, '--features-dir', Path('/new bank'))
+        self.assertEqual(result, ['sfm', '--features-dir', '/new bank', '--topk', '128'])
+        self.assertEqual(source[2], '/old')
+
+    def test_ambiguous_or_missing_flag_is_rejected(self):
+        for args in [[], ['--features-dir'], ['--features-dir', 'a', '--features-dir', 'b']]:
+            with self.assertRaises(ValueError):
+                replace_path(args, '--features-dir', Path('/new'))


### PR DESCRIPTION
Adds explicit feature/output paths to candidate and matching replay and matching-root/output to merge. Candidate and matcher validate frozen feature bytes plus exact membership; candidate validation occurs before output creation. Preserves default recipes and output equality checks. Tests52 pass; actual retained native/dense10k input manifest and membership checks pass. These are diagnostic adapters, not a full cold DAG, shared-envelope pipeline, fresh extraction or E2E claim. Stacked on PR135.