### PR TITLE
test: support dense extraction recipe and loci parity

### DIFF
--- a/benchmarks/electro/m8-dense-parallel-preflight-v1.json
+++ b/benchmarks/electro/m8-dense-parallel-preflight-v1.json
@@ -1,0 +1,16 @@
+{
+  "schema": "m8-dense-parallel-preflight-v1",
+  "status": "four-image-eight-file-parity-and-measurement-pass",
+  "artifact_root": "/home/sasaki/datasets/openloris/corridor1-1-m8-dense-parallel-preflight-v1",
+  "report_sha256": "5a948c45992c6687746be352e24fa5e353858bfc57bd8a40132b205a17847113",
+  "measurement_root": "/home/sasaki/datasets/openloris/m8-dense-small-measurement-v1",
+  "measurement_sha256": "ed0064569aab874770bfba8df2fecc4844d02b2d4ac7e903f6fe9c5fcbcbe5d7",
+  "images": 4,
+  "workers": 2,
+  "feature_and_loci_files": 8,
+  "worker_exit_codes": [0, 0],
+  "service_exit_status": 0,
+  "measurement_status": "pass",
+  "sampled_aggregate_peak_rss_kib": 616340,
+  "scope": "Dense recipe preflight only; not full10k dense extraction, long-duration durability, continuous E2E, speedup or quality evidence."
+}

--- a/benchmarks/electro/m8-full-base-extraction-v2.json
+++ b/benchmarks/electro/m8-full-base-extraction-v2.json
@@ -6,6 +6,7 @@
   "image_count": 10000,
   "worker_exit_codes": [0, 0, 0, 0, 0, 0],
   "all_feature_membership_and_bytes_equal": true,
+  "comparison_boundary": "10000 *_features.txt files. The new extractor also emitted 10000 *_loci.txt sidecars, absent from the retained base bank; those sidecars are not covered by the parity claim.",
   "scope_report": "/home/sasaki/datasets/openloris/m8-full-base-extraction-scope-v2.json",
   "scope_report_terminal": false,
   "resource_limitation": "Scope report remained running after all processes and the cgroup disappeared. Final aggregate RSS, memory.peak and memory.events are unavailable. Cause not yet established. Earlier live observations confirmed the configured 2 GiB/no-swap limit and zero OOM counters, but are not a complete final resource ledger.",

--- a/docs/openloris_frontend_reproduction.md
+++ b/docs/openloris_frontend_reproduction.md
@@ -393,6 +393,15 @@ not summed. GNU timeout uses `--foreground` so workers remain in the command
 process group for wrapper timeout cleanup. This remains base extraction only,
 not dense extraction or continuous E2E.
 
+`--variant dense` reuses the same partitioned harness with the already reproduced
+dense extraction recipe, retaining its two orientations, RootSIFT and compatible
+detector/descriptor/orientation/output-order/grayscale flags. Its reference check
+includes both `_features.txt` and `_loci.txt`: four spread-out images/two workers
+match all eight files, and the detached measurement service exited successfully.
+See `m8-dense-parallel-preflight-v1.json`. Full10k dense execution is not yet done.
+The base parity result covers only its 10,000 feature files: new base loci
+sidecars have no retained reference and are not covered by that comparison.
+
 ## Empty vocabulary safety
 
 Streamed candidate export now rejects a missing/empty appearance vocabulary

--- a/scripts/probe_openloris_base_extraction.py
+++ b/scripts/probe_openloris_base_extraction.py
@@ -27,6 +27,7 @@ def main():
     parser.add_argument('--all-images', action='store_true',
                         help='Run the full frozen 10k base bank instead of four spread-out images')
     parser.add_argument('--workers', type=int, default=1)
+    parser.add_argument('--variant', choices=['base', 'dense'], default='base')
     args = parser.parse_args()
     base = Path('/home/sasaki/datasets/openloris')
     source = base / 'corridor1-1-m5'
@@ -35,8 +36,14 @@ def main():
     if binary_sha != '8cfa9c53fcaea5d6305dbdd3018b8381ae214806751e6ee3dc85bb8692a8da34':
         raise RuntimeError('Frozen extractor changed')
     recipe = source / 'feature-extract/timing/shard-0.time.txt'
+    if args.variant == 'dense':
+        recipe = base / 'corridor1-1-m8-extraction-shard0-replay-v1/extract.time'
     command = shlex.split(shlex.split(recipe.read_text().splitlines()[0].split(
         'Command being timed: ', 1)[1])[0])
+    if args.variant == 'dense':
+        if command[:4] != ['timeout', '--signal=TERM', '--kill-after=10s', '3600s']:
+            raise RuntimeError('Unexpected dense extraction recipe wrapper')
+        command = command[4:]
     images = sorted((source / 'images').glob('*.png'))
     if len(images) < 4:
         raise RuntimeError('Raw image bank missing')
@@ -45,8 +52,12 @@ def main():
     selected = images if args.all_images else [images[index * (len(images) - 1) // 3] for index in range(4)]
     partitions = partition_images(selected, args.workers)
     reference = source / 'tiers/tier-10000/features256'
-    expected = {image.stem + '_features.txt': sha(reference / (image.stem + '_features.txt'))
-                for image in selected}
+    suffixes = ['_features.txt']
+    if args.variant == 'dense':
+        reference = base / 'corridor1-1-m8-dense256x2-full10k-v2/features'
+        suffixes.append('_loci.txt')
+    expected = {image.stem + suffix: sha(reference / (image.stem + suffix))
+                for image in selected for suffix in suffixes}
     output = args.output.resolve()
     required = sum((reference / name).stat().st_size for name in expected) + 1024**3
     if shutil.disk_usage(output.parent).free < required:
@@ -78,8 +89,8 @@ def main():
               'image_sha256': {image.name: sha(image) for image in selected},
               'rayon_num_threads': int(threads), 'malloc_arena_max': '1',
               'worker_commands': invocations, 'workers': args.workers,
-              'image_count': len(selected),
-              'scope': 'Base extraction parity only; full10k when --all-images is explicit. Not dense extraction, continuous E2E or a speedup claim.'}
+              'image_count': len(selected), 'variant': args.variant,
+              'scope': 'Selected variant extraction parity only; full10k when --all-images is explicit. Not continuous E2E or a speedup claim.'}
     report_path = output / 'report.json'
     report_path.write_text(json.dumps(report, indent=2) + '\n')
     def run_worker(item):
@@ -89,7 +100,8 @@ def main():
                 env=dict(os.environ, RAYON_NUM_THREADS=threads, MALLOC_ARENA_MAX='1')).returncode
     with ThreadPoolExecutor(max_workers=args.workers) as pool:
         codes = list(pool.map(run_worker, enumerate(invocations)))
-    actual = {path.name: sha(path) for path in (output / 'features').glob('*_features.txt')}
+    actual = {path.name: sha(path) for path in (output / 'features').iterdir()
+              if any(path.name.endswith(suffix) for suffix in suffixes)}
     report.update(exit_code=0 if all(code == 0 for code in codes) else 1,
                   worker_exit_codes=codes, output_feature_sha256=actual,
                   worker_measurements=[parse_gnu_time(output / f'time-{index}.txt') for index in range(args.workers)],


### PR DESCRIPTION
Adds dense variant to bounded partitioned extraction harness, preserving reproduced flags and checking feature+loci files. Four-image/two-worker real detached-service probe matches all8 files and terminal measurement passes. Tests57 pass. Full10k dense has not started; waiting for long-duration launcher probe. Clarifies base parity covers feature files, not loci sidecars without a retained reference. Stacked on PR139.