### PR TITLE
fix: persist long native measurements through detached services

### DIFF
--- a/benchmarks/electro/m8-durable-measurement-preflight-v1.json
+++ b/benchmarks/electro/m8-durable-measurement-preflight-v1.json
@@ -1,0 +1,15 @@
+{
+  "schema": "m8-durable-measurement-preflight-v1",
+  "status": "short-detached-probe-pass-long-probe-pending",
+  "short_service": "visloc-measure-durable-probe-v1.service",
+  "short_report": "/home/sasaki/datasets/openloris/m8-durable-measure-probe-v1.json",
+  "short_service_result": "success",
+  "short_service_main_exit_status": 0,
+  "short_measurement_status": "pass",
+  "short_sampled_aggregate_peak_rss_kib": 56900,
+  "short_cgroup_memory_peak_bytes": 45182976,
+  "long_service": "visloc-durable-long-probe-v1.service",
+  "long_artifact_root": "/home/sasaki/datasets/openloris/m8-durable-long-probe-v1",
+  "long_status_at_recording": "active/running; main PID 3712593 verified live",
+  "scope": "Launcher lifecycle only. Not long-duration completion, SfM RSS, continuous E2E or root-cause proof for the earlier missing scope ledger."
+}

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -295,6 +295,33 @@ A small 32 MiB allocation probe exited zero; a sleeping child hit its deadline
 and returned failure. These are launcher checks, not SfM resource evidence.
 The runner still needs the complete extraction-to-atlas DAG and restart protocol.
 
+For long work, use the detached service launcher instead of keeping the launch
+terminal alive:
+
+```sh
+python3 scripts/launch_native_measurement.py --unit visloc-UNIQUE-LOWERCASE-NAME \
+  --output NEW_MEASUREMENT_DIRECTORY --timeout 7200 -- COMMAND ARGUMENTS
+```
+
+Replace the example unit with an all-lowercase `visloc-` name. The launcher
+copies and hashes the monitor, configures the same memory limits, disables
+systemd argument environment expansion, persists stdout/stderr in `service.log`,
+and returns after service creation. It does not freeze the measured command's
+scripts/binaries/inputs; the executor must do that separately. `launch.json`
+with `launched-not-completed` is not a pass. Check `systemctl --user show UNIT`
+for `Result=success`, `ExecMainStatus=0`, and `SubState=exited`, plus a terminal
+passing `measurement.json`. The service has a runtime deadline and control-group
+cleanup; its retained service result is not a guarantee that cgroup counters
+remain available after exit. Persisted measurement data is still required.
+
+A short detached 32 MiB allocation probe saved its terminal ledger after the
+launch command returned. A 3,700-second low-load probe is in progress as
+`visloc-durable-long-probe-v1.service`, with artifacts under
+`/home/sasaki/datasets/openloris/m8-durable-long-probe-v1`. Long-duration success
+is not established until that service and its report are terminal. This addresses
+measurement durability, not extraction performance or the still-failing quality
+gate; the cause of the earlier missing final ledger remains unproven.
+
 The 2026-09-09 post-full-runner preflight found 8,914,128,896 bytes free on
 the dataset filesystem. Fresh base, dense (including loci) and adaptive banks
 alone require 8,332,098,526 logical bytes, leaving only 582,030,370 bytes before

--- a/scripts/launch_native_measurement.py
+++ b/scripts/launch_native_measurement.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Launch detached measured work as a persistent systemd user service."""
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+from replay_native_candidates import sha
+
+
+def launch_argv(unit, root, cwd, timeout, command):
+    if not re.fullmatch(r'visloc-[a-z0-9-]+', unit):
+        raise ValueError('Unit name must start with visloc- and contain lowercase letters/digits/hyphens')
+    if not command or not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError('Require a command and finite positive timeout')
+    return ['systemd-run', '--user', '--unit=' + unit, '--expand-environment=no',
+            '--property=MemoryMax=2G', '--property=MemorySwapMax=0',
+            '--property=RemainAfterExit=yes', '--property=KillMode=control-group',
+            '--property=RuntimeMaxSec=' + str(math.ceil(timeout) + 30),
+            '--working-directory=' + str(cwd),
+            '--property=StandardOutput=append:' + str(root / 'service.log'),
+            '--property=StandardError=append:' + str(root / 'service.log'),
+            sys.executable, str(root / 'measure_native_scope.py'),
+            '--report', str(root / 'measurement.json'), '--timeout', str(timeout), '--', *command]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--unit', required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--timeout', type=float, required=True)
+    parser.add_argument('command', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ['--'] else args.command
+    root = args.output.resolve()
+    argv = launch_argv(args.unit, root, Path.cwd(), args.timeout, command)
+    root.mkdir()  # Never overwrite prior measurements.
+    monitor = Path(__file__).with_name('measure_native_scope.py')
+    shutil.copy2(monitor, root / monitor.name)
+    digest = sha(monitor)
+    if sha(root / monitor.name) != digest:
+        raise RuntimeError('Monitor copy changed')
+    result = subprocess.run(argv, capture_output=True, text=True)
+    report = {'unit': args.unit + '.service', 'command': argv, 'monitor_sha256': digest,
+              'launch_exit_code': result.returncode, 'stdout': result.stdout, 'stderr': result.stderr,
+              'status': 'launched-not-completed' if result.returncode == 0 else 'launch-failed'}
+    (root / 'launch.json').write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+    return result.returncode
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/tests/test_launch_native_measurement.py
+++ b/scripts/tests/test_launch_native_measurement.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+import unittest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from launch_native_measurement import launch_argv
+
+class LaunchTests(unittest.TestCase):
+    def test_detached_limits_and_literal_arguments(self):
+        argv = launch_argv('visloc-test', Path('/run dir'), Path('/work'), 10, ['echo', '$literal'])
+        self.assertIn('--expand-environment=no', argv)
+        self.assertIn('--property=MemoryMax=2G', argv)
+        self.assertIn('--property=RuntimeMaxSec=40', argv)
+        self.assertNotIn('--scope', argv)
+        self.assertNotIn('--wait', argv)
+        self.assertEqual(argv[-2:], ['echo', '$literal'])
+
+    def test_invalid_arguments(self):
+        for unit, timeout, command in [('bad/name', 1, ['true']), ('visloc-test', 0, ['true']),
+                                       ('visloc-test', float('inf'), ['true']), ('visloc-test', 1, [])]:
+            with self.assertRaises(ValueError):
+                launch_argv(unit, Path('/out'), Path('/work'), timeout, command)


### PR DESCRIPTION
Adds detached systemd user service launcher with copied/hashed monitor, 2GiB/no-swap cap, persistent logs, no environment expansion, runtime deadline and cgroup cleanup. Launch state explicitly not completion. Short real service probe passes; 3700-second low-load probe is still running and not claimed complete. Tests57 passed. Does not establish cause of previous missing ledger, SfM RSS, E2E or quality. Stacked on PR138.