### PR TITLE
perf: bounded parallel full base feature extraction replay

### DIFF
--- a/benchmarks/electro/m8-full-base-extraction-transition-v1.json
+++ b/benchmarks/electro/m8-full-base-extraction-transition-v1.json
@@ -1,0 +1,14 @@
+{
+  "schema": "m8-full-base-extraction-transition-v1",
+  "sequential_run": "/home/sasaki/datasets/openloris/corridor1-1-m8-full-base-extraction-v1",
+  "sequential_status": "deliberately-interrupted-not-parity-pass",
+  "reason": "Observed stream extraction using approximately one CPU core. Replaced the still-live serial run with disjoint image partitions to use available CPU under the same dedicated 2 GiB scope.",
+  "termination": "Revalidated owned timeout/extractor process group 3656296 and sent SIGTERM. Harness exited 1 and recorded extraction code 143; original outputs/logs retained.",
+  "parallel_preflight": "/home/sasaki/datasets/openloris/corridor1-1-m8-base-parallel-preflight-v1",
+  "parallel_preflight_result": "Four spread-out images, two workers, all feature bytes equal; scope wrapper exit zero.",
+  "full_parallel_run": "/home/sasaki/datasets/openloris/corridor1-1-m8-full-base-extraction-v2",
+  "full_parallel_status_at_recording": "launched-awaiting-terminal-evidence",
+  "workers": 6,
+  "rayon_threads_per_worker": 1,
+  "limits": "No completed full10k parity, speedup, dense extraction or continuous E2E claim. Outer cgroup limits apply to the complete process tree; worker high-water values are not summed into aggregate RSS."
+}

--- a/benchmarks/electro/m8-full-base-extraction-v2.json
+++ b/benchmarks/electro/m8-full-base-extraction-v2.json
@@ -1,0 +1,14 @@
+{
+  "schema": "m8-full-base-extraction-v2",
+  "status": "full-feature-parity-pass-resource-ledger-incomplete",
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-full-base-extraction-v2",
+  "report_sha256": "99d41ed0f9588927adfee17eec9f6a75f0d9c0dec74b9758beb0858bd54a46b0",
+  "image_count": 10000,
+  "worker_exit_codes": [0, 0, 0, 0, 0, 0],
+  "all_feature_membership_and_bytes_equal": true,
+  "scope_report": "/home/sasaki/datasets/openloris/m8-full-base-extraction-scope-v2.json",
+  "scope_report_terminal": false,
+  "resource_limitation": "Scope report remained running after all processes and the cgroup disappeared. Final aggregate RSS, memory.peak and memory.events are unavailable. Cause not yet established. Earlier live observations confirmed the configured 2 GiB/no-swap limit and zero OOM counters, but are not a complete final resource ledger.",
+  "next": "Validate a durable detached service launcher with persisted output and terminal measurements before any long measured run. Do not label this run an aggregate RSS pass or infer a complete peak from worker peaks.",
+  "scope": "Full base extraction parity only. No full dense extraction, continuous native E2E, speedup or COLMAP quality claim."
+}

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -347,6 +347,20 @@ base SIFT recipe with the frozen image-capable extractor; all four feature files
 `m8-openloris-base-extraction-probe-v1.json`. This does not establish full10k
 extraction parity or E2E performance.
 
