### PR TITLE
feat: bind admission and targeted selection dependencies

### DIFF
--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -221,6 +221,16 @@ The downstream selector consumes only registration membership, not these poses
 or points. Do not omit the required mapping cost. Evidence:
 `m8-openloris-targeted-selection-replay-v1.json`.
 
+`replay_targeted_selection.py` now accepts `--features-dir`, `--snapshot` and
+`--output` so this required mapper can consume an enclosing run's repair output.
+It retains the frozen repair snapshot hash and exact adaptive feature validation;
+existing output directories are rejected. These options have not yet been used
+in a continuous cold run. The three admission commands can separately be emitted
+as non-executing templates with `python3 scripts/build_native_admission_recipe.py`.
+The repair template explicitly requires the intermediate mapper's generated
+registration components. Binary/evidence/output hashes are retained, but live
+input provenance and resource enforcement are responsibilities of the executor.
+
 ## Dense overlay frontend
 
 ```sh

--- a/scripts/build_native_admission_recipe.py
+++ b/scripts/build_native_admission_recipe.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Compile three reproduced admission stages without executing retained paths."""
+import hashlib
+import json
+from pathlib import Path
+import shlex
+
+from replay_native_candidates import replace_path
+
+
+STAGES = [
+    ('native-prefix-supplement', {
+        '--base-snapshot': '{native_snapshot}', '--augmented-snapshot': '{adaptive_snapshot}',
+        '--base-features-dir': '{base_features}'}),
+    ('repair19-admission', {
+        '--base-snapshot': '{prefix_snapshot}', '--augmented-snapshot': '{adaptive_snapshot}',
+        '--base-features-dir': '{adaptive_features}',
+        '--repair-registered-components': '{prefix_registration_components}'}),
+    ('targeted7-admission', {
+        '--base-snapshot': '{repair_snapshot}', '--augmented-snapshot': '{targeted_snapshot}',
+        '--base-features-dir': '{adaptive_features}'}),
+]
+
+
+def build(root):
+    stages = []
+    for name, inputs in STAGES:
+        path = root / f'm8-openloris-{name}-replay-v1.json'
+        raw = path.read_bytes()
+        evidence = json.loads(raw)
+        if evidence['exit_status'] != 0:
+            raise ValueError('Admission evidence did not exit zero')
+        argv = shlex.split(evidence['command'])
+        if Path(argv[0]).name != 'admit_verified_bridge_snapshot':
+            raise ValueError('Unexpected admission executable')
+        argv[0] = '{admission_binary}'
+        inputs = dict(inputs, **{'--rig-manifest': '{rig_manifest}'})
+        for flag, value in inputs.items():
+            argv = replace_path(argv, flag, value)
+        argv = replace_path(argv, '--output', '{run_root}/admissions/' + name + '.vps')
+        if any(value.startswith('/') for value in argv):
+            raise ValueError('Unbound admission input remains')
+        stages.append({'id': name, 'argv': argv, 'input_bindings': inputs,
+                       'binary_sha256': evidence['binary_sha256'],
+                       'evidence_sha256': hashlib.sha256(raw).hexdigest(),
+                       'expected_snapshot_sha256': evidence['output_and_reference_sha256']})
+    return {'schema': 'native-admission-recipe-v1', 'stages': stages,
+            'scope': 'Non-executing admission templates only. Registration components must be produced by the intermediate mapper, not supplied from retained runs. Does not implement selection, extraction, execution, resume or E2E.'}
+
+
+if __name__ == '__main__':
+    print(json.dumps(build(Path(__file__).resolve().parents[1] / 'benchmarks/electro'), indent=2))

--- a/scripts/replay_targeted_selection.py
+++ b/scripts/replay_targeted_selection.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Replay the recovered repair-prefix mapper and derive unregistered targets."""
+import argparse
 import json
 import os
 from pathlib import Path
 import subprocess
 import time
 
-from benchmark_electro import parse_gnu_time, validate_feature_manifest
-from replay_native_candidates import sha
+from benchmark_electro import parse_gnu_time
+from replay_native_candidates import sha, bind_feature_input
 from select_rig_sift_supplements import parse_frames
 
 
@@ -38,18 +39,27 @@ def unregistered_frames(frames, components):
 
 def main():
     base = Path('/home/sasaki/datasets/openloris')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--features-dir', type=Path,
+                        default=base / 'corridor1-1-m8-adaptive-bank-publication-v1/features')
+    parser.add_argument('--snapshot', type=Path,
+                        default=base / 'corridor1-1-m8-repair19-admission-replay-v1/output.vps')
+    parser.add_argument('--output', type=Path,
+                        default=base / 'corridor1-1-m8-targeted-selection-replay-v1')
+    args = parser.parse_args()
     rig = base / 'corridor1-1-m8-visloc-rig/tier-10000-champion/rig-manifest.txt'
-    features = base / 'corridor1-1-m8-adaptive-bank-publication-v1/features'
-    snapshot = base / 'corridor1-1-m8-repair19-admission-replay-v1/output.vps'
+    features = args.features_dir.resolve(strict=True)
+    snapshot = args.snapshot.resolve(strict=True)
     binary = base / 'corridor1-1-m8-retry-reuse-1k-v1/rig-0466499'
     if sha(binary) != '3d744ced8b2b09cbaba26bf963e9ac31c5293538b1a8bbbee62621ccfdd70c34':
         raise RuntimeError('Saved mapper binary changed')
     if sha(snapshot) != 'ac93b28daf92b9bb4a621b9687087abbf906a1bc78cca0d8f4ea9688a1ba7a8d':
         raise RuntimeError('Reproduced repair19 snapshot changed')
-    validate_feature_manifest(base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/features.json', features)
+    _, features = bind_feature_input(['mapper', '--features-dir', str(features)],
+        base / 'corridor1-1-m8-adaptive32-halo8-10k-v1/pipeline/features.json')
     frames = parse_frames(rig.read_bytes())
     reference = base / 'corridor1-1-m8-visloc-rig/tier-10000-deferred-repair19-pair-confidence-finalfix32-v1/model'
-    output = base / 'corridor1-1-m8-targeted-selection-replay-v1'
+    output = args.output.resolve()
     output.mkdir()
     command = [str(binary), '--manifest', str(rig), '--features-dir', str(features),
                '--snapshot', str(snapshot), '--out-colmap', str(output / 'model'),

--- a/scripts/tests/test_native_admission_recipe.py
+++ b/scripts/tests/test_native_admission_recipe.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from build_native_admission_recipe import build
+
+
+class AdmissionRecipeTests(unittest.TestCase):
+    def test_admissions_bind_produced_dependencies(self):
+        recipe = build(Path(__file__).resolve().parents[2] / 'benchmarks/electro')
+        self.assertEqual(len(recipe['stages']), 3)
+        prefix, repair, targeted = recipe['stages']
+        self.assertIn('--include-prefix-supplements', prefix['argv'])
+        self.assertEqual(prefix['input_bindings']['--base-features-dir'], '{base_features}')
+        self.assertEqual(repair['input_bindings']['--repair-registered-components'], '{prefix_registration_components}')
+        self.assertEqual(targeted['input_bindings']['--base-snapshot'], '{repair_snapshot}')
+        self.assertIn('--include-all-new-pairs', targeted['argv'])
+        for stage in recipe['stages']:
+            self.assertFalse(any(arg.startswith('/') for arg in stage['argv']))
+            self.assertEqual(len(stage['expected_snapshot_sha256']), 64)


### PR DESCRIPTION
Compiles three reproduced admission argv templates with binary/evidence/output hashes and explicit generated-input bindings. Adds explicit feature/snapshot/output paths to required targeted-selection mapper, preserving frozen snapshot and feature checks. Tests53 pass; CLI help works. No new mapper execution, full cold DAG, quality or E2E claim. Stacked on PR136.