+The same script now accepts `--all-images --workers 6`: the full frozen 10k
+image set is split into disjoint balanced partitions, with one Rayon thread per
+worker. Each worker writes distinct feature filenames and its own log/timing;
+the harness compares the complete combined feature membership and hashes after
+all workers exit. Four-image/two-worker parity passed. Full10k six-worker replay
+is still awaiting terminal evidence in `corridor1-1-m8-full-base-extraction-v2`.
+The earlier single-worker v1 was deliberately interrupted, not completed or
+reused as a speed baseline. See `m8-full-base-extraction-transition-v1.json`.
+Use the dedicated 2 GiB scope wrapper for aggregate measurement/enforcement;
+the extraction script alone does not impose that limit. Worker RSS peaks are
+not summed. GNU timeout uses `--foreground` so workers remain in the command
+process group for wrapper timeout cleanup. This remains base extraction only,
+not dense extraction or continuous E2E.
+
 ## Empty vocabulary safety
 
 Streamed candidate export now rejects a missing/empty appearance vocabulary

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -352,7 +352,12 @@ image set is split into disjoint balanced partitions, with one Rayon thread per
 worker. Each worker writes distinct feature filenames and its own log/timing;
 the harness compares the complete combined feature membership and hashes after
 all workers exit. Four-image/two-worker parity passed. Full10k six-worker replay
-is still awaiting terminal evidence in `corridor1-1-m8-full-base-extraction-v2`.
+now passes every feature hash and exact membership, with all six workers exiting
+zero, in `corridor1-1-m8-full-base-extraction-v2`. However, the outer scope report
+remained `running` after the processes/cgroup disappeared: final aggregate RSS
+and cgroup counters were not recovered. This closes full base feature parity,
+not the resource ledger. See `m8-full-base-extraction-v2.json`; validate durable
+detached service measurement before the next long measured run.
 The earlier single-worker v1 was deliberately interrupted, not completed or
 reused as a speed baseline. See `m8-full-base-extraction-transition-v1.json`.
 Use the dedicated 2 GiB scope wrapper for aggregate measurement/enforcement;

--- a/scripts/probe_openloris_base_extraction.py
+++ b/scripts/probe_openloris_base_extraction.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import shlex
 import subprocess
+import shutil
 
 from benchmark_electro import parse_gnu_time
 from replay_native_candidates import sha
@@ -14,6 +15,8 @@ from replay_native_candidates import sha
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--all-images', action='store_true',
+                        help='Run the full frozen 10k base bank instead of four spread-out images')
     args = parser.parse_args()
     base = Path('/home/sasaki/datasets/openloris')
     source = base / 'corridor1-1-m5'
@@ -27,11 +30,16 @@ def main():
     images = sorted((source / 'images').glob('*.png'))
     if len(images) < 4:
         raise RuntimeError('Raw image bank missing')
-    selected = [images[index * (len(images) - 1) // 3] for index in range(4)]
+    if args.all_images and len(images) != 10000:
+        raise RuntimeError('Full base replay requires exactly 10000 raw images')
+    selected = images if args.all_images else [images[index * (len(images) - 1) // 3] for index in range(4)]
     reference = source / 'tiers/tier-10000/features256'
     expected = {image.stem + '_features.txt': sha(reference / (image.stem + '_features.txt'))
                 for image in selected}
     output = args.output.resolve()
+    required = sum((reference / name).stat().st_size for name in expected) + 1024**3
+    if shutil.disk_usage(output.parent).free < required:
+        raise RuntimeError('Insufficient disk for expected base bank plus 1 GiB reserve')
     output.mkdir()  # Never overwrite an existing probe.
     inputs = output / 'images'
     inputs.mkdir()
@@ -43,12 +51,14 @@ def main():
                        ('--out-colmap', output / 'unused-model')]:
         command[command.index(flag) + 1] = str(path)
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
-                  'timeout', '--signal=TERM', '--kill-after=10s', '300s', *command]
+                  'timeout', '--signal=TERM', '--kill-after=10s',
+                  '21600s' if args.all_images else '300s', *command]
     report = {'status': 'running', 'command': invocation, 'binary_sha256': binary_sha,
               'recipe_sha256': sha(recipe), 'reference_feature_sha256': expected,
               'image_sha256': {image.name: sha(image) for image in selected},
               'rayon_num_threads': 8, 'malloc_arena_max': '1',
-              'scope': 'Four-image base extraction parity only; not full10k or E2E.'}
+              'image_count': len(selected),
+              'scope': 'Base extraction parity only; full10k when --all-images is explicit. Not dense extraction, continuous E2E or a speedup claim.'}
     report_path = output / 'report.json'
     report_path.write_text(json.dumps(report, indent=2) + '\n')
     with (output / 'run.log').open('w') as log:
@@ -59,7 +69,8 @@ def main():
                   measurement=parse_gnu_time(output / 'time.txt'),
                   status='pass' if result.returncode == 0 and actual == expected else 'fail')
     report_path.write_text(json.dumps(report, indent=2) + '\n')
-    print(json.dumps(report, indent=2))
+    print(json.dumps({key: value for key, value in report.items()
+                      if key not in ('image_sha256', 'reference_feature_sha256', 'output_feature_sha256')}, indent=2))
     return 0 if report['status'] == 'pass' else 1
 
 

--- a/scripts/probe_openloris_base_extraction.py
+++ b/scripts/probe_openloris_base_extraction.py
@@ -7,9 +7,18 @@ from pathlib import Path
 import shlex
 import subprocess
 import shutil
+from concurrent.futures import ThreadPoolExecutor
 
 from benchmark_electro import parse_gnu_time
 from replay_native_candidates import sha
+
+
+def partition_images(images, workers):
+    if not 1 <= workers <= 6 or workers > len(images):
+        raise ValueError('Require 1..6 workers and at least one image per worker')
+    if len({p.stem for p in images}) != len(images):
+        raise ValueError('Image stems must be unique')
+    return [images[index::workers] for index in range(workers)]
 
 
 def main():
@@ -17,6 +26,7 @@ def main():
     parser.add_argument('--output', type=Path, required=True)
     parser.add_argument('--all-images', action='store_true',
                         help='Run the full frozen 10k base bank instead of four spread-out images')
+    parser.add_argument('--workers', type=int, default=1)
     args = parser.parse_args()
     base = Path('/home/sasaki/datasets/openloris')
     source = base / 'corridor1-1-m5'
@@ -33,6 +43,7 @@ def main():
     if args.all_images and len(images) != 10000:
         raise RuntimeError('Full base replay requires exactly 10000 raw images')
     selected = images if args.all_images else [images[index * (len(images) - 1) // 3] for index in range(4)]
+    partitions = partition_images(selected, args.workers)
     reference = source / 'tiers/tier-10000/features256'
     expected = {image.stem + '_features.txt': sha(reference / (image.stem + '_features.txt'))
                 for image in selected}
@@ -42,35 +53,50 @@ def main():
         raise RuntimeError('Insufficient disk for expected base bank plus 1 GiB reserve')
     output.mkdir()  # Never overwrite an existing probe.
     inputs = output / 'images'
-    inputs.mkdir()
-    for image in selected:
-        (inputs / image.name).symlink_to(image.resolve(strict=True))
     command[0] = str(binary)
     for flag, path in [('--images-dir', inputs),
                        ('--export-features-dir', output / 'features'),
                        ('--out-colmap', output / 'unused-model')]:
         command[command.index(flag) + 1] = str(path)
     invocation = ['/usr/bin/time', '-v', '-o', str(output / 'time.txt'),
-                  'timeout', '--signal=TERM', '--kill-after=10s',
+                  'timeout', '--foreground', '--signal=TERM', '--kill-after=10s',
                   '21600s' if args.all_images else '300s', *command]
-    report = {'status': 'running', 'command': invocation, 'binary_sha256': binary_sha,
+    invocations = []
+    for index, partition in enumerate(partitions):
+        worker_inputs = output / f'images-{index}'
+        worker_inputs.mkdir()
+        for image in partition:
+            (worker_inputs / image.name).symlink_to(image.resolve(strict=True))
+        worker = list(invocation)
+        worker[worker.index('--images-dir') + 1] = str(worker_inputs)
+        worker[worker.index('-o') + 1] = str(output / f'time-{index}.txt')
+        worker[worker.index('--out-colmap') + 1] = str(output / f'unused-model-{index}')
+        invocations.append(worker)
+    threads = '8' if args.workers == 1 else '1'
+    report = {'status': 'running', 'binary_sha256': binary_sha,
               'recipe_sha256': sha(recipe), 'reference_feature_sha256': expected,
               'image_sha256': {image.name: sha(image) for image in selected},
-              'rayon_num_threads': 8, 'malloc_arena_max': '1',
+              'rayon_num_threads': int(threads), 'malloc_arena_max': '1',
+              'worker_commands': invocations, 'workers': args.workers,
               'image_count': len(selected),
               'scope': 'Base extraction parity only; full10k when --all-images is explicit. Not dense extraction, continuous E2E or a speedup claim.'}
     report_path = output / 'report.json'
     report_path.write_text(json.dumps(report, indent=2) + '\n')
-    with (output / 'run.log').open('w') as log:
-        result = subprocess.run(invocation, stdout=log, stderr=subprocess.STDOUT,
-                                env=dict(os.environ, RAYON_NUM_THREADS='8', MALLOC_ARENA_MAX='1'))
+    def run_worker(item):
+        index, worker = item
+        with (output / f'run-{index}.log').open('w') as log:
+            return subprocess.run(worker, stdout=log, stderr=subprocess.STDOUT,
+                env=dict(os.environ, RAYON_NUM_THREADS=threads, MALLOC_ARENA_MAX='1')).returncode
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        codes = list(pool.map(run_worker, enumerate(invocations)))
     actual = {path.name: sha(path) for path in (output / 'features').glob('*_features.txt')}
-    report.update(exit_code=result.returncode, output_feature_sha256=actual,
-                  measurement=parse_gnu_time(output / 'time.txt'),
-                  status='pass' if result.returncode == 0 and actual == expected else 'fail')
+    report.update(exit_code=0 if all(code == 0 for code in codes) else 1,
+                  worker_exit_codes=codes, output_feature_sha256=actual,
+                  worker_measurements=[parse_gnu_time(output / f'time-{index}.txt') for index in range(args.workers)],
+                  status='pass' if all(code == 0 for code in codes) and actual == expected else 'fail')
     report_path.write_text(json.dumps(report, indent=2) + '\n')
     print(json.dumps({key: value for key, value in report.items()
-                      if key not in ('image_sha256', 'reference_feature_sha256', 'output_feature_sha256')}, indent=2))
+                      if key not in ('image_sha256', 'reference_feature_sha256', 'output_feature_sha256', 'worker_commands')}, indent=2))
     return 0 if report['status'] == 'pass' else 1
 
 

--- a/scripts/tests/test_base_extraction_partition.py
+++ b/scripts/tests/test_base_extraction_partition.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+import unittest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from probe_openloris_base_extraction import partition_images
+
+class PartitionTests(unittest.TestCase):
+    def test_exact_disjoint_balanced_10k(self):
+        images = [Path(f'{i}.png') for i in range(10000)]
+        groups = partition_images(images, 6)
+        flattened = [p for group in groups for p in group]
+        self.assertEqual(len(flattened), 10000)
+        self.assertEqual(set(flattened), set(images))
+        self.assertLessEqual(max(map(len, groups)) - min(map(len, groups)), 1)
+
+    def test_invalid_workers_and_collisions(self):
+        for workers in (0, 7, 2):
+            with self.assertRaises(ValueError):
+                partition_images([Path('a.png')], workers)
+        with self.assertRaises(ValueError):
+            partition_images([Path('a.png'), Path('a.jpg')], 1)


### PR DESCRIPTION
Extends the base probe to full10k and 1..6 disjoint image workers, retaining exact combined output hashes and per-worker timings. Four-image/two-worker parity passed; tests55 pass. Full10k six-worker run is live under dedicated 2GiB/no-swap cgroup. Keep draft until terminal full-file validation and scope evidence. Original serial v1 was deliberately interrupted; logs retained, no completed speed baseline. No dense extraction or continuous E2E claim. Stacked on PR137.